### PR TITLE
fix(CastSet): remove-wins should trump last-write-wins

### DIFF
--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -133,7 +133,7 @@ class Engine {
    */
 
   async getAllCastsByUser(fid: number): Promise<Set<Cast>> {
-    return this._castSet.getAllCastMessagesByUser(fid);
+    return this._castSet.getAllCastsByUser(fid);
   }
 
   /**

--- a/src/sets/castSet.ts
+++ b/src/sets/castSet.ts
@@ -6,14 +6,23 @@ import RocksDB from '~/db/rocksdb';
 import { BadRequestError } from '~/errors';
 import { hashCompare } from '~/utils';
 
+type CastAdd = CastShort | CastRecast;
+
 /**
- * CastSet is a modified LWW set that stores and fetches casts. CastShort, CastRecast, and CastRemove messages
- * are stored in the CastDB.
+ * A CRDT that stores and retrieves Cast messages by fid with Remove-Wins and Last-Write-Wins semantics.
  *
- * Conflicts between two cast messages are resolved in this order (see castMessageCompare for implementation):
- * 1. Later timestamp wins
- * 2. CastRemove > (CastShort, CastRecast)
- * 3. Higher message hash lexicographic order wins
+ * The CastSet has an add and remove set to track state. Add messages (CastShort, CastRecast) are used to place casts
+ * in the add set while remove messages (CastRemove) move them into the delete set. Conflicts between add messages are
+ * impossible by design, since any change to the message body results in a new hash which makes the message distinct.
+ * Conflicts may arise between add and remove messages or remove and remove messages, which are handled with the
+ * following rules:
+ *
+ * 1. Remove-Wins - a remove message always supersedes an add message
+ * 2. Last-Write-Wins - a remove message with a higher timestamp supersedes one with a lower timestamp
+ * 3. Lexicographical Ordering - a remove message with a higher hash supersedes one with a lower hash
+ *
+ * The CastRemove on a CastShort also does not retain the text of the message and instead stores the message hash,
+ * which allows permanent deletion of message content.
  */
 class CastSet {
   private _db: CastDB;
@@ -22,24 +31,28 @@ class CastSet {
     this._db = new CastDB(db);
   }
 
-  getCast(fid: number, hash: string): Promise<CastShort | CastRecast> {
+  getCast(fid: number, hash: string): Promise<CastAdd> {
     return this._db.getCastAdd(fid, hash);
   }
 
-  async getCastsByUser(fid: number): Promise<Set<CastShort | CastRecast>> {
+  /** Get all Casts in a user's add set */
+  async getCastsByUser(fid: number): Promise<Set<CastAdd>> {
     const casts = await this._db.getCastAddsByUser(fid);
     return new Set(casts);
   }
 
-  async getAllCastMessagesByUser(fid: number): Promise<Set<Cast>> {
+  /* Get all Casts in a user's add and remove sets */
+  async getAllCastsByUser(fid: number): Promise<Set<Cast>> {
     const casts = await this._db.getAllCastMessagesByUser(fid);
     return new Set(casts);
   }
 
+  /* Delete all Casts created by a Signer */
   async revokeSigner(fid: number, signer: string): Promise<void> {
     return this._db.deleteAllCastMessagesBySigner(fid, signer);
   }
 
+  /* Merge a Cast into the CastSet */
   async merge(cast: Cast): Promise<void> {
     if (isCastRemove(cast)) {
       return this.mergeRemove(cast);
@@ -60,25 +73,25 @@ class CastSet {
     // If they are the same message, return 0
     if (a.hash === b.hash) return 0;
 
-    // Compare signedAt timestamps
-    if (a.data.signedAt > b.data.signedAt) {
-      return 1;
-    } else if (a.data.signedAt < b.data.signedAt) {
-      return -1;
-    }
-
-    // Compare message types (ReactionRemove > ReactionAdd)
+    // 1. Remove-Wins: compare message type (ReactionRemove > ReactionAdd)
     if (isCastRemove(a) && (isCastShort(b) || isCastRecast(b))) {
       return 1;
     } else if ((isCastShort(a) || isCastRecast(a)) && isCastRemove(b)) {
       return -1;
     }
 
-    // Compare lexicographical order of hash
+    // 2. Last-Write-Wins: compare signedAt timestamps
+    if (a.data.signedAt > b.data.signedAt) {
+      return 1;
+    } else if (a.data.signedAt < b.data.signedAt) {
+      return -1;
+    }
+
+    // 3. Tie Breaker: Compare lexicographical order of hash
     return hashCompare(a.hash, b.hash);
   }
 
-  private async mergeAdd(cast: CastShort | CastRecast): Promise<void> {
+  private async mergeAdd(cast: CastAdd): Promise<void> {
     const { fid } = cast.data;
 
     // If cast has already been removed, no-op


### PR DESCRIPTION
## Motivation

CastSet implemented LWW-RW instead of RW-LWW which meant that a remove message would be ignored if it was incorrectly generated with an older timestamp. 

## Change Summary

This PR fixes the core issue by making the RemoveWins rule take precedence over the LastWriteWins rule. It also:

1. Adds more class and method documentation
2. Renames  CastSet's `getAllCastMessagesByUser` to `getAllCastsByUser` to be consistent with other methods
3. Improves test coverage for some lines and cases  

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged
