### PR TITLE
test: fix yarn jest failing on node.test.ts

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,24 +1,23 @@
-import type { Config } from '@jest/types';
+import type { JestConfigWithTsJest } from 'ts-jest';
 
-export default async (): Promise<Config.InitialOptions> => {
-  return {
-    preset: 'ts-jest/presets/default-esm',
-    testEnvironment: 'node',
-    moduleNameMapper: {
-      '^~/(.*)$': '<rootDir>/src/$1',
-    },
-    coveragePathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
-    testPathIgnorePatterns: ['<rootDir>/build', '<rootDir>/node_modules'],
-    // transform ts files with ts-jest and enable ESM
-    transform: {
-      '^.+\\.tsx?$': [
-        'ts-jest',
-        {
-          tsconfig: 'tsconfig.json',
-          useESM: true,
-        },
-      ],
-    },
-    extensionsToTreatAsEsm: ['.ts'],
-  };
+const jestConfig: JestConfigWithTsJest = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^~/(.*)$': '<rootDir>/src/$1',
+  },
+  coveragePathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
+  testPathIgnorePatterns: ['<rootDir>/build', '<rootDir>/node_modules'],
+  // transform ts files with ts-jest and enable ESM
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.json',
+        useESM: true,
+      },
+    ],
+  },
 };
+
+export default jestConfig;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "npm run lint -- --fix",
     "server": "tsx src/server.ts",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --runInBand --forceExit --coverage",
+    "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage",
     "typecheck": "tsc --noEmit"
   },
   "repository": {


### PR DESCRIPTION
## Motivation

Fixes #141 

## Change Summary

`jest.config.ts` was using a combination of manual and pre-set configuration and was being exported as a different type. Restoring settings to [recommended configuration](https://kulshekhar.github.io/ts-jest/docs/next/guides/esm-support/) seemed to resolve the issue

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
