### PR TITLE
Add signatureType to messages

### DIFF
--- a/src/engine/engine.cast.test.ts
+++ b/src/engine/engine.cast.test.ts
@@ -1,32 +1,32 @@
 import Engine from '~/engine';
 import { Factories } from '~/factories';
-import { Cast, Reaction, Root } from '~/types';
+import { Cast, MessageFactoryTransientParams, MessageSigner, Reaction, Root } from '~/types';
 import Faker from 'faker';
-import { generateEd25519KeyPair, convertToHex } from '~/utils';
-import { hexToBytes } from 'ethereum-cryptography/utils';
+import { generateEd25519Signer, generateEthereumSigner } from '~/utils';
 
 const engine = new Engine();
 const username = 'alice';
 
 describe('mergeCast', () => {
-  let alicePrivateKey: string;
+  // let alicePrivateKey: string;
+  let aliceSigner: MessageSigner;
   let aliceAddress: string;
   let root: Root;
   let cast: Cast;
   let reaction: Reaction;
-  let transient: { transient: { privateKey: Uint8Array } };
+  let transient: { transient: MessageFactoryTransientParams };
   const subject = () => engine._getCastAdds(username);
 
   beforeAll(async () => {
-    const keyPair = await generateEd25519KeyPair();
+    // Randomly generate either an Ed25519 or Ethereum signer
+    if (Math.random() > 0.5) {
+      aliceSigner = await generateEd25519Signer();
+    } else {
+      aliceSigner = await generateEthereumSigner();
+    }
+    aliceAddress = aliceSigner.signerKey;
 
-    const privateKeyBuffer = keyPair.privateKey;
-    alicePrivateKey = await convertToHex(privateKeyBuffer);
-
-    const addressBuffer = keyPair.publicKey;
-    aliceAddress = await convertToHex(addressBuffer);
-
-    transient = { transient: { privateKey: hexToBytes(alicePrivateKey) } };
+    transient = { transient: { signer: aliceSigner } };
 
     root = await Factories.Root.create({ data: { rootBlock: 100, username: 'alice' } }, transient);
 

--- a/src/engine/engine.cast.test.ts
+++ b/src/engine/engine.cast.test.ts
@@ -2,7 +2,7 @@ import Engine from '~/engine';
 import { Factories } from '~/factories';
 import { Cast, MessageFactoryTransientParams, MessageSigner, Reaction, Root } from '~/types';
 import Faker from 'faker';
-import { generateEd25519Signer, generateEthereumSigner } from '~/utils';
+import { generateEd25519Signer } from '~/utils';
 
 const engine = new Engine();
 const username = 'alice';

--- a/src/engine/engine.cast.test.ts
+++ b/src/engine/engine.cast.test.ts
@@ -8,7 +8,6 @@ const engine = new Engine();
 const username = 'alice';
 
 describe('mergeCast', () => {
-  // let alicePrivateKey: string;
   let aliceSigner: MessageSigner;
   let aliceAddress: string;
   let root: Root;

--- a/src/engine/engine.cast.test.ts
+++ b/src/engine/engine.cast.test.ts
@@ -17,12 +17,7 @@ describe('mergeCast', () => {
   const subject = () => engine._getCastAdds(username);
 
   beforeAll(async () => {
-    // Randomly generate either an Ed25519 or Ethereum signer
-    if (Math.random() > 0.5) {
-      aliceSigner = await generateEd25519Signer();
-    } else {
-      aliceSigner = await generateEthereumSigner();
-    }
+    aliceSigner = await generateEd25519Signer();
     aliceAddress = aliceSigner.signerKey;
 
     transient = { transient: { signer: aliceSigner } };

--- a/src/engine/engine.reaction.test.ts
+++ b/src/engine/engine.reaction.test.ts
@@ -17,12 +17,7 @@ describe('mergeReaction', () => {
   const subject = () => engine._getActiveReactions(username);
 
   beforeAll(async () => {
-    // Randomly generate either an Ed25519 or Ethereum signer
-    if (Math.random() > 0.5) {
-      aliceSigner = await generateEd25519Signer();
-    } else {
-      aliceSigner = await generateEthereumSigner();
-    }
+    aliceSigner = await generateEd25519Signer();
     aliceAddress = aliceSigner.signerKey;
     transient = { transient: { signer: aliceSigner } };
 

--- a/src/engine/engine.reaction.test.ts
+++ b/src/engine/engine.reaction.test.ts
@@ -2,7 +2,7 @@ import Engine from '~/engine';
 import { Factories } from '~/factories';
 import { Cast, MessageFactoryTransientParams, MessageSigner, Reaction, Root } from '~/types';
 import Faker from 'faker';
-import { generateEd25519Signer, generateEthereumSigner } from '~/utils';
+import { generateEd25519Signer } from '~/utils';
 
 const engine = new Engine();
 const username = 'alice';

--- a/src/engine/engine.root.test.ts
+++ b/src/engine/engine.root.test.ts
@@ -1,9 +1,8 @@
 import Engine from '~/engine';
 import { Factories } from '~/factories';
-import { Cast, Root } from '~/types';
-import { hashCompare, generateEd25519KeyPair, convertToHex } from '~/utils';
+import { Cast, MessageFactoryTransientParams, MessageSigner, Root } from '~/types';
+import { hashCompare, generateEd25519Signer, generateEthereumSigner } from '~/utils';
 import Faker from 'faker';
-import { hexToBytes } from 'ethereum-cryptography/utils';
 
 const engine = new Engine();
 const username = 'alice';
@@ -14,19 +13,21 @@ describe('mergeRoot', () => {
   let root90: Root;
   let root200_1: Root;
   let root200_2: Root;
-  let transient: { transient: { privateKey: Uint8Array } };
+  let transient: { transient: MessageFactoryTransientParams };
 
-  let alicePrivateKey: string;
+  let aliceSigner: MessageSigner;
   let aliceAddress: string;
   const subject = () => engine.getRoot(username);
 
   beforeAll(async () => {
-    const keyPair = await generateEd25519KeyPair();
-    const privateKeyBuffer = keyPair.privateKey;
-    alicePrivateKey = await convertToHex(privateKeyBuffer);
-    const addressBuffer = keyPair.publicKey;
-    aliceAddress = await convertToHex(addressBuffer);
-    transient = { transient: { privateKey: hexToBytes(alicePrivateKey) } };
+    // Randomly generate either an Ed25519 or Ethereum signer
+    if (Math.random() > 0.5) {
+      aliceSigner = await generateEd25519Signer();
+    } else {
+      aliceSigner = await generateEthereumSigner();
+    }
+    aliceAddress = aliceSigner.signerKey;
+    transient = { transient: { signer: aliceSigner } };
 
     root100 = await Factories.Root.create({ data: { rootBlock: 100, username: 'alice' } }, transient);
 

--- a/src/engine/engine.root.test.ts
+++ b/src/engine/engine.root.test.ts
@@ -1,7 +1,7 @@
 import Engine from '~/engine';
 import { Factories } from '~/factories';
 import { Cast, MessageFactoryTransientParams, MessageSigner, Root } from '~/types';
-import { hashCompare, generateEd25519Signer, generateEthereumSigner } from '~/utils';
+import { hashCompare, generateEd25519Signer } from '~/utils';
 import Faker from 'faker';
 
 const engine = new Engine();

--- a/src/engine/engine.root.test.ts
+++ b/src/engine/engine.root.test.ts
@@ -20,12 +20,7 @@ describe('mergeRoot', () => {
   const subject = () => engine.getRoot(username);
 
   beforeAll(async () => {
-    // Randomly generate either an Ed25519 or Ethereum signer
-    if (Math.random() > 0.5) {
-      aliceSigner = await generateEd25519Signer();
-    } else {
-      aliceSigner = await generateEthereumSigner();
-    }
+    aliceSigner = await generateEd25519Signer();
     aliceAddress = aliceSigner.signerKey;
     transient = { transient: { signer: aliceSigner } };
 

--- a/src/engine/engine.verification.test.ts
+++ b/src/engine/engine.verification.test.ts
@@ -17,12 +17,7 @@ describe('mergeVerification', () => {
 
   // Generate key pair for alice and root message
   beforeAll(async () => {
-    // Randomly generate either an Ed25519 or Ethereum signer
-    if (Math.random() > 0.5) {
-      aliceSigner = await generateEd25519Signer();
-    } else {
-      aliceSigner = await generateEthereumSigner();
-    }
+    aliceSigner = await generateEd25519Signer();
     aliceAddress = aliceSigner.signerKey;
     transientParams = { transient: { signer: aliceSigner } };
     aliceRoot = await Factories.Root.create({ data: { rootBlock: 100, username: 'alice' } }, transientParams);

--- a/src/engine/engine.verification.test.ts
+++ b/src/engine/engine.verification.test.ts
@@ -3,7 +3,7 @@ import { Factories } from '~/factories';
 import { MessageSigner, Root, Verification, VerificationAddFactoryTransientParams } from '~/types';
 import Faker from 'faker';
 import { ethers } from 'ethers';
-import { hashFCObject, generateEd25519Signer, generateEthereumSigner } from '~/utils';
+import { hashFCObject, generateEd25519Signer } from '~/utils';
 
 const engine = new Engine();
 

--- a/src/engine/engine.verification.test.ts
+++ b/src/engine/engine.verification.test.ts
@@ -1,29 +1,30 @@
 import Engine from '~/engine';
 import { Factories } from '~/factories';
-import { Root, Verification, VerificationAddFactoryTransientParams } from '~/types';
+import { MessageSigner, Root, Verification, VerificationAddFactoryTransientParams } from '~/types';
 import Faker from 'faker';
 import { ethers } from 'ethers';
-import { generateEd25519KeyPair, convertToHex, hashFCObject } from '~/utils';
-import { hexToBytes } from 'ethereum-cryptography/utils';
+import { hashFCObject, generateEd25519Signer, generateEthereumSigner } from '~/utils';
 
 const engine = new Engine();
 
 // TODO: add test helpers to clean up the setup of these tests
 // TODO: refactor these tests to be faster (currently ~7s)
 describe('mergeVerification', () => {
-  let alicePrivateKey: string;
+  let aliceSigner: MessageSigner;
   let aliceAddress: string;
   let aliceRoot: Root;
   let transientParams: { transient: VerificationAddFactoryTransientParams };
 
   // Generate key pair for alice and root message
   beforeAll(async () => {
-    const keyPair = await generateEd25519KeyPair();
-    const privateKeyBuffer = keyPair.privateKey;
-    alicePrivateKey = await convertToHex(privateKeyBuffer);
-    const addressBuffer = keyPair.publicKey;
-    aliceAddress = await convertToHex(addressBuffer);
-    transientParams = { transient: { privateKey: hexToBytes(alicePrivateKey) } };
+    // Randomly generate either an Ed25519 or Ethereum signer
+    if (Math.random() > 0.5) {
+      aliceSigner = await generateEd25519Signer();
+    } else {
+      aliceSigner = await generateEthereumSigner();
+    }
+    aliceAddress = aliceSigner.signerKey;
+    transientParams = { transient: { signer: aliceSigner } };
     aliceRoot = await Factories.Root.create({ data: { rootBlock: 100, username: 'alice' } }, transientParams);
   });
 

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -361,7 +361,7 @@ class Engine {
     if (message.signatureType === SignatureAlgorithm.EthereumPersonalSign) {
       try {
         const recoveredSigner = ethers.utils.verifyMessage(message.hash, message.signature);
-        if (recoveredSigner !== message.signer) {
+        if (recoveredSigner.toLowerCase() !== message.signer.toLowerCase()) {
           return err('validateMessage: invalid signature');
         }
       } catch (e: any) {

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -7,12 +7,13 @@ import {
   VerificationAdd,
   VerificationRemove,
   VerificationClaim,
+  SignatureAlgorithm,
 } from '~/types';
 import { hashMessage, hashCompare, hashFCObject } from '~/utils';
 import * as ed from '@noble/ed25519';
 import { hexToBytes } from 'ethereum-cryptography/utils';
 import { ok, err, Result } from 'neverthrow';
-import { utils } from 'ethers';
+import { ethers, utils } from 'ethers';
 import { isCast, isCastShort, isRoot, isReaction, isVerificationAdd, isVerificationRemove } from '~/types/typeguards';
 import CastSet from '~/sets/castSet';
 import ReactionSet from '~/sets/reactionSet';
@@ -356,16 +357,27 @@ class Engine {
       return err('validateMessage: invalid hash');
     }
 
-    // 3. Check that the message is valid.
-    // ed25519 library hates strings for some reason, so we need to convert to a buffer
-
-    const recoveredAddress = await ed.verify(
-      hexToBytes(message.signature),
-      hexToBytes(message.hash),
-      hexToBytes(message.signer)
-    );
-    if (!recoveredAddress) {
-      return err('validateMessage: invalid signature');
+    // 3. Check that the signatureType and signature are valid.
+    if (message.signatureType === SignatureAlgorithm.EthereumPersonalSign) {
+      try {
+        const recoveredSigner = ethers.utils.verifyMessage(message.hash, message.signature);
+        if (recoveredSigner !== message.signer) {
+          return err('validateMessage: invalid signature');
+        }
+      } catch (e: any) {
+        return err('validateMessage: invalid signature');
+      }
+    } else if (message.signatureType === SignatureAlgorithm.Ed25519) {
+      const signatureIsValid = await ed.verify(
+        hexToBytes(message.signature),
+        hexToBytes(message.hash),
+        hexToBytes(message.signer)
+      );
+      if (!signatureIsValid) {
+        return err('validateMessage: invalid signature');
+      }
+    } else {
+      return err('validateMessage: invalid signatureType');
     }
 
     // 4. Verify that the timestamp is not too far in the future.

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -12,29 +12,48 @@ import {
   VerificationClaim,
   VerificationRemoveFactoryTransientParams,
   VerificationAddFactoryTransientParams,
+  MessageFactoryTransientParams,
+  Message,
+  SignatureAlgorithm,
+  MessageSigner,
 } from '~/types';
-import { convertToHex, hashMessage, signEd25519, hashFCObject } from '~/utils';
-import * as ed from '@noble/ed25519';
+import { hashMessage, signEd25519, hashFCObject, generateEd25519Signer, generateEthereumSigner } from '~/utils';
+
+/**
+ * addEnvelopeToMessage adds hash, signer, signature, and signatureType to a message
+ * object using the signer in transientParams if one is present
+ */
+const addEnvelopeToMessage = async (
+  props: Message,
+  transientParams: MessageFactoryTransientParams
+): Promise<Message> => {
+  let signer: MessageSigner;
+  if (transientParams.signer) {
+    signer = transientParams.signer;
+  } else if (props.signatureType === SignatureAlgorithm.EthereumPersonalSign) {
+    signer = await generateEthereumSigner();
+  } else {
+    signer = await generateEd25519Signer();
+  }
+  props.hash = await hashMessage(props);
+  props.signer = signer.signerKey;
+  if (signer.type === SignatureAlgorithm.EthereumPersonalSign) {
+    props.signature = await signer.wallet.signMessage(props.hash);
+  } else if (signer.type === SignatureAlgorithm.Ed25519) {
+    props.signature = await signEd25519(props.hash, signer.privateKey);
+  }
+  props.signatureType = signer.type;
+  return props;
+};
 
 /**
  * ProtocolFactories are used to construct valid Farcaster Protocol JSON objects.
  */
 export const Factories = {
   /** Generate a valid Cast with randomized properties */
-  Cast: Factory.define<CastShort, any, CastShort>(({ onCreate, transientParams }) => {
-    const { privateKey = ed.utils.randomPrivateKey() } = transientParams;
-
+  Cast: Factory.define<CastShort, MessageFactoryTransientParams, CastShort>(({ onCreate, transientParams }) => {
     onCreate(async (castProps) => {
-      const publicKey = await ed.getPublicKey(privateKey);
-      const hash = await hashMessage(castProps);
-      castProps.hash = hash;
-
-      castProps.signer = await convertToHex(publicKey);
-
-      const signature = await signEd25519(castProps.hash, privateKey);
-      castProps.signature = signature;
-
-      return castProps;
+      return (await addEnvelopeToMessage(castProps, transientParams)) as CastShort;
     });
 
     const embed = { items: [] };
@@ -53,25 +72,15 @@ export const Factories = {
       },
       hash: '',
       signature: '',
+      signatureType: Faker.helpers.randomize([SignatureAlgorithm.Ed25519, SignatureAlgorithm.EthereumPersonalSign]),
       signer: '',
     };
   }),
 
   /** Generate a valid CastRemove with randomized properties */
-  CastRemove: Factory.define<CastRemove, any, CastRemove>(({ onCreate, transientParams }) => {
-    const { privateKey = ed.utils.randomPrivateKey() } = transientParams;
-
+  CastRemove: Factory.define<CastRemove, MessageFactoryTransientParams, CastRemove>(({ onCreate, transientParams }) => {
     onCreate(async (castProps) => {
-      const publicKey = await ed.getPublicKey(privateKey);
-      const hash = await hashMessage(castProps);
-      castProps.hash = hash;
-
-      castProps.signer = await convertToHex(publicKey);
-
-      const signature = await signEd25519(castProps.hash, privateKey);
-      castProps.signature = signature;
-
-      return castProps;
+      return (await addEnvelopeToMessage(castProps, transientParams)) as CastRemove;
     });
 
     return {
@@ -86,25 +95,15 @@ export const Factories = {
       },
       hash: '',
       signature: '',
+      signatureType: Faker.helpers.randomize([SignatureAlgorithm.Ed25519, SignatureAlgorithm.EthereumPersonalSign]),
       signer: '',
     };
   }),
 
   /** Generate a valid Cast with randomized properties */
-  CastRecast: Factory.define<CastRecast, any, CastRecast>(({ onCreate, transientParams }) => {
-    const { privateKey = ed.utils.randomPrivateKey() } = transientParams;
-
+  CastRecast: Factory.define<CastRecast, MessageFactoryTransientParams, CastRecast>(({ onCreate, transientParams }) => {
     onCreate(async (castProps) => {
-      const publicKey = await ed.getPublicKey(privateKey);
-      const hash = await hashMessage(castProps);
-      castProps.hash = hash;
-
-      castProps.signer = await convertToHex(publicKey);
-
-      const signature = await signEd25519(castProps.hash, privateKey);
-      castProps.signature = signature;
-
-      return castProps;
+      return (await addEnvelopeToMessage(castProps, transientParams)) as CastRecast;
     });
 
     return {
@@ -119,24 +118,15 @@ export const Factories = {
       },
       hash: '',
       signature: '',
+      signatureType: Faker.helpers.randomize([SignatureAlgorithm.Ed25519, SignatureAlgorithm.EthereumPersonalSign]),
       signer: '',
     };
   }),
 
   /** Generate a valid Root with randomized properties */
-  Root: Factory.define<Root, any, Root>(({ onCreate, transientParams }) => {
-    const { privateKey = ed.utils.randomPrivateKey() } = transientParams;
+  Root: Factory.define<Root, MessageFactoryTransientParams, Root>(({ onCreate, transientParams }) => {
     onCreate(async (rootProps) => {
-      const publicKey = await ed.getPublicKey(privateKey);
-      const hash = await hashMessage(rootProps);
-      rootProps.hash = hash;
-
-      rootProps.signer = await convertToHex(publicKey);
-
-      const signature = await signEd25519(rootProps.hash, privateKey);
-      rootProps.signature = signature;
-
-      return rootProps;
+      return (await addEnvelopeToMessage(rootProps, transientParams)) as Root;
     });
 
     return {
@@ -151,41 +141,15 @@ export const Factories = {
       },
       hash: '',
       signature: '',
+      signatureType: Faker.helpers.randomize([SignatureAlgorithm.Ed25519, SignatureAlgorithm.EthereumPersonalSign]),
       signer: '',
     };
   }),
 
-  /** Generate a new ETH Address with its corresponding private key */
-  EthAddress: Factory.define<EthAddress, any, EthAddress>(({ onCreate }) => {
-    onCreate(async (addressProps) => {
-      const wallet = new ethers.Wallet(addressProps.privateKey);
-      addressProps.address = await wallet.getAddress();
-      return addressProps;
-    });
-
-    const privateKey = Faker.datatype.hexaDecimal(64).toLowerCase();
-
-    return {
-      address: '',
-      privateKey,
-    };
-  }),
-
   /** Generate a valid Reaction with randomized properties */
-  Reaction: Factory.define<Reaction, any, Reaction>(({ onCreate, transientParams }) => {
-    const { privateKey = ed.utils.randomPrivateKey() } = transientParams;
-
+  Reaction: Factory.define<Reaction, MessageFactoryTransientParams, Reaction>(({ onCreate, transientParams }) => {
     onCreate(async (castProps) => {
-      const publicKey = await ed.getPublicKey(privateKey);
-      const hash = await hashMessage(castProps);
-      castProps.hash = hash;
-
-      castProps.signer = await convertToHex(publicKey);
-
-      const signature = await signEd25519(castProps.hash, privateKey);
-      castProps.signature = signature;
-
-      return castProps;
+      return (await addEnvelopeToMessage(castProps, transientParams)) as Reaction;
     });
 
     return {
@@ -202,6 +166,7 @@ export const Factories = {
       },
       hash: '',
       signature: '',
+      signatureType: Faker.helpers.randomize([SignatureAlgorithm.Ed25519, SignatureAlgorithm.EthereumPersonalSign]),
       signer: '',
     };
   }),
@@ -209,34 +174,25 @@ export const Factories = {
   /** Generate a VerificationAdd message */
   VerificationAdd: Factory.define<VerificationAdd, VerificationAddFactoryTransientParams, VerificationAdd>(
     ({ onCreate, transientParams }) => {
-      const { privateKey = ed.utils.randomPrivateKey(), ethWallet = ethers.Wallet.createRandom() } = transientParams;
+      const { ethWallet = ethers.Wallet.createRandom() } = transientParams;
 
-      onCreate(async (castProps) => {
-        /** Generate claimHash is missing */
-        if (!castProps.data.body.claimHash) {
+      onCreate(async (props) => {
+        /** Generate claimHash if missing */
+        if (!props.data.body.claimHash) {
           const verificationClaim: VerificationClaim = {
-            username: castProps.data.username,
-            externalUri: castProps.data.body.externalUri,
+            username: props.data.username,
+            externalUri: props.data.body.externalUri,
           };
-          castProps.data.body.claimHash = await hashFCObject(verificationClaim);
+          props.data.body.claimHash = await hashFCObject(verificationClaim);
         }
 
         /** Generate externalSignature if missing */
-        if (!castProps.data.body.externalSignature) {
-          castProps.data.body.externalSignature = await ethWallet.signMessage(castProps.data.body.claimHash);
+        if (!props.data.body.externalSignature) {
+          props.data.body.externalSignature = await ethWallet.signMessage(props.data.body.claimHash);
         }
 
         /** Complete envelope */
-        const publicKey = await ed.getPublicKey(privateKey);
-        const hash = await hashMessage(castProps);
-        castProps.hash = hash;
-
-        castProps.signer = await convertToHex(publicKey);
-
-        const signature = await signEd25519(castProps.hash, privateKey);
-        castProps.signature = signature;
-
-        return castProps;
+        return (await addEnvelopeToMessage(props, transientParams)) as VerificationAdd;
       });
 
       return {
@@ -254,6 +210,7 @@ export const Factories = {
         },
         hash: '',
         signature: '',
+        signatureType: Faker.helpers.randomize([SignatureAlgorithm.Ed25519, SignatureAlgorithm.EthereumPersonalSign]),
         signer: '',
       };
     }
@@ -262,29 +219,20 @@ export const Factories = {
   /** Generate a VerificationRemove message */
   VerificationRemove: Factory.define<VerificationRemove, VerificationRemoveFactoryTransientParams, VerificationRemove>(
     ({ onCreate, transientParams }) => {
-      const { privateKey = ed.utils.randomPrivateKey(), externalUri = Faker.datatype.hexaDecimal(40).toLowerCase() } =
-        transientParams;
+      const { externalUri = Faker.datatype.hexaDecimal(40).toLowerCase() } = transientParams;
 
-      onCreate(async (castProps) => {
+      onCreate(async (props) => {
         /** Generate claimHash is missing */
-        if (!castProps.data.body.claimHash) {
+        if (!props.data.body.claimHash) {
           const verificationClaim: VerificationClaim = {
-            username: castProps.data.username,
+            username: props.data.username,
             externalUri,
           };
-          castProps.data.body.claimHash = await hashFCObject(verificationClaim);
+          props.data.body.claimHash = await hashFCObject(verificationClaim);
         }
 
-        const publicKey = await ed.getPublicKey(privateKey);
-        const hash = await hashMessage(castProps);
-        castProps.hash = hash;
-
-        castProps.signer = await convertToHex(publicKey);
-
-        const signature = await signEd25519(castProps.hash, privateKey);
-        castProps.signature = signature;
-
-        return castProps;
+        /** Complete envelope */
+        return (await addEnvelopeToMessage(props, transientParams)) as VerificationRemove;
       });
 
       return {
@@ -299,13 +247,9 @@ export const Factories = {
         },
         hash: '',
         signature: '',
+        signatureType: Faker.helpers.randomize([SignatureAlgorithm.Ed25519, SignatureAlgorithm.EthereumPersonalSign]),
         signer: '',
       };
     }
   ),
 };
-
-interface EthAddress {
-  address: string;
-  privateKey: string;
-}

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -24,26 +24,26 @@ import { hashMessage, signEd25519, hashFCObject, generateEd25519Signer, generate
  * object using the signer in transientParams if one is present
  */
 const addEnvelopeToMessage = async (
-  props: Message,
+  message: Message,
   transientParams: MessageFactoryTransientParams
 ): Promise<Message> => {
   let signer: MessageSigner;
   if (transientParams.signer) {
     signer = transientParams.signer;
-  } else if (props.signatureType === SignatureAlgorithm.EthereumPersonalSign) {
+  } else if (message.signatureType === SignatureAlgorithm.EthereumPersonalSign) {
     signer = await generateEthereumSigner();
   } else {
     signer = await generateEd25519Signer();
   }
-  props.hash = await hashMessage(props);
-  props.signer = signer.signerKey;
+  message.hash = await hashMessage(message);
+  message.signer = signer.signerKey;
   if (signer.type === SignatureAlgorithm.EthereumPersonalSign) {
-    props.signature = await signer.wallet.signMessage(props.hash);
+    message.signature = await signer.wallet.signMessage(message.hash);
   } else if (signer.type === SignatureAlgorithm.Ed25519) {
-    props.signature = await signEd25519(props.hash, signer.privateKey);
+    message.signature = await signEd25519(message.hash, signer.privateKey);
   }
-  props.signatureType = signer.type;
-  return props;
+  message.signatureType = signer.type;
+  return message;
 };
 
 /**

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -72,7 +72,7 @@ export const Factories = {
       },
       hash: '',
       signature: '',
-      signatureType: Faker.helpers.randomize([SignatureAlgorithm.Ed25519, SignatureAlgorithm.EthereumPersonalSign]),
+      signatureType: SignatureAlgorithm.Ed25519,
       signer: '',
     };
   }),
@@ -95,7 +95,7 @@ export const Factories = {
       },
       hash: '',
       signature: '',
-      signatureType: Faker.helpers.randomize([SignatureAlgorithm.Ed25519, SignatureAlgorithm.EthereumPersonalSign]),
+      signatureType: SignatureAlgorithm.Ed25519,
       signer: '',
     };
   }),
@@ -118,7 +118,7 @@ export const Factories = {
       },
       hash: '',
       signature: '',
-      signatureType: Faker.helpers.randomize([SignatureAlgorithm.Ed25519, SignatureAlgorithm.EthereumPersonalSign]),
+      signatureType: SignatureAlgorithm.Ed25519,
       signer: '',
     };
   }),
@@ -141,7 +141,7 @@ export const Factories = {
       },
       hash: '',
       signature: '',
-      signatureType: Faker.helpers.randomize([SignatureAlgorithm.Ed25519, SignatureAlgorithm.EthereumPersonalSign]),
+      signatureType: SignatureAlgorithm.Ed25519,
       signer: '',
     };
   }),
@@ -166,7 +166,7 @@ export const Factories = {
       },
       hash: '',
       signature: '',
-      signatureType: Faker.helpers.randomize([SignatureAlgorithm.Ed25519, SignatureAlgorithm.EthereumPersonalSign]),
+      signatureType: SignatureAlgorithm.Ed25519,
       signer: '',
     };
   }),
@@ -210,7 +210,7 @@ export const Factories = {
         },
         hash: '',
         signature: '',
-        signatureType: Faker.helpers.randomize([SignatureAlgorithm.Ed25519, SignatureAlgorithm.EthereumPersonalSign]),
+        signatureType: SignatureAlgorithm.Ed25519,
         signer: '',
       };
     }
@@ -247,7 +247,7 @@ export const Factories = {
         },
         hash: '',
         signature: '',
-        signatureType: Faker.helpers.randomize([SignatureAlgorithm.Ed25519, SignatureAlgorithm.EthereumPersonalSign]),
+        signatureType: SignatureAlgorithm.Ed25519,
         signer: '',
       };
     }

--- a/src/simulation.ts
+++ b/src/simulation.ts
@@ -3,15 +3,15 @@ import BasicSimulator from '~/simulator/basicSimulator';
 import ChaosSimulator from '~/simulator/chaosSimulator';
 import SplitBrainAltSimulator from '~/simulator/splitBrainAltSimulator';
 import SplitBrainSimulator from '~/simulator/splitBrainSimulator';
-import { generateEd25519KeyPair } from '~/utils';
+import { generateEd25519Signer } from '~/utils';
 
 const instanceNames = ['alice', 'bob'];
 const clients = new Map<string, Client>();
 
 const runSimulations = async () => {
   for (const name of instanceNames) {
-    const keyPair = await generateEd25519KeyPair();
-    clients.set(name, new Client(name, keyPair.privateKey, keyPair.publicKey));
+    const signer = await generateEd25519Signer();
+    clients.set(name, new Client(name, signer));
   }
 
   const basicSim = new BasicSimulator(clients);

--- a/src/simulator/basicSimulator.ts
+++ b/src/simulator/basicSimulator.ts
@@ -4,7 +4,6 @@ import Faker from 'faker';
 import Simulator from '~/simulator';
 import { ethers } from 'ethers';
 import * as FC from '~/types';
-import { convertToHex } from '~/utils';
 
 /**
  * Basic Simulator
@@ -75,7 +74,7 @@ class BasicSimulator extends Simulator {
       blockNumber: this.blockNumber,
       blockHash: this.blockHash,
       logIndex: logIndex || 0,
-      address: await convertToHex(client.publicKey),
+      address: client.signer.signerKey,
     };
   }
 

--- a/src/simulator/chaosSimulator.ts
+++ b/src/simulator/chaosSimulator.ts
@@ -2,14 +2,13 @@ import Client from '~/client';
 import Debugger from '~/debugger';
 import Faker from 'faker';
 import Simulator from '~/simulator';
-import { convertToHex } from '~/utils';
+
 /**
  * Chaos Simulator
  *
  * Clients send messages to random nodes in random order with randomzied delays. Nodes sync with other nodes every 10 seconds, but with a 33% chance
  * of sync failure.
  */
-
 class ChaosSimulator extends Simulator {
   clients: Map<string, Client>;
 
@@ -80,7 +79,7 @@ class ChaosSimulator extends Simulator {
       blockNumber: this.blockNumber,
       blockHash: this.blockHash,
       logIndex: logIndex || 0,
-      address: await convertToHex(client.publicKey),
+      address: client.signer.signerKey,
     };
   }
 

--- a/src/simulator/splitBrainAltSimulator.ts
+++ b/src/simulator/splitBrainAltSimulator.ts
@@ -2,7 +2,6 @@ import Client from '~/client';
 import Debugger from '~/debugger';
 import Faker from 'faker';
 import Simulator from '~/simulator';
-import { convertToHex } from '~/utils';
 
 const duration = 30_000;
 const name = 'SplitBrainAltSimulator';
@@ -104,7 +103,7 @@ class SplitBrainAltSimulator extends Simulator {
       blockNumber: this.blockNumber,
       blockHash: this.blockHash,
       logIndex: logIndex || 0,
-      address: await convertToHex(client.publicKey),
+      address: client.signer.signerKey,
     };
   }
 

--- a/src/simulator/splitBrainSimulator.ts
+++ b/src/simulator/splitBrainSimulator.ts
@@ -2,7 +2,6 @@ import Client from '~/client';
 import Debugger from '~/debugger';
 import Faker from 'faker';
 import Simulator from '~/simulator';
-import { convertToHex } from '~/utils';
 
 const duration = 40_000;
 const name = 'SplitBrainSimulator';
@@ -106,7 +105,7 @@ class SplitBrainSimulator extends Simulator {
       blockNumber: this.blockNumber,
       blockHash: this.blockHash,
       logIndex: logIndex || 0,
-      address: await convertToHex(client.publicKey),
+      address: client.signer.signerKey,
     };
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -245,7 +245,6 @@ export enum SignatureAlgorithm {
 /** MessageFactoryTransientParams is the generic transient params type for factories */
 export type MessageFactoryTransientParams = {
   signer?: MessageSigner;
-  // privateKey?: Uint8Array;
 };
 
 export type MessageSigner = Ed25519Signer | EthereumSigner;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,7 @@ export type Message<T = Body> = {
   data: Data<T>;
   hash: string;
   signature: string;
+  signatureType: SignatureAlgorithm;
   signer: string;
 };
 
@@ -161,11 +162,9 @@ export type VerificationAddBody = {
 /**
  * A VerificationAddFactoryTransientParams is passed to the VerificationAdd factory
  *
- * @privateKey - the private key for signing the Verification message
  * @ethWallet - the wallet to generate and/or sign the claimHash
  */
-export type VerificationAddFactoryTransientParams = {
-  privateKey?: Uint8Array;
+export type VerificationAddFactoryTransientParams = MessageFactoryTransientParams & {
   ethWallet?: ethers.Wallet;
 };
 
@@ -197,11 +196,9 @@ export type VerificationRemoveBody = {
 /**
  * A VerificationRemoveFactoryTransientParams is passed to the VerificationRemove factory
  *
- * @privateKey - the private key for signing the Verification message
  * @externalUri - the external address to generate the claimHash
  */
-export type VerificationRemoveFactoryTransientParams = {
-  privateKey?: Uint8Array;
+export type VerificationRemoveFactoryTransientParams = MessageFactoryTransientParams & {
   externalUri?: string;
 };
 
@@ -237,4 +234,32 @@ export type HTTPURI = string;
 export type KeyPair = {
   privateKey: Uint8Array;
   publicKey: Uint8Array;
+};
+
+/** SignatureAlgorithm enum */
+export enum SignatureAlgorithm {
+  Ed25519 = 'ed25519',
+  EthereumPersonalSign = 'eth-personal-sign',
+}
+
+/** MessageFactoryTransientParams is the generic transient params type for factories */
+export type MessageFactoryTransientParams = {
+  signer?: MessageSigner;
+  // privateKey?: Uint8Array;
+};
+
+export type MessageSigner = Ed25519Signer | EthereumSigner;
+
+/** An Ed25519Signer is a MessageSigner object with a Ed25519 private key */
+export type Ed25519Signer = {
+  privateKey: Uint8Array;
+  signerKey: string; // Public key hex
+  type: SignatureAlgorithm.Ed25519;
+};
+
+/** An EthereumSigner is a MessageSigner object with an ethers wallet */
+export type EthereumSigner = {
+  wallet: ethers.Wallet;
+  signerKey: string; // Address
+  type: SignatureAlgorithm.EthereumPersonalSign;
 };

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,9 @@
-import { hashFCObject, hashCompare } from '~/utils';
+import { ethers } from 'ethers';
+import Faker from 'faker';
+import * as ed from '@noble/ed25519';
+import { hashFCObject, hashCompare, generateEthereumSigner, generateEd25519Signer, convertToHex } from '~/utils';
+import { Ed25519Signer, EthereumSigner } from '~/types';
+import { hexToBytes, utf8ToBytes } from 'ethereum-cryptography/utils';
 
 describe('hashFCObject', () => {
   const blake2bEmptyObject =
@@ -109,5 +114,64 @@ describe('hashCompare', () => {
   test('compare strings first input is uppercase second input is lower case', async () => {
     const cmp = hashCompare('A', 'a');
     expect(cmp).toBeLessThan(0);
+  });
+});
+
+describe('generateEthereumSigner', () => {
+  let signer: EthereumSigner;
+
+  beforeAll(async () => {
+    signer = await generateEthereumSigner();
+  });
+
+  test('signerKey is lowercased address', async () => {
+    const address = await signer.wallet.getAddress();
+    expect(signer.signerKey).toEqual(address.toLowerCase());
+  });
+
+  test('lowercased address is still a valid address', () => {
+    expect(ethers.utils.isAddress(signer.signerKey)).toBe(true);
+  });
+
+  test('text can be signed and verified', async () => {
+    const text = Faker.lorem.sentence(2);
+    const signature = await signer.wallet.signMessage(text);
+    const recoveredAddress = await ethers.utils.verifyMessage(text, signature);
+    expect(recoveredAddress.toLowerCase()).toEqual(signer.signerKey);
+  });
+
+  test('hex can be signed and verified', async () => {
+    const hex = Faker.datatype.hexaDecimal(40);
+    const signature = await signer.wallet.signMessage(hex);
+    const recoveredAddress = await ethers.utils.verifyMessage(hex, signature);
+    expect(recoveredAddress.toLowerCase()).toEqual(signer.signerKey);
+  });
+});
+
+describe('generateEd25519Signer', () => {
+  let signer: Ed25519Signer;
+  let pubKey: string;
+
+  beforeAll(async () => {
+    signer = await generateEd25519Signer();
+    pubKey = await convertToHex(await ed.getPublicKey(signer.privateKey));
+  });
+
+  test('signerKey is public key', () => {
+    expect(signer.signerKey).toEqual(pubKey);
+  });
+
+  test('text can be signed and verified', async () => {
+    const text = Faker.lorem.sentence(2);
+    const signature = await ed.sign(utf8ToBytes(text), signer.privateKey);
+    const isValid = await ed.verify(signature, utf8ToBytes(text), hexToBytes(signer.signerKey));
+    expect(isValid).toBe(true);
+  });
+
+  test('hex can be signed and verified', async () => {
+    const hex = Faker.datatype.hexaDecimal(40);
+    const signature = await ed.sign(hexToBytes(hex), signer.privateKey);
+    const isValid = await ed.verify(signature, hexToBytes(hex), hexToBytes(signer.signerKey));
+    expect(isValid).toBe(true);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,5 +115,6 @@ export const generateEd25519Signer = async (): Promise<Ed25519Signer> => {
 
 export const generateEthereumSigner = async (): Promise<EthereumSigner> => {
   const wallet = ethers.Wallet.createRandom();
-  return { wallet, signerKey: wallet.address, type: SignatureAlgorithm.EthereumPersonalSign };
+  const signerKey = wallet.address.toLowerCase();
+  return { wallet, signerKey, type: SignatureAlgorithm.EthereumPersonalSign };
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
-import { KeyPair, Message } from '~/types';
+import { Ed25519Signer, EthereumSigner, KeyPair, Message, SignatureAlgorithm } from '~/types';
 import canonicalize from 'canonicalize';
-import { utils } from 'ethers';
+import { ethers, utils } from 'ethers';
 import * as ed from '@noble/ed25519';
 import { blake2b } from 'ethereum-cryptography/blake2b';
 import { hexToBytes, utf8ToBytes } from 'ethereum-cryptography/utils';
@@ -105,4 +105,15 @@ export const generateEd25519KeyPair = async (): Promise<KeyPair> => {
 
 export const convertToHex = async (text: Uint8Array): Promise<string> => {
   return '0x' + ed.utils.bytesToHex(text);
+};
+
+export const generateEd25519Signer = async (): Promise<Ed25519Signer> => {
+  const { privateKey, publicKey } = await generateEd25519KeyPair();
+  const signerKey = await convertToHex(publicKey);
+  return { privateKey, signerKey, type: SignatureAlgorithm.Ed25519 };
+};
+
+export const generateEthereumSigner = async (): Promise<EthereumSigner> => {
+  const wallet = ethers.Wallet.createRandom();
+  return { wallet, signerKey: wallet.address, type: SignatureAlgorithm.EthereumPersonalSign };
 };


### PR DESCRIPTION
Implements https://github.com/farcasterxyz/hub/issues/49

Summary of changes:
* Add `SignatureAlgorithm` enum type
* Add `MessageSigner` type that encompasses either an Ed25519 signer (with private key) or Ethereum signer (with wallet)
* Use `MessageSigner` instead of `privateKey` in factories and whenever we generated a key pair in order to support multiple types of signers
* Add `generateEd25519Signer` and `generateEthereumSigner` utils
* Clean up factories to share envelope stamping/signing code
* Update `validateMessage` method in the engine to handle multiple kinds of signatures