### PR TITLE
feat: increase cast length checks to 500 from 280 [#121]

### DIFF
--- a/src/engine/engine.cast.test.ts
+++ b/src/engine/engine.cast.test.ts
@@ -206,13 +206,13 @@ describe('mergeCast', () => {
       });
       // test('fails if the targetUri references itself', async () => {});
 
-      test('fails if text is greater than 280 chars', async () => {
+      test('fails if text is greater than 500 chars', async () => {
         const castLongText = await Factories.CastShort.create(
           {
             data: {
               fid: aliceFid,
               body: {
-                text: 'a'.repeat(281),
+                text: 'a'.repeat(501),
               },
             },
           },
@@ -221,7 +221,7 @@ describe('mergeCast', () => {
         const result = await engine.mergeMessage(castLongText);
 
         expect(result.isOk()).toBe(false);
-        expect(result._unsafeUnwrapErr()).toMatchObject(new BadRequestError('validateCastShort: text > 280 chars'));
+        expect(result._unsafeUnwrapErr()).toMatchObject(new BadRequestError('validateCastShort: text > 500 chars'));
         expect(await aliceAdds()).toEqual(new Set());
       });
 

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -336,8 +336,8 @@ class Engine implements RPCHandler {
   private validateCastShort(cast: CastShort): Result<void, FarcasterError> {
     const { text, embed, targetUri } = cast.data.body;
 
-    if (text && text.length > 280) {
-      return err(new BadRequestError('validateCastShort: text > 280 chars'));
+    if (text && text.length > 500) {
+      return err(new BadRequestError('validateCastShort: text > 500 chars'));
     }
 
     if (embed && embed.items.length > 2) {


### PR DESCRIPTION
## Motivation

Discussed in #121

## Change Summary

Changed the checks from 280 to 500.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

I have not yet submitted the protocol PR. Also I have no idea what else might need to be changed. But I wanted to be the person who changed cast length 😋 