### PR TITLE
Rename CastDelete to CastRemove

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -66,8 +66,8 @@ class Client {
     return message as FC.CastShort;
   }
 
-  async makeCastDelete(targetCast: FC.Cast, root: FC.Root): Promise<FC.CastDelete> {
-    const schema = 'farcaster.xyz/schemas/v1/cast-delete' as const;
+  async makeCastRemove(targetCast: FC.Cast, root: FC.Root): Promise<FC.CastRemove> {
+    const schema = 'farcaster.xyz/schemas/v1/cast-remove' as const;
     const signedAt = Date.now();
 
     const rootBlock = root.data.rootBlock;
@@ -83,7 +83,7 @@ class Client {
     };
     const message = await this.makeMessage(messageData);
 
-    return message as FC.CastDelete;
+    return message as FC.CastRemove;
   }
 
   async makeReaction(targetCast: FC.CastShort, root: FC.Root, active = true): Promise<FC.Reaction> {

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -3,7 +3,7 @@ import Table from 'cli-table3';
 import logUpdate from 'log-update';
 import colors from 'colors/safe';
 import {
-  isCastDelete,
+  isCastRemove,
   isCastShort,
   isReaction,
   isRoot,
@@ -88,8 +88,8 @@ const Debugger = {
       data = message.data.body.text.slice(0, 5) + '...';
     }
 
-    if (isCastDelete(message)) {
-      type = Debugger._padString('cst-del', 7);
+    if (isCastRemove(message)) {
+      type = Debugger._padString('cst-rem', 7);
       data = '0x' + message.data.body.targetHash.slice(message.data.body.targetHash.length - 3);
     }
 

--- a/src/engine/engine.cast.test.ts
+++ b/src/engine/engine.cast.test.ts
@@ -314,11 +314,11 @@ describe('mergeCast', () => {
     });
   });
 
-  describe('cast-delete merge: ', () => {
+  describe('cast-remove merge: ', () => {
     test('succeeds and removes cast if known', async () => {
       expect((await engine.mergeCast(cast)).isOk()).toBe(true);
 
-      const castDelete = await Factories.CastDelete.create(
+      const castRemove = await Factories.CastRemove.create(
         {
           data: {
             rootBlock: root.data.rootBlock,
@@ -331,14 +331,14 @@ describe('mergeCast', () => {
         transient
       );
 
-      expect((await engine.mergeCast(castDelete)).isOk()).toBe(true);
+      expect((await engine.mergeCast(castRemove)).isOk()).toBe(true);
       expect(subject()).toEqual([]);
     });
 
     test('succeeds and does nothing if cast is unknown', async () => {
       expect((await engine.mergeCast(cast)).isOk()).toBe(true);
 
-      const castDelete = await Factories.CastDelete.create(
+      const castRemove = await Factories.CastRemove.create(
         {
           data: {
             rootBlock: root.data.rootBlock,
@@ -348,11 +348,11 @@ describe('mergeCast', () => {
         transient
       );
 
-      expect((await engine.mergeCast(castDelete)).isOk()).toBe(true);
+      expect((await engine.mergeCast(castRemove)).isOk()).toBe(true);
       expect(subject()).toEqual([cast]);
     });
 
-    // test('fails if delete timestamp is < cast timestamp', async () => {});
+    // test('fails if remove timestamp is < cast timestamp', async () => {});
   });
 
   describe('cast-recast merge: ', () => {

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -111,7 +111,7 @@ class Engine {
     return castSet ? castSet.get(hash) : undefined;
   }
 
-  /** Get hashes of undeleted cast messages for a username */
+  /** Get hashes of unremoved cast messages for a username */
   getCastHashes(username: string): string[] {
     const castSet = this._casts.get(username);
     return castSet ? castSet.getHashes() : [];
@@ -436,7 +436,7 @@ class Engine {
       }
     }
 
-    // TODO: For delete cast, validate hash length.
+    // TODO: For remove cast, validate hash length.
 
     return ok(undefined);
   }

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -5,7 +5,7 @@ import {
   CastShort,
   Root,
   CastRecast,
-  CastDelete,
+  CastRemove,
   Reaction,
   VerificationAdd,
   VerificationRemove,
@@ -57,8 +57,8 @@ export const Factories = {
     };
   }),
 
-  /** Generate a valid Cast-Delete with randomized properties */
-  CastDelete: Factory.define<CastDelete, any, CastDelete>(({ onCreate, transientParams }) => {
+  /** Generate a valid CastRemove with randomized properties */
+  CastRemove: Factory.define<CastRemove, any, CastRemove>(({ onCreate, transientParams }) => {
     const { privateKey = ed.utils.randomPrivateKey() } = transientParams;
 
     onCreate(async (castProps) => {
@@ -78,7 +78,7 @@ export const Factories = {
       data: {
         body: {
           targetHash: Faker.datatype.hexaDecimal(40).toLowerCase(),
-          schema: 'farcaster.xyz/schemas/v1/cast-delete' as const,
+          schema: 'farcaster.xyz/schemas/v1/cast-remove',
         },
         rootBlock: Faker.datatype.number(10_000),
         signedAt: Faker.time.recent(),

--- a/src/sets/castSet.test.ts
+++ b/src/sets/castSet.test.ts
@@ -1,6 +1,6 @@
 import { Factories } from '~/factories';
 import CastSet from '~/sets/castSet';
-import { CastDelete, CastShort } from '~/types';
+import { CastRemove, CastShort } from '~/types';
 
 const set = new CastSet();
 
@@ -8,14 +8,14 @@ describe('merge', () => {
   let castShort1: CastShort;
   let castShort2: CastShort;
 
-  let castDelete1: CastDelete;
-  let castDelete2: CastDelete;
+  let castRemove1: CastRemove;
+  let castRemove2: CastRemove;
 
   beforeAll(async () => {
     castShort1 = await Factories.Cast.create();
     castShort2 = await Factories.Cast.create();
 
-    castDelete1 = await Factories.CastDelete.create({
+    castRemove1 = await Factories.CastRemove.create({
       data: {
         body: {
           targetHash: castShort1.hash,
@@ -23,7 +23,7 @@ describe('merge', () => {
       },
     });
 
-    castDelete2 = await Factories.CastDelete.create({
+    castRemove2 = await Factories.CastRemove.create({
       data: {
         body: {
           targetHash: castShort2.hash,
@@ -36,7 +36,7 @@ describe('merge', () => {
     set._reset();
   });
 
-  describe('cast-add', () => {
+  describe('add', () => {
     const subject = () => set._getAdds();
 
     test('succeeds with a valid add message', async () => {
@@ -51,8 +51,8 @@ describe('merge', () => {
       expect(new Set(subject())).toEqual(new Set([castShort2, castShort1]));
     });
 
-    test('fails if the add was already deleted', async () => {
-      expect(set.merge(castDelete1).isOk()).toBe(true);
+    test('fails if the add was already removed', async () => {
+      expect(set.merge(castRemove1).isOk()).toBe(true);
       expect(set.merge(castShort1).isOk()).toBe(false);
       expect(subject()).toEqual([]);
     });
@@ -66,34 +66,34 @@ describe('merge', () => {
     // test('fails with an incorrect message type', async () => {});
   });
 
-  describe('cast-delete', () => {
-    const subject = () => set._getDeletes();
+  describe('remove', () => {
+    const subject = () => set._getRemoves();
 
     test("succeeds even if the add message doesn't exist", async () => {
       expect(set._getAdds()).toEqual([]);
-      expect(set.merge(castDelete1).isOk()).toBe(true);
-      expect(subject()).toEqual([castDelete1]);
+      expect(set.merge(castRemove1).isOk()).toBe(true);
+      expect(subject()).toEqual([castRemove1]);
     });
 
-    test('succeeds with multiple delete messages', async () => {
+    test('succeeds with multiple remove messages', async () => {
       expect(set._getAdds()).toEqual([]);
-      expect(set.merge(castDelete1).isOk()).toBe(true);
-      expect(set.merge(castDelete2).isOk()).toBe(true);
-      expect(subject()).toEqual([castDelete1, castDelete2]);
+      expect(set.merge(castRemove1).isOk()).toBe(true);
+      expect(set.merge(castRemove2).isOk()).toBe(true);
+      expect(subject()).toEqual([castRemove1, castRemove2]);
     });
 
     test('succeeds and removes the add message if it exists', async () => {
       expect(set.merge(castShort1).isOk()).toBe(true);
-      expect(set.merge(castDelete1).isOk()).toBe(true);
+      expect(set.merge(castRemove1).isOk()).toBe(true);
       expect(set._getAdds()).toEqual([]);
-      expect(subject()).toEqual([castDelete1]);
+      expect(subject()).toEqual([castRemove1]);
     });
 
-    test('fails if the same delete message is added twice', async () => {
-      expect(set.merge(castDelete1).isOk()).toBe(true);
-      expect(set.merge(castDelete1).isOk()).toBe(false);
+    test('fails if the same remove message is added twice', async () => {
+      expect(set.merge(castRemove1).isOk()).toBe(true);
+      expect(set.merge(castRemove1).isOk()).toBe(false);
       expect(set._getAdds()).toEqual([]);
-      expect(subject()).toEqual([castDelete1]);
+      expect(subject()).toEqual([castRemove1]);
     });
 
     // test('fails with an incorrect message type', async () => {});

--- a/src/simulator/basicSimulator.ts
+++ b/src/simulator/basicSimulator.ts
@@ -92,7 +92,7 @@ class BasicSimulator extends Simulator {
     const cs1 = await client.makeCastShort(Faker.lorem.words(3), root1);
     const cs2 = await client.makeCastShort(Faker.lorem.words(3), root1);
     const cs3 = await client.makeCastShort(Faker.lorem.words(3), root1);
-    const cd1 = await client.makeCastDelete(cs2, root1);
+    const cd1 = await client.makeCastRemove(cs2, root1);
     const cs4 = await client.makeCastShort(Faker.lorem.words(3), root1);
     const ra1 = await client.makeReaction(cs4, root1);
     const ru1 = await client.makeReaction(cs4, root1, false);

--- a/src/simulator/chaosSimulator.ts
+++ b/src/simulator/chaosSimulator.ts
@@ -89,7 +89,7 @@ class ChaosSimulator extends Simulator {
     const cs1 = await client.makeCastShort(Faker.lorem.words(3), root1);
     const cs2 = await client.makeCastShort(Faker.lorem.words(3), root1);
     const cs3 = await client.makeCastShort(Faker.lorem.words(3), root1);
-    const cd1 = await client.makeCastDelete(cs2, root1);
+    const cd1 = await client.makeCastRemove(cs2, root1);
     const cs4 = await client.makeCastShort(Faker.lorem.words(3), root1);
     const ra1 = await client.makeReaction(cs4, root1);
     const ru1 = await client.makeReaction(cs4, root1, false);

--- a/src/simulator/splitBrainAltSimulator.ts
+++ b/src/simulator/splitBrainAltSimulator.ts
@@ -113,7 +113,7 @@ class SplitBrainAltSimulator extends Simulator {
     const cs1 = await client.makeCastShort(Faker.lorem.words(3), root1);
     const cs2 = await client.makeCastShort(Faker.lorem.words(3), root1);
     const cs3 = await client.makeCastShort(Faker.lorem.words(3), root1);
-    const cd1 = await client.makeCastDelete(cs2, root1);
+    const cd1 = await client.makeCastRemove(cs2, root1);
     const cs4 = await client.makeCastShort(Faker.lorem.words(3), root1);
     const ra1 = await client.makeReaction(cs4, root1);
     const ru1 = await client.makeReaction(cs4, root1, false);

--- a/src/simulator/splitBrainSimulator.ts
+++ b/src/simulator/splitBrainSimulator.ts
@@ -115,7 +115,7 @@ class SplitBrainSimulator extends Simulator {
     const cs1 = await client.makeCastShort(Faker.lorem.words(3), root1);
     const cs2 = await client.makeCastShort(Faker.lorem.words(3), root1);
     const cs3 = await client.makeCastShort(Faker.lorem.words(3), root1);
-    const cd1 = await client.makeCastDelete(cs2, root1);
+    const cd1 = await client.makeCastRemove(cs2, root1);
     const cs4 = await client.makeCastShort(Faker.lorem.words(3), root1);
     const ra1 = await client.makeReaction(cs4, root1);
     const ru1 = await client.makeReaction(cs4, root1, false);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,10 +63,10 @@ export type CastShort = Message<CastShortBody>;
 /** A CastReact is a share of an existing cast-short from any user */
 export type CastRecast = Message<CastRecastBody>;
 
-/** A CastDelete is a delete of an existing cast from the same user */
-export type CastDelete = Message<CastDeleteBody>;
+/** A CastRemove is a remove of an existing cast from the same user */
+export type CastRemove = Message<CastRemoveBody>;
 
-export type CastBody = CastShortBody | CastDeleteBody | CastRecastBody;
+export type CastBody = CastShortBody | CastRemoveBody | CastRecastBody;
 
 /**
  * Body of a CastShort Message
@@ -88,14 +88,14 @@ type Embed = {
 };
 
 /**
- * A CastDeleteBody indicates that a previous Cast should be removed from the feed.
+ * A CastRemoveBody indicates that a previous Cast should be removed from the feed.
  *
- * @targetHash - the hash of the cast that is beign deleted.
+ * @targetHash - the hash of the cast that is being removed.
  */
-export type CastDeleteBody = {
+export type CastRemoveBody = {
   // TODO: is there any benefit to making this a URI, like a recast?
   targetHash: string;
-  schema: 'farcaster.xyz/schemas/v1/cast-delete';
+  schema: 'farcaster.xyz/schemas/v1/cast-remove';
 };
 
 /**

--- a/src/types/typeguards.ts
+++ b/src/types/typeguards.ts
@@ -6,7 +6,7 @@ export function isRoot(msg: FC.Message): msg is FC.Root {
 }
 
 export function isCast(msg: FC.Message): msg is FC.Cast {
-  return isCastShort(msg) || isCastDelete(msg) || isCastRecast(msg);
+  return isCastShort(msg) || isCastRemove(msg) || isCastRecast(msg);
 }
 
 export function isCastShort(msg: FC.Message): msg is FC.CastShort {
@@ -20,9 +20,9 @@ export function isCastShort(msg: FC.Message): msg is FC.CastShort {
   );
 }
 
-export function isCastDelete(msg: FC.Message): msg is FC.CastDelete {
-  const body = (msg as FC.CastDelete).data?.body;
-  return body && body.schema === 'farcaster.xyz/schemas/v1/cast-delete' && typeof body.targetHash === 'string';
+export function isCastRemove(msg: FC.Message): msg is FC.CastRemove {
+  const body = (msg as FC.CastRemove).data?.body;
+  return body && body.schema === 'farcaster.xyz/schemas/v1/cast-remove' && typeof body.targetHash === 'string';
 }
 
 export function isCastRecast(msg: FC.Message): msg is FC.CastRecast {


### PR DESCRIPTION
Right now the codebase is inconsistent in terms of naming remove sets and remove messages:
* Casts use `CastDelete` and a `_deletes` set
* Verifications (and soon signers) use `VerificationRemove`, `SignerRemove`, and a `_removes` set

This PR renames `CastDelete` to `CastRemove` and `CastSet._deletes` to `CastSet._removes` to be consistent. In CRDT literature, "remove set" is more common than "delete set." 
