### PR TITLE
ci: add yarn audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Run audit
+        run: yarn audit
+
       - name: Run linter
         run: yarn lint
 


### PR DESCRIPTION
## Motivation

Add yarn audit so that ci fails when a vulnerability is found in a package we own.

## Change Summary

N/A

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] Changes to the protocol specification have been merged