### PR TITLE
feat: add a generic merge handler for the engine

### DIFF
--- a/src/engine/engine.revoke.test.ts
+++ b/src/engine/engine.revoke.test.ts
@@ -84,11 +84,11 @@ describe('revokeSignerMessages', () => {
   describe('with messages signed by delegate', () => {
     beforeEach(async () => {
       await engine.mergeIDRegistryEvent(aliceCustodyRegister);
-      await engine.mergeSignerMessage(aliceSignerAdd);
-      await engine.mergeCast(aliceCast);
-      await engine.mergeReaction(aliceReaction);
-      await engine.mergeVerification(aliceVerification);
-      await engine.mergeFollow(aliceFollow);
+      await engine.mergeMessage(aliceSignerAdd);
+      await engine.mergeMessage(aliceCast);
+      await engine.mergeMessage(aliceReaction);
+      await engine.mergeMessage(aliceVerification);
+      await engine.mergeMessage(aliceFollow);
       expect(aliceCustodyAddress()).toEqual(aliceCustody.signerKey);
       expect(aliceSigners()).toEqual(new Set([aliceSigner.signerKey]));
       expect(aliceCasts()).toEqual(new Set([aliceCast]));
@@ -98,7 +98,7 @@ describe('revokeSignerMessages', () => {
     });
 
     test('drops all signed messages when the delegate is removed', async () => {
-      const res = await engine.mergeSignerMessage(aliceSignerRemove);
+      const res = await engine.mergeMessage(aliceSignerRemove);
       expect(res.isOk()).toBe(true);
       expect(aliceCustodyAddress()).toEqual(aliceCustody.signerKey);
       expect(aliceSigners()).toEqual(new Set());
@@ -120,7 +120,7 @@ describe('revokeSignerMessages', () => {
     });
 
     test('does not drop signed messages when signer is added by a new custody address', async () => {
-      await engine.mergeSignerMessage(aliceSignerAdd2);
+      await engine.mergeMessage(aliceSignerAdd2);
       const res = await engine.mergeIDRegistryEvent(aliceCustody2Transfer);
       expect(res.isOk()).toBe(true);
       expect(aliceCustodyAddress()).toEqual(aliceCustody2.signerKey);


### PR DESCRIPTION
## Motivation

A generic merge handler moves the message parsing burden entirely into the engine

## Change Summary

Added a generic `mergeMessage` api to the Engine that figures out which inner `merge` function to call based on the message type.
## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
