### PR TITLE
docs: simplify PR template to use github labels for change type

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,15 +2,6 @@
 
 Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.
 
-## Change Type
-
-_Choose one of the options below by adding an `x` now or at any time before submitting for review_
-
-- [ ] Protocol Feature: changes the design of the hub and the protocol
-- [ ] Hub Feature: changes the design of the hub, but does not affect the protocol
-- [ ] Bugfix: solves an issue with the current implementation
-- [ ] Chore: miscellaneous improvement to the system
-
 ## Change Summary
 
 Describe the changes being made in 1-2 concise sentences.
@@ -20,6 +11,7 @@ Describe the changes being made in 1-2 concise sentences.
 _Choose all relevant options below by adding an `x` now or at any time before submitting for review_
 
 - [ ] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
+- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
 - [ ] Changes to the protocol specification have been merged
 
 ## Additional Context


### PR DESCRIPTION
## Motivation

The PR template is heavy-handed, and it causes Github to think that the change type list is a todo list in the PR list view.

## Change Type

_Choose one of the options below by adding an `x` now or at any time before submitting for review_

- [ ] Protocol Feature: changes the design of the hub and the protocol
- [ ] Hub Feature: changes the design of the hub, but does not affect the protocol
- [ ] Bugfix: solves an issue with the current implementation
- [x] Chore: miscellaneous improvement to the system

## Change Summary

Ask contributors to use github labels to mark PRs with the change type instead of a checklist.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] Add `feature`, `chore`, `bugfix` to repo labels if we're going to merge this

