### PR TITLE
feat: allow checksummed, lowercased, or uppercased externalUri for verifications

### DIFF
--- a/src/engine/engine.verification.test.ts
+++ b/src/engine/engine.verification.test.ts
@@ -95,7 +95,7 @@ describe('mergeVerification', () => {
     expect(aliceAdds()).toEqual(new Set([genericVerificationAdd]));
   });
 
-  test('succeeds with lowercased ethereum address', async () => {
+  test('succeeds with lowercased externalUri', async () => {
     const lowercaseExternalUri = Factories.EthereumAddressURL.build(undefined, {
       transient: { address: aliceEthWallet.address.toLowerCase() },
     }).toString();
@@ -112,6 +112,35 @@ describe('mergeVerification', () => {
           fid: aliceFid,
           body: {
             externalUri: lowercaseExternalUri,
+            claimHash: aliceClaimHash,
+            blockHash: aliceBlockHash,
+            externalSignature: aliceExternalSignature,
+          },
+        },
+      },
+      transientParams
+    );
+    expect((await engine.mergeVerification(verificationAdd)).isOk()).toBe(true);
+    expect(engine._getVerificationEthereumAddressAdds(aliceFid)).toEqual(new Set([verificationAdd]));
+  });
+
+  test('succeeds with uppercased externalUri', async () => {
+    const uppercasedExternalUri = Factories.EthereumAddressURL.build(undefined, {
+      transient: { address: '0x' + aliceEthWallet.address.slice(2).toUpperCase() },
+    }).toString();
+    const verificationClaim: VerificationEthereumAddressClaim = {
+      fid: aliceFid,
+      externalUri: uppercasedExternalUri,
+      blockHash: aliceBlockHash,
+    };
+    const aliceClaimHash = await hashFCObject(verificationClaim);
+    const aliceExternalSignature = await aliceEthWallet.signMessage(aliceClaimHash);
+    const verificationAdd = await Factories.VerificationEthereumAddress.create(
+      {
+        data: {
+          fid: aliceFid,
+          body: {
+            externalUri: uppercasedExternalUri,
             claimHash: aliceClaimHash,
             blockHash: aliceBlockHash,
             externalSignature: aliceExternalSignature,

--- a/src/engine/engine.verification.test.ts
+++ b/src/engine/engine.verification.test.ts
@@ -50,7 +50,7 @@ describe('mergeVerification', () => {
     const verificationClaim: VerificationEthereumAddressClaim = {
       fid: aliceFid,
       externalUri: Factories.EthereumAddressURL.build(undefined, {
-        transient: { address: aliceEthWallet.address.toLowerCase() },
+        transient: { address: aliceEthWallet.address },
       }).toString(),
       blockHash: aliceBlockHash,
     };
@@ -95,7 +95,36 @@ describe('mergeVerification', () => {
     expect(aliceAdds()).toEqual(new Set([genericVerificationAdd]));
   });
 
-  test('fails if claim is constructed with checksummed address', async () => {
+  test('succeeds with lowercased ethereum address', async () => {
+    const lowercaseExternalUri = Factories.EthereumAddressURL.build(undefined, {
+      transient: { address: aliceEthWallet.address.toLowerCase() },
+    }).toString();
+    const verificationClaim: VerificationEthereumAddressClaim = {
+      fid: aliceFid,
+      externalUri: lowercaseExternalUri,
+      blockHash: aliceBlockHash,
+    };
+    const aliceClaimHash = await hashFCObject(verificationClaim);
+    const aliceExternalSignature = await aliceEthWallet.signMessage(aliceClaimHash);
+    const verificationAdd = await Factories.VerificationEthereumAddress.create(
+      {
+        data: {
+          fid: aliceFid,
+          body: {
+            externalUri: lowercaseExternalUri,
+            claimHash: aliceClaimHash,
+            blockHash: aliceBlockHash,
+            externalSignature: aliceExternalSignature,
+          },
+        },
+      },
+      transientParams
+    );
+    expect((await engine.mergeVerification(verificationAdd)).isOk()).toBe(true);
+    expect(engine._getVerificationEthereumAddressAdds(aliceFid)).toEqual(new Set([verificationAdd]));
+  });
+
+  test('fails when claim externalUri is checksummed and message externalUri is lowercased', async () => {
     const verificationClaim: VerificationEthereumAddressClaim = {
       fid: aliceFid,
       externalUri: Factories.EthereumAddressURL.build(undefined, {
@@ -111,7 +140,7 @@ describe('mergeVerification', () => {
           fid: aliceFid,
           body: {
             externalUri: Factories.EthereumAddressURL.build(undefined, {
-              transient: { address: aliceEthWallet.address },
+              transient: { address: aliceEthWallet.address.toLowerCase() },
             }).toString(),
             claimHash: aliceClaimHash,
             blockHash: aliceBlockHash,
@@ -121,8 +150,6 @@ describe('mergeVerification', () => {
       },
       transientParams
     );
-
-    // run the verification through the engine
     const res = await engine.mergeVerification(verificationAdd);
     expect(res.isOk()).toBe(false);
     expect(res._unsafeUnwrapErr()).toBe('validateVerificationEthereumAddress: invalid claimHash');

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -399,7 +399,7 @@ class Engine {
 
     const verificationClaim: VerificationEthereumAddressClaim = {
       fid: message.data.fid,
-      externalUri: message.data.body.externalUri.toLowerCase(),
+      externalUri: message.data.body.externalUri,
       blockHash: message.data.body.blockHash,
     };
     const reconstructedClaimHash = await hashFCObject(verificationClaim);

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -372,7 +372,7 @@ export const Factories = {
       if (!props.data.body.claimHash) {
         const verificationClaim: VerificationEthereumAddressClaim = {
           fid: props.data.fid,
-          externalUri: props.data.body.externalUri.toLowerCase(),
+          externalUri: props.data.body.externalUri,
           blockHash: props.data.body.blockHash,
         };
         props.data.body.claimHash = await hashFCObject(verificationClaim);


### PR DESCRIPTION
## Motivation

Valid Ethereum addresses can be represented in lowercase, checksummed, or uppercase form. Hubs should accept verification messages that use any format, as long as the verification claims associated with those messages used the same format. Thanks @gsgalloway for the catch on this.

## Change Summary

Updated engine and factories to allow lowercase, checksummed, or uppercase addresses.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
