### PR TITLE
ci: upload coverage results to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,8 @@ jobs:
       - name: Run build
         run: yarn build
 
-      - name: Run test
+      - name: Run tests
         run: yarn test:ci
+
+      - name: Upload coverage results
+        uses: codecov/codecov-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ node_modules/
 .eslintcache
 
 .console-history
+
+# Code Coverage Reports
+coverage/

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "server": "npm run build && node build/simulation.js",
     "start": "npm run server",
     "test": "rm -rf ./build && jest src/",
-    "test:ci": "ENVIRONMENT=test jest src/ --ci --runInBand --forceExit",
+    "test:ci": "ENVIRONMENT=test jest src/ --ci --runInBand --forceExit --coverage",
     "typecheck": "tsc --noEmit"
   },
   "repository": {


### PR DESCRIPTION
adding ci reports to make it easier to determine if a method has sufficient coverage when reviewing ode. 