### PR TITLE
Rename externalAddressUri to externalUri

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -108,15 +108,15 @@ class Client {
     return message as FC.Reaction;
   }
 
-  async makeVerificationClaimHash(externalAddressUri: FC.URI): Promise<string> {
+  async makeVerificationClaimHash(externalUri: FC.URI): Promise<string> {
     return await hashFCObject({
       username: this.username,
-      externalAddressUri,
+      externalUri,
     });
   }
 
   async makeVerificationAdd(
-    externalAddressUri: FC.URI,
+    externalUri: FC.URI,
     claimHash: string,
     externalSignature: string,
     root: FC.Root
@@ -124,7 +124,7 @@ class Client {
     const message = await this.makeMessage({
       body: {
         schema: 'farcaster.xyz/schemas/v1/verification-add',
-        externalAddressUri,
+        externalUri,
         externalSignature,
         externalSignatureType: 'eip-191-0x45',
         claimHash,

--- a/src/engine/engine.verification.test.ts
+++ b/src/engine/engine.verification.test.ts
@@ -112,13 +112,13 @@ describe('mergeVerification', () => {
           rootBlock: aliceRoot.data.rootBlock,
           username: 'alice',
           signedAt: aliceRoot.data.signedAt + 1,
-          body: { externalAddressUri: ethWalletAlice.address },
+          body: { externalUri: ethWalletAlice.address },
         },
       },
       transientParams
     );
     const res = await engine.mergeVerification(verificationAddMessage);
-    expect(res._unsafeUnwrapErr()).toBe('validateVerificationAdd: externalSignature does not match externalAddressUri');
+    expect(res._unsafeUnwrapErr()).toBe('validateVerificationAdd: externalSignature does not match externalUri');
     expect(engine._getVerificationAdds('alice')).toEqual([]);
   });
 

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -447,13 +447,13 @@ class Engine {
   }
 
   private async validateVerificationAdd(message: VerificationAdd): Promise<Result<void, string>> {
-    const { externalAddressUri, externalSignature, externalSignatureType, claimHash } = message.data.body;
+    const { externalUri, externalSignature, externalSignatureType, claimHash } = message.data.body;
 
     if (externalSignatureType !== 'eip-191-0x45') return err('validateVerificationAdd: invalid externalSignatureType');
 
     const verificationClaim: VerificationClaim = {
       username: message.data.username,
-      externalAddressUri: message.data.body.externalAddressUri,
+      externalUri: message.data.body.externalUri,
     };
     const reconstructedClaimHash = await hashFCObject(verificationClaim);
     if (reconstructedClaimHash !== claimHash) {
@@ -462,8 +462,8 @@ class Engine {
 
     try {
       const verifiedExternalAddress = utils.verifyMessage(claimHash, externalSignature);
-      if (verifiedExternalAddress !== externalAddressUri) {
-        return err('validateVerificationAdd: externalSignature does not match externalAddressUri');
+      if (verifiedExternalAddress !== externalUri) {
+        return err('validateVerificationAdd: externalSignature does not match externalUri');
       }
     } catch (e: any) {
       // TODO: pass through more helpful errors from Ethers

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -216,7 +216,7 @@ export const Factories = {
         if (!castProps.data.body.claimHash) {
           const verificationClaim: VerificationClaim = {
             username: castProps.data.username,
-            externalAddressUri: castProps.data.body.externalAddressUri,
+            externalUri: castProps.data.body.externalUri,
           };
           castProps.data.body.claimHash = await hashFCObject(verificationClaim);
         }
@@ -242,7 +242,7 @@ export const Factories = {
       return {
         data: {
           body: {
-            externalAddressUri: ethWallet.address,
+            externalUri: ethWallet.address,
             claimHash: '',
             externalSignature: '',
             externalSignatureType: 'eip-191-0x45',
@@ -262,17 +262,15 @@ export const Factories = {
   /** Generate a VerificationRemove message */
   VerificationRemove: Factory.define<VerificationRemove, VerificationRemoveFactoryTransientParams, VerificationRemove>(
     ({ onCreate, transientParams }) => {
-      const {
-        privateKey = ed.utils.randomPrivateKey(),
-        externalAddressUri = Faker.datatype.hexaDecimal(40).toLowerCase(),
-      } = transientParams;
+      const { privateKey = ed.utils.randomPrivateKey(), externalUri = Faker.datatype.hexaDecimal(40).toLowerCase() } =
+        transientParams;
 
       onCreate(async (castProps) => {
         /** Generate claimHash is missing */
         if (!castProps.data.body.claimHash) {
           const verificationClaim: VerificationClaim = {
             username: castProps.data.username,
-            externalAddressUri,
+            externalUri,
           };
           castProps.data.body.claimHash = await hashFCObject(verificationClaim);
         }

--- a/src/sets/verificationSet.ts
+++ b/src/sets/verificationSet.ts
@@ -28,9 +28,9 @@ class VerificationSet {
     return [...this.getClaimHashes(), ...Array.from(this._removes.keys())];
   }
 
-  /** Helper to get externalAddressURIs that are currently verified */
-  getVerifiedExternalAddressURIs(): string[] {
-    return Array.from(this._adds.values()).map((message) => message.data.body.externalAddressUri);
+  /** Helper to get external URIs that are currently verified */
+  getVerifiedExternalUris(): string[] {
+    return Array.from(this._adds.values()).map((message) => message.data.body.externalUri);
   }
 
   merge(message: Verification): Result<void, string> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -142,16 +142,16 @@ export type Verification = VerificationAdd | VerificationRemove;
 export type VerificationAdd = Message<VerificationAddBody>;
 
 /**
- * A VerificationAddBody represents a signed claim between a Farcaster account and an external key pair (i.e. an Ethereum key pair).
+ * A VerificationAddBody represents a signed claim between a Farcaster account and an external entity (i.e. an Ethereum address).
  *
- * @externalAddressUri - the Ethereum address that is part of the verification claim.
+ * @externalUri - the URI of the external entity
  * @claimHash - the hash of the verification claim.
  * @externalSignature - the signature of the hash of the verification claim, signed by the external key pair.
  * @externalSignatureType - type of signature from set of supported types (see version 0x45 of https://eips.ethereum.org/EIPS/eip-191 for 'eip-191-0x45')
  * @schema -
  */
 export type VerificationAddBody = {
-  externalAddressUri: URI;
+  externalUri: URI;
   claimHash: string;
   externalSignature: string;
   externalSignatureType: 'eip-191-0x45';
@@ -173,11 +173,11 @@ export type VerificationAddFactoryTransientParams = {
  * A VerificationClaim is an object that includes both the farcaster account and external address
  *
  * @username - the farcaster username
- * @externalAddressUri - URI of the external address (i.e. Ethereum address)
+ * @externalUri - URI of the external address (i.e. Ethereum address)
  */
 export type VerificationClaim = {
   username: string; // TODO: make this account rather than username when we migrate the rest of the codebase to that
-  externalAddressUri: URI; // TODO: constrain this farther
+  externalUri: URI; // TODO: constrain this farther
 };
 
 /** VerificationRemove message */
@@ -198,11 +198,11 @@ export type VerificationRemoveBody = {
  * A VerificationRemoveFactoryTransientParams is passed to the VerificationRemove factory
  *
  * @privateKey - the private key for signing the Verification message
- * @externalAddressUri - the external address to generate the claimHash
+ * @externalUri - the external address to generate the claimHash
  */
 export type VerificationRemoveFactoryTransientParams = {
   privateKey?: Uint8Array;
-  externalAddressUri?: string;
+  externalUri?: string;
 };
 
 // ===========================

--- a/src/types/typeguards.ts
+++ b/src/types/typeguards.ts
@@ -52,7 +52,7 @@ export function isVerificationAdd(msg: FC.Message): msg is FC.VerificationAdd {
     body.schema === 'farcaster.xyz/schemas/v1/verification-add' &&
     body.externalSignatureType === 'eip-191-0x45' &&
     typeof body.externalSignature === 'string' &&
-    typeof body.externalAddressUri === 'string' &&
+    typeof body.externalUri === 'string' &&
     typeof body.claimHash === 'string' &&
     body.claimHash.length > 0
   );


### PR DESCRIPTION
Renaming `externalAddressUri` to `externalUri` for verifications. See [conversation here](https://github.com/farcasterxyz/protocol/pull/16#discussion_r928197826) for background on the change.