### PR TITLE
bugfix: Faker imported twice in client.test.ts

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -2,7 +2,6 @@ import { hexToBytes } from 'ethereum-cryptography/utils';
 import Client from '~/client';
 import { Factories } from '~/factories';
 import * as ed from '@noble/ed25519';
-import Faker from 'faker';
 import { CastShort, Ed25519Signer, EthereumSigner } from '~/types';
 import {
   isCastRemove,


### PR DESCRIPTION
## Motivation

Faker got imported twice into `client.test.ts` due to merged code and is causing tests to fail.

## Change Summary

Remove import

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
