### PR TITLE
feat(sync): Implement a simple Engine sync over RPC

### DIFF
--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -235,6 +235,14 @@ class Engine implements RPCHandler {
     return new Set();
   }
 
+  async getCustodyEventByUser(fid: number): Promise<IDRegistryEvent | undefined> {
+    const signerSet = this._signers.get(fid);
+    if (signerSet) {
+      return signerSet.getCustodyAddressEvent();
+    }
+    return undefined;
+  }
+
   /**
    * Private Methods
    */

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -237,10 +237,7 @@ class Engine implements RPCHandler {
 
   async getCustodyEventByUser(fid: number): Promise<IDRegistryEvent | undefined> {
     const signerSet = this._signers.get(fid);
-    if (signerSet) {
-      return signerSet.getCustodyAddressEvent();
-    }
-    return undefined;
+    return signerSet ? signerSet.getCustodyAddressEvent() : undefined;
   }
 
   /**

--- a/src/network/rpc.sync.test.ts
+++ b/src/network/rpc.sync.test.ts
@@ -51,7 +51,7 @@ describe('rpcSync', () => {
 
       for (const user of userIds) {
         // get the signer messages first so we can prepare to ingest the remaining messages later
-        let result: Result<any, string> = await client.getCustodyEventByuser(user);
+        let result: Result<any, string> = await client.getCustodyEventByUser(user);
         expect(result.isOk()).toBeTruthy();
         const custodyResult = await clientEngine.mergeIDRegistryEvent(result._unsafeUnwrap());
         expect(custodyResult.isOk()).toBeTruthy();

--- a/src/network/rpc.sync.test.ts
+++ b/src/network/rpc.sync.test.ts
@@ -1,0 +1,109 @@
+import { AddressInfo } from 'net';
+import { populateEngine } from '~/engine/engine.mock.test';
+import { Result } from 'neverthrow';
+import { RPCServer, RPCClient } from '~/network/rpc';
+import Engine from '~/engine';
+
+const serverEngine = new Engine();
+
+let server: RPCServer;
+let client: RPCClient;
+
+const NUM_USERS = 5;
+
+describe('rpcSync', () => {
+  beforeAll(async () => {
+    // setup the rpc server and client
+    server = new RPCServer(serverEngine);
+    await server.start();
+    const address = server.address;
+    expect(address).not.toBeNull();
+    client = new RPCClient(server.address as AddressInfo);
+
+    await populateEngine(serverEngine, NUM_USERS);
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  test(
+    'sync data from one engine to another ',
+    async () => {
+      const clientEngine = new Engine();
+
+      // sanity test that the server has something in it
+      const users = await serverEngine.getUsers();
+      expect(users.size).toEqual(NUM_USERS);
+
+      //
+      // TODO this logic needs to live in the "Hub executable" when that exists
+      // Sync logic
+      // Get the list of all users from the server
+      // Get all custody events and signer messages and merge them
+      // Get all the messages from the other sets on the server
+      // Merge all the messages
+      //
+
+      const result = await client.getUsers();
+      expect(result.isOk()).toBeTruthy();
+      const userIds = result._unsafeUnwrap();
+
+      for (const user of userIds) {
+        // get the signer messages first so we can prepare to ingest the remaining messages later
+        let result: Result<any, string> = await client.getCustodyEventByuser(user);
+        expect(result.isOk()).toBeTruthy();
+        const custodyResult = await clientEngine.mergeIDRegistryEvent(result._unsafeUnwrap());
+        expect(custodyResult.isOk()).toBeTruthy();
+        // next, get all the signer messages
+        result = await client.getAllSignerMessagesByUser(user);
+        expect(result.isOk()).toBeTruthy();
+        const signerResults = await Promise.all(clientEngine.mergeMessages([...result._unsafeUnwrap()]));
+        signerResults.forEach((result) => {
+          expect(result.isOk()).toBeTruthy();
+        });
+
+        // now collect all the messages from each set
+        const responses = await Promise.all([
+          client.getAllCastsByUser(user),
+          client.getAllFollowsByUser(user),
+          client.getAllReactionsByUser(user),
+          client.getAllVerificationsByUser(user),
+        ]);
+
+        const messages = responses.flatMap((response) => {
+          expect(response.isOk()).toBeTruthy();
+          return response.match(
+            (messages) => {
+              return [...messages];
+            },
+            () => {
+              return [];
+            }
+          );
+        });
+
+        // replay all messages into the client Engine
+        const mergeResults = await Promise.all(clientEngine.mergeMessages(messages));
+        mergeResults.forEach((result) => {
+          expect(result.isOk()).toBeTruthy();
+        });
+      }
+
+      // Finally compare the two Engines and make sure they're equal.
+      await expect(clientEngine.getUsers()).resolves.toEqual(users);
+      for (const user of userIds) {
+        const casts = await serverEngine.getAllCastsByUser(user);
+        await expect(clientEngine.getAllCastsByUser(user)).resolves.toEqual(casts);
+        const follows = await serverEngine.getAllFollowsByUser(user);
+        await expect(clientEngine.getAllFollowsByUser(user)).resolves.toEqual(follows);
+        const reactions = await serverEngine.getAllReactionsByUser(user);
+        await expect(clientEngine.getAllReactionsByUser(user)).resolves.toEqual(reactions);
+        const verifications = await serverEngine.getAllVerificationsByUser(user);
+        await expect(clientEngine.getAllVerificationsByUser(user)).resolves.toEqual(verifications);
+      }
+    },
+    // Set a 2 minute timeout for this test
+    2 * 60 * 1000
+  );
+});

--- a/src/network/rpc.test.ts
+++ b/src/network/rpc.test.ts
@@ -106,6 +106,20 @@ describe('rpc', () => {
     await server.stop();
   });
 
+  test('returns an error if there is no custody event', async () => {
+    engine._reset();
+    const response = await client.getCustodyEventByuser(aliceFid);
+    expect(response.isOk()).not.toBeTruthy();
+    expect(response._unsafeUnwrapErr()).toBe('Not Found');
+  });
+
+  test('get the custody event for an fid', async () => {
+    const response = await client.getCustodyEventByuser(aliceFid);
+    expect(response.isOk()).toBeTruthy();
+    const custodyEvent = response._unsafeUnwrap();
+    expect(custodyEvent).toEqual(aliceCustodyRegister);
+  });
+
   test('get all signer messages for an fid', async () => {
     const response = await client.getAllSignerMessagesByUser(aliceFid);
     expect(response.isOk()).toBeTruthy();

--- a/src/network/rpc.test.ts
+++ b/src/network/rpc.test.ts
@@ -108,13 +108,13 @@ describe('rpc', () => {
 
   test('returns an error if there is no custody event', async () => {
     engine._reset();
-    const response = await client.getCustodyEventByuser(aliceFid);
+    const response = await client.getCustodyEventByUser(aliceFid);
     expect(response.isOk()).not.toBeTruthy();
     expect(response._unsafeUnwrapErr()).toBe('Not Found');
   });
 
   test('get the custody event for an fid', async () => {
-    const response = await client.getCustodyEventByuser(aliceFid);
+    const response = await client.getCustodyEventByUser(aliceFid);
     expect(response.isOk()).toBeTruthy();
     const custodyEvent = response._unsafeUnwrap();
     expect(custodyEvent).toEqual(aliceCustodyRegister);

--- a/src/network/rpc.ts
+++ b/src/network/rpc.ts
@@ -202,7 +202,7 @@ export class RPCClient {
     return new Ok(response.result);
   }
 
-  async getCustodyEventByuser(fid: number): Promise<Result<IDRegistryEvent, string>> {
+  async getCustodyEventByUser(fid: number): Promise<Result<IDRegistryEvent, string>> {
     const response = await this._tcpClient.request(RPCRequest.GetCustodyEventByuser, { fid });
     if (response.error) {
       return new Err(response.error);

--- a/src/network/rpc.ts
+++ b/src/network/rpc.ts
@@ -2,7 +2,7 @@ import { AddressInfo } from 'net';
 import { Err, Ok, Result } from 'neverthrow';
 import { rejects } from 'assert';
 import * as jayson from 'jayson/promise';
-import { Cast, Follow, Message, Reaction, SignerMessage, Verification } from '~/types';
+import { Cast, Follow, IDRegistryEvent, Message, Reaction, SignerMessage, Verification } from '~/types';
 
 const VERSION = 0.1;
 
@@ -15,6 +15,7 @@ export enum RPCRequest {
   GetAllReactionsByUser = 'getAllReactionsByUser',
   GetAllFollowsByUser = 'getAllFollowsByUser',
   GetAllVerificationsByUser = 'getAllVerificationsByUser',
+  GetCustodyEventByuser = 'getCustodyEventByUser',
 }
 
 export interface RPCHandler {
@@ -24,6 +25,7 @@ export interface RPCHandler {
   getAllReactionsByUser(fid: number): Promise<Set<Reaction>>;
   getAllFollowsByUser(fid: number): Promise<Set<Follow>>;
   getAllVerificationsByUser(fid: number): Promise<Set<Verification>>;
+  getCustodyEventByUser(fid: number): Promise<IDRegistryEvent | undefined>;
 }
 
 const replacer = (key: any, value: any) => {
@@ -90,6 +92,12 @@ export class RPCServer {
         [RPCRequest.GetAllVerificationsByUser]: new jayson.Method({
           handler: async (args: any) => {
             return rpcHandler.getAllVerificationsByUser(args.fid);
+          },
+        }),
+
+        [RPCRequest.GetCustodyEventByuser]: new jayson.Method({
+          handler: async (args: any) => {
+            return rpcHandler.getCustodyEventByUser(args.fid);
           },
         }),
       },
@@ -190,6 +198,17 @@ export class RPCClient {
     const response = await this._tcpClient.request(RPCRequest.GetAllVerificationsByUser, { fid });
     if (response.error) {
       return new Err(response.error);
+    }
+    return new Ok(response.result);
+  }
+
+  async getCustodyEventByuser(fid: number): Promise<Result<IDRegistryEvent, string>> {
+    const response = await this._tcpClient.request(RPCRequest.GetCustodyEventByuser, { fid });
+    if (response.error) {
+      return new Err(response.error);
+    }
+    if (!response.result) {
+      return new Err('Not Found');
     }
     return new Ok(response.result);
   }


### PR DESCRIPTION
## Motivation

Fixes https://github.com/farcasterxyz/hub/issues/102

## Change Summary

- Wrote a simple test that copies data from one Engine (server) to another (client) over RPC.
- Added RPC APIs for querying IDRegistry events as well

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)

## Additional Context

Depends on https://github.com/farcasterxyz/hub/pull/105. 
I will rebase this once that's landed.