### PR TITLE
chore: use SignatureAlgorithm.EthereumPersonalSign for verification's externalSignatureType attribute

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -87,7 +87,7 @@ class Client {
         schema: 'farcaster.xyz/schemas/v1/verification-add',
         externalUri,
         externalSignature,
-        externalSignatureType: 'eip-191-0x45',
+        externalSignatureType: FC.SignatureAlgorithm.EthereumPersonalSign,
         claimHash,
       },
       signedAt: Date.now(),

--- a/src/engine/engine.verification.test.ts
+++ b/src/engine/engine.verification.test.ts
@@ -9,6 +9,7 @@ import {
   VerificationAdd,
   VerificationClaim,
   IDRegistryEvent,
+  SignatureAlgorithm,
 } from '~/types';
 import { Wallet } from 'ethers';
 import { hashFCObject, generateEd25519Signer, generateEthereumSigner } from '~/utils';
@@ -150,7 +151,7 @@ describe('mergeVerification', () => {
           body: {
             claimHash: aliceClaimHash,
             externalSignature: aliceExternalSignature,
-            externalSignatureType: 'bar' as unknown as 'eip-191-0x45',
+            externalSignatureType: 'bar' as unknown as SignatureAlgorithm.EthereumPersonalSign,
           },
         },
       },

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -340,7 +340,8 @@ class Engine {
   private async validateVerificationAdd(message: VerificationAdd): Promise<Result<void, string>> {
     const { externalUri, externalSignature, externalSignatureType, claimHash } = message.data.body;
 
-    if (externalSignatureType !== 'eip-191-0x45') return err('validateVerificationAdd: invalid externalSignatureType');
+    if (externalSignatureType !== SignatureAlgorithm.EthereumPersonalSign)
+      return err('validateVerificationAdd: invalid externalSignatureType');
 
     const verificationClaim: VerificationClaim = {
       username: message.data.username,

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -80,7 +80,7 @@ export const Factories = {
         body: {
           embed,
           text,
-          schema: 'farcaster.xyz/schemas/v1/cast-short' as const,
+          schema: 'farcaster.xyz/schemas/v1/cast-short',
         },
         signedAt: Faker.time.recent(),
         username: Faker.name.firstName().toLowerCase(),
@@ -126,7 +126,7 @@ export const Factories = {
       data: {
         body: {
           targetCastUri: 'farcaster://alice/cast/1', // TODO: Find some way to generate this.
-          schema: 'farcaster.xyz/schemas/v1/cast-recast' as const,
+          schema: 'farcaster.xyz/schemas/v1/cast-recast',
         },
         signedAt: Faker.time.recent(),
         username: Faker.name.firstName().toLowerCase(),
@@ -151,7 +151,7 @@ export const Factories = {
           active: true,
           targetUri: Faker.internet.url(),
           type: 'like',
-          schema: 'farcaster.xyz/schemas/v1/reaction' as const,
+          schema: 'farcaster.xyz/schemas/v1/reaction',
         },
         signedAt: Faker.time.recent(),
         username: Faker.name.firstName().toLowerCase(),
@@ -193,7 +193,7 @@ export const Factories = {
       return {
         data: {
           body: {
-            schema: 'farcaster.xyz/schemas/v1/custody-remove-all' as const,
+            schema: 'farcaster.xyz/schemas/v1/custody-remove-all',
           },
           signedAt: Faker.time.recent(),
           username: Faker.name.firstName().toLowerCase(),
@@ -312,8 +312,8 @@ export const Factories = {
             externalUri: ethWallet.address,
             claimHash: '',
             externalSignature: '',
-            externalSignatureType: 'eip-191-0x45',
-            schema: 'farcaster.xyz/schemas/v1/verification-add' as const,
+            externalSignatureType: SignatureAlgorithm.EthereumPersonalSign,
+            schema: 'farcaster.xyz/schemas/v1/verification-add',
           },
           signedAt: Faker.time.recent(),
           username: Faker.name.firstName().toLowerCase(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -138,14 +138,14 @@ export type VerificationAdd = Message<VerificationAddBody>;
  * @externalUri - the URI of the external entity
  * @claimHash - the hash of the verification claim.
  * @externalSignature - the signature of the hash of the verification claim, signed by the external key pair.
- * @externalSignatureType - type of signature from set of supported types (see version 0x45 of https://eips.ethereum.org/EIPS/eip-191 for 'eip-191-0x45')
+ * @externalSignatureType - type of signature from set of supported types (see version 0x45 of https://eips.ethereum.org/EIPS/eip-191 for 'eth-personal-sign')
  * @schema -
  */
 export type VerificationAddBody = {
   externalUri: URI;
   claimHash: string;
   externalSignature: string;
-  externalSignatureType: 'eip-191-0x45';
+  externalSignatureType: SignatureAlgorithm.EthereumPersonalSign;
   schema: 'farcaster.xyz/schemas/v1/verification-add';
 };
 
@@ -312,7 +312,7 @@ export enum HashAlgorithm {
 /** SignatureAlgorithm enum */
 export enum SignatureAlgorithm {
   Ed25519 = 'ed25519',
-  EthereumPersonalSign = 'eth-personal-sign',
+  EthereumPersonalSign = 'eth-personal-sign', // EIP 191 version 0x45 of https://eips.ethereum.org/EIPS/eip-191
 }
 
 /** MessageFactoryTransientParams is the generic transient params type for message factories */

--- a/src/types/typeguards.ts
+++ b/src/types/typeguards.ts
@@ -72,7 +72,7 @@ export const isVerificationAdd = (msg: FC.Message): msg is FC.VerificationAdd =>
   return (
     body &&
     body.schema === 'farcaster.xyz/schemas/v1/verification-add' &&
-    body.externalSignatureType === 'eip-191-0x45' &&
+    body.externalSignatureType === FC.SignatureAlgorithm.EthereumPersonalSign &&
     typeof body.externalSignature === 'string' &&
     typeof body.externalUri === 'string' &&
     typeof body.claimHash === 'string' &&


### PR DESCRIPTION
## Motivation

Last item from https://github.com/farcasterxyz/hub/issues/49

## Change Type


- [ ] Protocol Feature: changes the design of the hub and the protocol
- [ ] Hub Feature: changes the design of the hub, but does not affect the protocol
- [ ] Bugfix: solves an issue with the current implementation
- [x] Chore: miscellaneous improvement to the system

## Change Summary

Replace `eip-191-0x45` string with `SignatureAlgorithm.EthereumPersonalSign` for `externalSignatureType` field of verifications.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard


