### PR TITLE
ci: should not fail on every project coverage decrease

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 100%
+        threshold: 1%

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,5 +2,5 @@ coverage:
   status:
     project:
       default:
-        target: 100%
+        target: 85%
         threshold: 1%


### PR DESCRIPTION
## Motivation

Codecov complains if total repo coverage decreases by any amount, which creates a lot of false positives. Eliminating false positives by using a hardcoded threshold lets us to focus on the important failures (patch changes that reduce coverage). Also, reviewers should always be thoughtful about inspecting coverage reports to determine if a change is sufficiently covered. 

## Change Summary

Add 85% requirement to the codecov project, instead of using auto


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
