### PR TITLE
feat: follow set

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -2,10 +2,12 @@ import { hexToBytes } from 'ethereum-cryptography/utils';
 import Client from '~/client';
 import { Factories } from '~/factories';
 import * as ed from '@noble/ed25519';
+import Faker from 'faker';
 import { CastShort, Ed25519Signer, EthereumSigner } from '~/types';
 import {
   isCastRemove,
   isCastShort,
+  isFollow,
   isReaction,
   isSignerAdd,
   isSignerRemove,
@@ -91,6 +93,14 @@ describe('when signer is a delegate signer', () => {
       const claimHash = await client.makeVerificationClaimHash(wallet.address);
       const message = await client.makeVerificationRemove(claimHash);
       expect(isVerificationRemove(message)).toBe(true);
+    });
+  });
+
+  describe('makeFollow', () => {
+    test('succeeds', async () => {
+      const targetUser = Faker.internet.url();
+      const message = await client.makeFollow(targetUser);
+      expect(isFollow(message)).toBe(true);
     });
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -70,6 +70,22 @@ class Client {
     return message as FC.Reaction;
   }
 
+  async makeFollow(targetUser: FC.URI, active = true): Promise<FC.Follow> {
+    const schema = 'farcaster.xyz/schemas/v1/follow' as const;
+    const signedAt = Date.now();
+    const messageData = {
+      body: {
+        active,
+        targetUri: targetUser,
+        schema,
+      },
+      signedAt,
+      username: this.username,
+    };
+    const message = await this.makeMessage(messageData);
+    return message as FC.Follow;
+  }
+
   async makeVerificationClaimHash(externalUri: FC.URI): Promise<string> {
     return await hashFCObject({
       username: this.username,

--- a/src/engine/engine.follow.test.ts
+++ b/src/engine/engine.follow.test.ts
@@ -1,0 +1,147 @@
+import Engine from '~/engine';
+import Faker from 'faker';
+import { Factories } from '~/factories';
+import {
+  Cast,
+  Ed25519Signer,
+  EthereumSigner,
+  Follow,
+  IDRegistryEvent,
+  MessageFactoryTransientParams,
+  Reaction,
+  SignerAdd,
+} from '~/types';
+import { generateEd25519Signer, generateEthereumSigner } from '~/utils';
+
+const engine = new Engine();
+
+describe('mergeFollow', () => {
+  let aliceCustody: EthereumSigner;
+  let aliceCustodyRegister: IDRegistryEvent;
+  let aliceSigner: Ed25519Signer;
+  let aliceSignerAdd: SignerAdd;
+  let cast: Cast;
+  let follow: Follow;
+  let unfollow: Follow;
+  let transientParams: { transient: MessageFactoryTransientParams };
+
+  const aliceFollows = () => engine._getActiveFollows('alice');
+
+  beforeAll(async () => {
+    aliceCustody = await generateEthereumSigner();
+    aliceCustodyRegister = await Factories.IDRegistryEvent.create({
+      args: { to: aliceCustody.signerKey },
+      name: 'Register',
+    });
+    aliceSigner = await generateEd25519Signer();
+    aliceSignerAdd = await Factories.SignerAdd.create(
+      { data: { username: 'alice' } },
+      { transient: { signer: aliceCustody, delegateSigner: aliceSigner } }
+    );
+    transientParams = { transient: { signer: aliceSigner } };
+    cast = await Factories.Cast.create({ data: { username: 'alice' } }, transientParams);
+    follow = await Factories.Follow.create({ data: { username: 'alice', body: { active: true } } }, transientParams);
+    unfollow = await Factories.Follow.create(
+      { data: { username: 'alice', body: { targetUri: follow.data.body.targetUri, active: false } } },
+      transientParams
+    );
+  });
+
+  beforeEach(async () => {
+    engine._reset();
+    engine.mergeIDRegistryEvent('alice', aliceCustodyRegister);
+    await engine.mergeSignerMessage(aliceSignerAdd);
+  });
+
+  test('fails with invalid message type', async () => {
+    const invalidFollow = cast as unknown as Follow;
+    const result = await engine.mergeFollow(invalidFollow);
+    expect(result.isOk()).toBe(false);
+    expect(result._unsafeUnwrapErr()).toBe('FollowSet.merge: invalid message format');
+    expect(aliceFollows()).toEqual(new Set());
+  });
+
+  describe('signer validation', () => {
+    test('fails if there are no known signers', async () => {
+      engine._resetSigners();
+      const result = await engine.mergeFollow(follow);
+      expect(result._unsafeUnwrapErr()).toBe('mergeFollow: unknown user');
+      expect(aliceFollows()).toEqual(new Set());
+    });
+
+    test('fails if the signer is not valid', async () => {
+      // Calling Factory without specifying a signing key makes Faker choose a random one
+      const followNewSigner = await Factories.Follow.create({
+        data: {
+          username: 'alice',
+          body: { targetUri: follow.data.body.targetUri, active: true },
+        },
+      });
+
+      const result = await engine.mergeFollow(followNewSigner);
+      expect(result._unsafeUnwrapErr()).toBe('validateMessage: invalid signer');
+      expect(aliceFollows()).toEqual(new Set());
+    });
+
+    test('fails if the signer is valid, but the username is invalid', async () => {
+      const unknownUser = await Factories.Follow.create(
+        { data: { username: 'bob', body: { active: true } } },
+        transientParams
+      );
+      const res = await engine.mergeFollow(unknownUser);
+      expect(res.isOk()).toBe(false);
+      expect(res._unsafeUnwrapErr()).toBe('mergeFollow: unknown user');
+      expect(aliceFollows()).toEqual(new Set());
+    });
+  });
+
+  describe('message validation', () => {
+    test('fails if the hash is invalid', async () => {
+      const followInvalidHash: Follow = { ...follow, hash: follow.hash + 'foo' };
+      const res = await engine.mergeFollow(followInvalidHash);
+      expect(res.isOk()).toBe(false);
+      expect(res._unsafeUnwrapErr()).toBe('validateMessage: invalid hash');
+      expect(aliceFollows()).toEqual(new Set());
+    });
+
+    test('fails if the signature is invalid', async () => {
+      const followInvalidSignature: Follow = { ...follow, signature: Faker.datatype.hexaDecimal(128) };
+      const res = await engine.mergeFollow(followInvalidSignature);
+      expect(res.isOk()).toBe(false);
+      expect(res._unsafeUnwrapErr()).toBe('validateMessage: invalid signature');
+      expect(aliceFollows()).toEqual(new Set());
+    });
+
+    test('fails if signedAt is > current time + safety margin', async () => {
+      const elevenMinutesAhead = Date.now() + 11 * 60 * 1000;
+      const futureFollow = await Factories.Follow.create(
+        {
+          data: {
+            username: 'alice',
+            signedAt: elevenMinutesAhead,
+          },
+        },
+        transientParams
+      );
+      const res = await engine.mergeFollow(futureFollow);
+      expect(res.isOk()).toBe(false);
+      expect(res._unsafeUnwrapErr()).toEqual('validateMessage: signedAt more than 10 mins in the future');
+    });
+  });
+
+  test('succeeds with a valid follow', async () => {
+    expect((await engine.mergeFollow(follow)).isOk()).toBe(true);
+    expect(aliceFollows()).toEqual(new Set([follow]));
+  });
+
+  test('succeeds with a valid unfollow', async () => {
+    expect((await engine.mergeFollow(unfollow)).isOk()).toBe(true);
+    expect(aliceFollows()).toEqual(new Set());
+  });
+
+  test('succeeds with a valid unfollow and removes follow', async () => {
+    expect((await engine.mergeFollow(follow)).isOk()).toBe(true);
+    expect((await engine.mergeFollow(unfollow)).isOk()).toBe(true);
+    expect(aliceFollows()).toEqual(new Set());
+  });
+});

--- a/src/engine/engine.follow.test.ts
+++ b/src/engine/engine.follow.test.ts
@@ -8,7 +8,6 @@ import {
   Follow,
   IDRegistryEvent,
   MessageFactoryTransientParams,
-  Reaction,
   SignerAdd,
 } from '~/types';
 import { generateEd25519Signer, generateEthereumSigner } from '~/utils';

--- a/src/engine/engine.revoke.test.ts
+++ b/src/engine/engine.revoke.test.ts
@@ -10,6 +10,7 @@ import {
   SignerAdd,
   SignerRemove,
   VerificationAdd,
+  Follow,
 } from '~/types';
 import { generateEd25519Signer, generateEthereumSigner } from '~/utils';
 
@@ -19,6 +20,7 @@ const aliceAllSigners = () => engine._getAllSigners('alice');
 const aliceCasts = () => engine._getCastAdds('alice');
 const aliceReactions = () => engine._getActiveReactions('alice');
 const aliceVerifications = () => engine._getVerificationAdds('alice');
+const aliceFollows = () => engine._getActiveFollows('alice');
 
 let aliceCustody: EthereumSigner;
 let aliceCustodyRegister: IDRegistryEvent;
@@ -33,6 +35,7 @@ let aliceSignerRemove: SignerRemove;
 let aliceCast: CastShort;
 let aliceReaction: Reaction;
 let aliceVerification: VerificationAdd;
+let aliceFollow: Follow;
 
 beforeAll(async () => {
   aliceCustody = await generateEthereumSigner();
@@ -78,6 +81,7 @@ beforeAll(async () => {
     { data: { username: 'alice' } },
     { transient: { signer: aliceSigner } }
   );
+  aliceFollow = await Factories.Follow.create({ data: { username: 'alice' } }, { transient: { signer: aliceSigner } });
 });
 
 describe('revokeSignerMessages', () => {
@@ -92,10 +96,12 @@ describe('revokeSignerMessages', () => {
       await engine.mergeCast(aliceCast);
       await engine.mergeReaction(aliceReaction);
       await engine.mergeVerification(aliceVerification);
+      await engine.mergeFollow(aliceFollow);
       expect(aliceAllSigners()).toEqual(new Set([aliceCustody.signerKey, aliceSigner.signerKey]));
       expect(aliceCasts()).toEqual([aliceCast]);
       expect(aliceReactions()).toEqual([aliceReaction]);
       expect(aliceVerifications()).toEqual([aliceVerification]);
+      expect(aliceFollows()).toEqual(new Set([aliceFollow]));
     });
 
     test('drops all signed messages when the delegate is removed', async () => {
@@ -105,6 +111,7 @@ describe('revokeSignerMessages', () => {
       expect(aliceCasts()).toEqual([]);
       expect(aliceReactions()).toEqual([]);
       expect(aliceVerifications()).toEqual([]);
+      expect(aliceFollows()).toEqual(new Set());
     });
 
     test('drops all signed messages when custody address is removed', async () => {
@@ -115,6 +122,7 @@ describe('revokeSignerMessages', () => {
       expect(aliceCasts()).toEqual([]);
       expect(aliceReactions()).toEqual([]);
       expect(aliceVerifications()).toEqual([]);
+      expect(aliceFollows()).toEqual(new Set());
     });
 
     test('does not drop signed messages when there are no earlier custody addresses', async () => {
@@ -124,6 +132,7 @@ describe('revokeSignerMessages', () => {
       expect(aliceCasts()).toEqual([aliceCast]);
       expect(aliceReactions()).toEqual([aliceReaction]);
       expect(aliceVerifications()).toEqual([aliceVerification]);
+      expect(aliceFollows()).toEqual(new Set([aliceFollow]));
     });
 
     test('does not drop signed messages when signer is added by a new custody address', async () => {
@@ -135,6 +144,7 @@ describe('revokeSignerMessages', () => {
       expect(aliceCasts()).toEqual([aliceCast]);
       expect(aliceReactions()).toEqual([aliceReaction]);
       expect(aliceVerifications()).toEqual([aliceVerification]);
+      expect(aliceFollows()).toEqual(new Set([aliceFollow]));
     });
   });
 });

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -12,6 +12,7 @@ import {
   SignerMessage,
   HashAlgorithm,
   IDRegistryEvent,
+  Follow,
 } from '~/types';
 import { hashMessage, hashFCObject } from '~/utils';
 import * as ed from '@noble/ed25519';
@@ -28,11 +29,13 @@ import {
   isSignerRemove,
   isSignerMessage,
   isCustodyRemoveAll,
+  isFollow,
 } from '~/types/typeguards';
 import CastSet from '~/sets/castSet';
 import ReactionSet from '~/sets/reactionSet';
 import VerificationSet from '~/sets/verificationSet';
 import SignerSet from '~/sets/signerSet';
+import FollowSet from '~/sets/followSet';
 
 /** The Engine receives messages and determines the current state of the Farcaster network */
 class Engine {
@@ -40,12 +43,14 @@ class Engine {
   private _reactions: Map<string, ReactionSet>;
   private _verifications: Map<string, VerificationSet>;
   private _signers: Map<string, SignerSet>;
+  private _follows: Map<string, FollowSet>;
 
   constructor() {
     this._casts = new Map();
     this._reactions = new Map();
     this._verifications = new Map();
     this._signers = new Map();
+    this._follows = new Map();
   }
 
   /**
@@ -135,7 +140,54 @@ class Engine {
 
       return reactionSet.merge(reaction);
     } catch (e: any) {
-      return err('addCast: unexpected error');
+      return err('mergeReaction: unexpected error');
+    }
+  }
+
+  /**
+   * Follow Methods
+   */
+
+  /** Get a follow for a username by hash */
+  getFollow(username: string, hash: string): Follow | undefined {
+    const followSet = this._follows.get(username);
+    return followSet ? followSet.get(hash) : undefined;
+  }
+
+  /** Get hashes of all known follows for a username */
+  getFollowHashes(username: string): string[] {
+    const followSet = this._follows.get(username);
+    return followSet ? followSet.getHashes() : [];
+  }
+
+  /** Get hashes of all known follows for a username */
+  getAllFollowHashes(username: string): string[] {
+    const followSet = this._follows.get(username);
+    return followSet ? followSet.getAllHashes() : [];
+  }
+
+  /** Merge a follow into the set  */
+  async mergeFollow(follow: Follow): Promise<Result<void, string>> {
+    try {
+      const username = follow.data.username;
+
+      if (!this._signers.get(username)) {
+        return err('mergeFollow: unknown user');
+      }
+
+      const isFollowValidResult = await this.validateMessage(follow);
+      if (isFollowValidResult.isErr()) return isFollowValidResult;
+
+      let followSet = this._follows.get(username);
+      if (!followSet) {
+        followSet = new FollowSet();
+        this._follows.set(username, followSet);
+      }
+
+      return followSet.merge(follow);
+    } catch (e: any) {
+      console.log('error', e);
+      return err('mergeFollow: unexpected error');
     }
   }
 
@@ -226,6 +278,10 @@ class Engine {
     const verificationSet = this._verifications.get(username);
     if (verificationSet) verificationSet.revokeSigner(signer);
 
+    // Revoke follows
+    const followSet = this._follows.get(username);
+    if (followSet) followSet.revokeSigner(signer);
+
     return ok(undefined);
   }
 
@@ -260,12 +316,16 @@ class Engine {
         return err('validateMessage: invalid signature');
       }
     } else if (message.signatureType === SignatureAlgorithm.Ed25519) {
-      const signatureIsValid = await ed.verify(
-        hexToBytes(message.signature),
-        hexToBytes(message.hash),
-        hexToBytes(message.signer)
-      );
-      if (!signatureIsValid) {
+      try {
+        const signatureIsValid = await ed.verify(
+          hexToBytes(message.signature),
+          hexToBytes(message.hash),
+          hexToBytes(message.signer)
+        );
+        if (!signatureIsValid) {
+          return err('validateMessage: invalid signature');
+        }
+      } catch (e: any) {
         return err('validateMessage: invalid signature');
       }
     } else {
@@ -304,6 +364,10 @@ class Engine {
 
     if (isSignerRemove(message)) {
       return this.validateSignerRemove();
+    }
+
+    if (isFollow(message)) {
+      return this.validateFollow();
     }
 
     // TODO: check that the schema is a valid and known schema.
@@ -409,6 +473,11 @@ class Engine {
     return ok(undefined);
   }
 
+  private async validateFollow(): Promise<Result<void, string>> {
+    // TODO: any Follow custom validation?
+    return ok(undefined);
+  }
+
   /**
    * Testing Methods
    */
@@ -418,6 +487,7 @@ class Engine {
     this._resetSigners();
     this._resetReactions();
     this._resetVerifications();
+    this._resetFollows();
   }
 
   _resetCasts(): void {
@@ -436,6 +506,10 @@ class Engine {
     this._verifications = new Map();
   }
 
+  _resetFollows(): void {
+    this._follows = new Map();
+  }
+
   _getCastAdds(username: string): Cast[] {
     const castSet = this._casts.get(username);
     return castSet ? castSet._getAdds() : [];
@@ -444,6 +518,11 @@ class Engine {
   _getActiveReactions(username: string): Reaction[] {
     const reactionSet = this._reactions.get(username);
     return reactionSet ? reactionSet._getActiveReactions() : [];
+  }
+
+  _getActiveFollows(username: string): Set<Follow> {
+    const followSet = this._follows.get(username);
+    return followSet ? followSet._getActiveFollows() : new Set();
   }
 
   _getVerificationAdds(username: string): VerificationAdd[] {

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -22,6 +22,7 @@ import {
   CustodyRemoveAll,
   HashAlgorithm,
   IDRegistryEvent,
+  Follow,
 } from '~/types';
 import { hashMessage, signEd25519, hashFCObject, generateEd25519Signer, generateEthereumSigner } from '~/utils';
 
@@ -152,6 +153,30 @@ export const Factories = {
           targetUri: Faker.internet.url(),
           type: 'like',
           schema: 'farcaster.xyz/schemas/v1/reaction',
+        },
+        signedAt: Faker.time.recent(),
+        username: Faker.name.firstName().toLowerCase(),
+      },
+      hash: '',
+      hashType: HashAlgorithm.Blake2b,
+      signature: '',
+      signatureType: SignatureAlgorithm.Ed25519,
+      signer: '',
+    };
+  }),
+
+  /** Generate a valid Follow with randomized properties */
+  Follow: Factory.define<Follow, MessageFactoryTransientParams, Follow>(({ onCreate, transientParams }) => {
+    onCreate(async (props) => {
+      return (await addEnvelopeToMessage(props, transientParams)) as Follow;
+    });
+
+    return {
+      data: {
+        body: {
+          active: true,
+          targetUri: Faker.internet.url(),
+          schema: 'farcaster.xyz/schemas/v1/follow',
         },
         signedAt: Faker.time.recent(),
         username: Faker.name.firstName().toLowerCase(),

--- a/src/sets/followSet.test.ts
+++ b/src/sets/followSet.test.ts
@@ -1,0 +1,222 @@
+import { Factories } from '~/factories';
+import Faker from 'faker';
+import FollowSet from '~/sets/followSet';
+import { Ed25519Signer, Follow, Reaction, URI } from '~/types';
+import { generateEd25519Signer, hashCompare } from '~/utils';
+
+const set = new FollowSet();
+const activeFollows = () => set._getActiveFollows();
+const inactiveFollows = () => set._getInactiveFollows();
+
+let signer: Ed25519Signer;
+let a: URI;
+let followA: Follow;
+let unfollowA: Follow;
+let b: URI;
+let followB: Follow;
+let unfollowB: Follow;
+
+beforeAll(async () => {
+  signer = await generateEd25519Signer();
+  a = Faker.internet.url();
+  followA = await Factories.Follow.create({ data: { body: { targetUri: a } } }, { transient: { signer } });
+  unfollowA = await Factories.Follow.create(
+    { data: { body: { targetUri: a, active: false }, signedAt: followA.data.signedAt + 1 } },
+    { transient: { signer } }
+  );
+  b = Faker.internet.url();
+  followB = await Factories.Follow.create({ data: { body: { targetUri: b } } }, { transient: { signer } });
+  unfollowB = await Factories.Follow.create(
+    { data: { body: { targetUri: b, active: false }, signedAt: followB.data.signedAt + 1 } },
+    { transient: { signer } }
+  );
+});
+
+beforeEach(() => {
+  set._reset();
+});
+
+describe('merge', () => {
+  test('fails with invalid message format', async () => {
+    const invalidFollow = (await Factories.Cast.create()) as unknown as Follow;
+    const res = await set.merge(invalidFollow);
+    expect(res.isOk()).toBe(false);
+    expect(res._unsafeUnwrapErr()).toBe('FollowSet.merge: invalid message format');
+    expect(activeFollows()).toEqual(new Set());
+    expect(inactiveFollows()).toEqual(new Set());
+  });
+
+  describe('with an active follow', () => {
+    test('succeeds with valid follow', () => {
+      expect(set.merge(followA).isOk()).toBe(true);
+      expect(activeFollows()).toEqual(new Set([followA]));
+      expect(inactiveFollows()).toEqual(new Set());
+    });
+
+    test('succeeds (no-op) with duplicate follow', () => {
+      expect(set.merge(followA).isOk()).toBe(true);
+      expect(set.merge(followA).isOk()).toBe(true);
+      expect(activeFollows()).toEqual(new Set([followA]));
+      expect(inactiveFollows()).toEqual(new Set());
+    });
+
+    test('succeeds with multiple valid follows', () => {
+      expect(set.merge(followA).isOk()).toBe(true);
+      expect(set.merge(followB).isOk()).toBe(true);
+      expect(activeFollows()).toEqual(new Set([followA, followB]));
+      expect(inactiveFollows()).toEqual(new Set());
+    });
+
+    describe('with the same targetURI', () => {
+      let followALater: Follow;
+
+      beforeAll(() => {
+        followALater = { ...followA };
+        followALater.data.signedAt = followA.data.signedAt + 1;
+      });
+
+      test('succeeds with later timestamp', () => {
+        expect(set.merge(followA).isOk()).toBe(true);
+        expect(set.merge(followALater).isOk()).toBe(true);
+        expect(activeFollows()).toEqual(new Set([followALater]));
+        expect(inactiveFollows()).toEqual(new Set());
+      });
+
+      test('succeeds (no-op) with earlier timestamp', () => {
+        expect(set.merge(followALater).isOk()).toBe(true);
+        expect(set.merge(followA).isOk()).toBe(true);
+        expect(activeFollows()).toEqual(new Set([followALater]));
+        expect(inactiveFollows()).toEqual(new Set());
+      });
+    });
+
+    describe('with the same targetURI and timestamp', () => {
+      let followAHigherHash: Follow;
+
+      beforeAll(() => {
+        followAHigherHash = { ...followA, hash: followA.hash + 'a' };
+        followAHigherHash.data.signedAt = followA.data.signedAt;
+      });
+
+      test('succeeds with a higher hash order', () => {
+        expect(set.merge(followA).isOk()).toBe(true);
+        expect(set.merge(followAHigherHash).isOk()).toBe(true);
+        expect(activeFollows()).toEqual(new Set([followAHigherHash]));
+        expect(inactiveFollows()).toEqual(new Set());
+      });
+
+      test('succeeds (no-op) with a lower hash order', () => {
+        expect(set.merge(followAHigherHash).isOk()).toBe(true);
+        expect(set.merge(followA).isOk()).toBe(true);
+        expect(activeFollows()).toEqual(new Set([followAHigherHash]));
+        expect(inactiveFollows()).toEqual(new Set());
+      });
+    });
+  });
+
+  describe('with an inactive follow (unfollow)', () => {
+    test('succeeds with valid unfollow', () => {
+      expect(set.merge(unfollowA).isOk()).toBe(true);
+      expect(activeFollows()).toEqual(new Set());
+      expect(inactiveFollows()).toEqual(new Set([unfollowA]));
+    });
+
+    test('succeeds (no-op) with duplicate unfollow', () => {
+      expect(set.merge(unfollowA).isOk()).toBe(true);
+      expect(set.merge(unfollowA).isOk()).toBe(true);
+      expect(activeFollows()).toEqual(new Set());
+      expect(inactiveFollows()).toEqual(new Set([unfollowA]));
+    });
+
+    test('succeeds with multiple valid unfollows', () => {
+      expect(set.merge(unfollowA).isOk()).toBe(true);
+      expect(set.merge(unfollowB).isOk()).toBe(true);
+      expect(activeFollows()).toEqual(new Set());
+      expect(inactiveFollows()).toEqual(new Set([unfollowA, unfollowB]));
+    });
+
+    test('succeeds when a follow exists', () => {
+      expect(set.merge(followA).isOk()).toBe(true);
+      expect(set.merge(unfollowA).isOk()).toBe(true);
+      expect(activeFollows()).toEqual(new Set());
+      expect(inactiveFollows()).toEqual(new Set([unfollowA]));
+    });
+
+    test('succeeds when a follow exists with the same timestamp', () => {
+      const unfollowASameTimestamp: Follow = { ...unfollowA };
+      unfollowASameTimestamp.data.signedAt = followA.data.signedAt;
+      expect(set.merge(followA).isOk()).toBe(true);
+      expect(set.merge(unfollowASameTimestamp).isOk()).toBe(true);
+      expect(activeFollows()).toEqual(new Set());
+      expect(inactiveFollows()).toEqual(new Set([unfollowASameTimestamp]));
+    });
+
+    describe('with the same targetURI', () => {
+      let unfollowALater: Follow;
+
+      beforeAll(() => {
+        unfollowALater = { ...unfollowA };
+        unfollowALater.data.signedAt = unfollowA.data.signedAt + 1;
+      });
+
+      test('succeeds with later timestamp', () => {
+        expect(set.merge(unfollowA).isOk()).toBe(true);
+        expect(set.merge(unfollowALater).isOk()).toBe(true);
+        expect(activeFollows()).toEqual(new Set());
+        expect(inactiveFollows()).toEqual(new Set([unfollowALater]));
+      });
+
+      test('succeeds (no-op) with earlier timestamp', () => {
+        expect(set.merge(unfollowALater).isOk()).toBe(true);
+        expect(set.merge(unfollowA).isOk()).toBe(true);
+        expect(activeFollows()).toEqual(new Set());
+        expect(inactiveFollows()).toEqual(new Set([unfollowALater]));
+      });
+    });
+
+    describe('with the same targetURI and timestamp', () => {
+      let unfollowAHigherHash: Follow;
+
+      beforeAll(() => {
+        unfollowAHigherHash = { ...unfollowA, hash: unfollowA.hash + 'a' };
+        unfollowAHigherHash.data.signedAt = unfollowA.data.signedAt;
+      });
+
+      test('succeeds with a higher hash order', () => {
+        expect(set.merge(unfollowA).isOk()).toBe(true);
+        expect(set.merge(unfollowAHigherHash).isOk()).toBe(true);
+        expect(activeFollows()).toEqual(new Set());
+        expect(inactiveFollows()).toEqual(new Set([unfollowAHigherHash]));
+      });
+
+      test('succeeds (no-op) with a lower hash order', () => {
+        expect(set.merge(unfollowAHigherHash).isOk()).toBe(true);
+        expect(set.merge(unfollowA).isOk()).toBe(true);
+        expect(activeFollows()).toEqual(new Set());
+        expect(inactiveFollows()).toEqual(new Set([unfollowAHigherHash]));
+      });
+    });
+  });
+});
+
+describe('revokeSigner', () => {
+  test('succeeds without any messages', () => {
+    expect(set.revokeSigner(followA.signer).isOk()).toBe(true);
+  });
+
+  test('succeeds and drops messages', () => {
+    expect(set.merge(followA).isOk()).toBe(true);
+    expect(set.revokeSigner(followA.signer).isOk()).toBe(true);
+    expect(activeFollows()).toEqual(new Set());
+    expect(inactiveFollows()).toEqual(new Set());
+  });
+
+  test('suceeds and only removes messages from signer', () => {
+    const followBDifferentSigner: Follow = { ...followB, signer: 'foo' };
+    expect(set.merge(followA).isOk()).toBe(true);
+    expect(set.merge(followBDifferentSigner).isOk()).toBe(true);
+    expect(set.revokeSigner(followA.signer).isOk()).toBe(true);
+    expect(activeFollows()).toEqual(new Set([followBDifferentSigner]));
+    expect(inactiveFollows()).toEqual(new Set());
+  });
+});

--- a/src/sets/followSet.test.ts
+++ b/src/sets/followSet.test.ts
@@ -1,8 +1,8 @@
 import { Factories } from '~/factories';
 import Faker from 'faker';
 import FollowSet from '~/sets/followSet';
-import { Ed25519Signer, Follow, Reaction, URI } from '~/types';
-import { generateEd25519Signer, hashCompare } from '~/utils';
+import { Ed25519Signer, Follow, URI } from '~/types';
+import { generateEd25519Signer } from '~/utils';
 
 const set = new FollowSet();
 const activeFollows = () => set._getActiveFollows();

--- a/src/sets/followSet.ts
+++ b/src/sets/followSet.ts
@@ -6,10 +6,15 @@ import { hashCompare, sanitizeSigner } from '~/utils';
 /**
  * FollowSet stores and fetches follow actions for a Farcaster ID.
  *
- * TODO: add more info
+ * The FollowSet is implemented as a modified LWW set. Follow objects are stored in the hashToFollow map,
+ * indexed by message hash. Another data structure, targetToHash, stores references from a targetURI (i.e. user URI)
+ * to the most recent follow message hash.
+ *
+ * When two follow messages conflict, the one with the later signedAt timestamp wins. If two messages have the same timestamp,
+ * the remove (i.e. where active is false) wins. If two messages have the same active value, the message with the higher
+ * lexicographical hash wins.
  */
 class FollowSet {
-  /** Both maps indexed by targetURI */
   private hashToFollow: Map<string, Follow>;
   private targetToHash: Map<string, string>;
 

--- a/src/sets/followSet.ts
+++ b/src/sets/followSet.ts
@@ -1,0 +1,120 @@
+import { Result, ok, err } from 'neverthrow';
+import { Follow } from '~/types';
+import { isFollow } from '~/types/typeguards';
+import { hashCompare, sanitizeSigner } from '~/utils';
+
+/**
+ * FollowSet stores and fetches follow actions for a Farcaster ID.
+ *
+ * TODO: add more info
+ */
+class FollowSet {
+  /** Both maps indexed by targetURI */
+  private hashToFollow: Map<string, Follow>;
+  private targetToHash: Map<string, string>;
+
+  constructor() {
+    this.hashToFollow = new Map();
+    this.targetToHash = new Map();
+  }
+
+  /** Get a follow by its hash */
+  get(hash: string): Follow | undefined {
+    return this.hashToFollow.get(hash);
+  }
+
+  /** Get hashes of active follows. */
+  getHashes(): string[] {
+    return Array.from(this.hashToFollow.values())
+      .filter((follow) => follow.data.body.active)
+      .map((follow) => follow.hash);
+  }
+
+  /** Get hashes of all known follows. */
+  getAllHashes(): string[] {
+    return Array.from(this.hashToFollow.keys());
+  }
+
+  /** Merge a new follow into the set */
+  merge(follow: Follow): Result<void, string> {
+    if (!isFollow(follow)) {
+      return err('FollowSet.merge: invalid message format');
+    }
+
+    const { targetUri } = follow.data.body;
+    const existingFollowHash = this.targetToHash.get(targetUri);
+
+    if (!existingFollowHash) {
+      this.mergeFollow(follow);
+      return ok(undefined);
+    }
+
+    const existingFollow = this.hashToFollow.get(existingFollowHash);
+    if (!existingFollow) return err('FollowSet.merge: unexpected state');
+
+    if (existingFollow.data.signedAt > follow.data.signedAt) return ok(undefined);
+
+    if (existingFollow.data.signedAt === follow.data.signedAt) {
+      if (
+        existingFollow.data.body.active === follow.data.body.active &&
+        hashCompare(existingFollow.hash, follow.hash) >= 0
+      ) {
+        return ok(undefined);
+      }
+
+      if (!existingFollow.data.body.active && follow.data.body.active) {
+        return ok(undefined);
+      }
+    }
+
+    this.addOrUpdateFollow(follow);
+    return ok(undefined);
+  }
+
+  revokeSigner(signer: string): Result<void, string> {
+    for (const [target, hash] of this.targetToHash) {
+      const follow = this.hashToFollow.get(hash);
+      if (follow && sanitizeSigner(follow.signer) === sanitizeSigner(signer)) {
+        this.hashToFollow.delete(hash);
+        this.targetToHash.delete(target);
+      }
+    }
+    return ok(undefined);
+  }
+
+  /**
+   * Private Methods
+   */
+
+  private addOrUpdateFollow(follow: Follow): void {
+    const prevHash = this.targetToHash.get(follow.data.body.targetUri);
+    if (prevHash) {
+      this.hashToFollow.delete(prevHash);
+    }
+    this.mergeFollow(follow);
+  }
+
+  private mergeFollow(follow: Follow): void {
+    this.targetToHash.set(follow.data.body.targetUri, follow.hash);
+    this.hashToFollow.set(follow.hash, follow);
+  }
+
+  /**
+   * Testing Methods
+   */
+
+  _getActiveFollows(): Set<Follow> {
+    return new Set(Array.from(this.hashToFollow.values()).filter((follow) => follow.data.body.active));
+  }
+
+  _getInactiveFollows(): Set<Follow> {
+    return new Set(Array.from(this.hashToFollow.values()).filter((follow) => !follow.data.body.active));
+  }
+
+  _reset(): void {
+    this.hashToFollow = new Map();
+    this.targetToHash = new Map();
+  }
+}
+
+export default FollowSet;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,7 +39,8 @@ export type Body =
   | VerificationRemoveBody
   | SignerAddBody
   | SignerRemoveBody
-  | CustodyRemoveAllBody;
+  | CustodyRemoveAllBody
+  | FollowBody;
 
 // ===========================
 //  Cast Types
@@ -122,6 +123,26 @@ export type ReactionBody = {
 };
 
 export type ReactionType = 'like';
+
+//  ===========================
+//  Follow Types
+//  ===========================
+
+/** A Follow message */
+export type Follow = Message<FollowBody>;
+
+/**
+ * A FollowAddBody represents the addition of a follow action on an Farcaster object
+ *
+ * @active - whether the follow is active or not
+ * @targetUri - the object that is being followed
+ * @schema -
+ */
+export type FollowBody = {
+  active: boolean;
+  schema: 'farcaster.xyz/schemas/v1/follow';
+  targetUri: URI;
+};
 
 //  ===========================
 //  Verification Types

--- a/src/types/typeguards.ts
+++ b/src/types/typeguards.ts
@@ -89,3 +89,13 @@ export const isVerificationRemove = (msg: FC.Message): msg is FC.VerificationRem
     body.claimHash.length > 0
   );
 };
+
+export const isFollow = (msg: FC.Message): msg is FC.Follow => {
+  const body = (msg as FC.Follow).data?.body;
+  return (
+    body &&
+    body.schema === 'farcaster.xyz/schemas/v1/follow' &&
+    typeof body.active === 'boolean' &&
+    typeof body.targetUri === 'string'
+  );
+};


### PR DESCRIPTION
## Motivation

Implements https://github.com/farcasterxyz/hub/issues/60

## Change Summary

Tracks follows using a LWW set and similar message format to reactions. Integrated follow set into engine and client.

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] Changes to the protocol specification have been merged

## Additional Context

* Conflicts are resolved using a very similar mechanism to the reactions set, except if two follows with the same timestamp conflict, the unfollow wins, and we only check message hash if the two messages have the same `active` value (i.e. both follows or both unfollows)
* While follows are very similar to reactions, I chose to implement them separately because the target will be different (reactions are attached to casts, and follows are attached to users) and reactions have a type whereas follows do not. Also, reactions as they're implemented now allow only one reaction per target, so putting both actions in the same set would require either (1) making a new key system that combined the type and target or (2) storing reactions and actions in separate data structures inside the set to avoid collisions. If it makes sense to merge them at some point in the future we can, but it's more straightforward to implement them separately now.
* Once we make more progress on URIs, we'll have to type the targetURI more tightly and add tests validating it.
