### PR TITLE
feat: Script to benchmark a network of Hubs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "npm run lint -- --fix",
     "server": "tsx src/server.ts",
+    "bench": "tsx src/bench.ts",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage",
     "typecheck": "tsc --noEmit"

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -66,7 +66,10 @@ const submitInBatches = async (messages: Message[] | IDRegistryEvent[]) => {
 
 const app = new Command();
 
-app.name('farcaster-benchmark-client').description('Farcaster Benchmark').version('0.1.0');
+app
+  .name('farcaster-benchmark-client')
+  .description('Farcaster Benchmark')
+  .version(process.env.npm_package_version ?? '1.0.0');
 
 app
   .requiredOption('-a, --ip-address <address>', 'The IP address of a Hub to submit messages to')

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -1,0 +1,157 @@
+import { Command } from 'commander';
+import { RPCClient } from '~/network/rpc';
+import { AddressInfo, isIP } from 'net';
+import { generateUserInfo, getIDRegistryEvent, getSignerAdd, UserInfo } from '~/engine/mock';
+import Faker from 'faker';
+import { IDRegistryEvent, Message, SignerAdd } from '~/types';
+import { Factories } from '~/factories';
+import { Result } from 'neverthrow';
+import { sleep } from '~/utils';
+import { JSONRPCError } from 'jayson/promise';
+import { isIDRegistryEvent, isMessage } from '~/types/typeguards';
+
+const post = (msg: string, start: number, stop: number) => {
+  const delta = Number((stop - start) / 1000);
+  const time = delta.toFixed(3);
+  console.log(`Time ${time}s : ${msg}`);
+  return delta;
+};
+
+const parseNumber = (string: string) => {
+  const number = Number(string);
+  if (isNaN(number)) throw new Error('Not a number.');
+  return number;
+};
+
+const getCounts = (results: Result<any, any>[]): SubmitCounts => {
+  const counts = results
+    .map((r) => [Number(r.isOk()), Number(r.isErr())])
+    .reduce((results, result) => {
+      results[0] += result[0];
+      results[1] += result[1];
+      return results;
+    });
+  return {
+    success: counts[0],
+    fail: counts[1],
+  };
+};
+
+type SubmitCounts = {
+  success: number;
+  fail: number;
+};
+
+const submitInBatches = async (messages: Message[] | IDRegistryEvent[]) => {
+  // limits what we try to do in parallel. If this number is too large, we'll run out of sockets to use for tcp
+  const BATCH_SIZE = 100;
+  let results: Result<void, JSONRPCError>[] = [];
+  for (let i = 0; i < messages.length; i += BATCH_SIZE) {
+    const batch = messages.slice(i, i + BATCH_SIZE);
+    const innerRes = await Promise.all(
+      batch.map((message) => {
+        if (isIDRegistryEvent(message)) {
+          return client.submitIDRegistryEvent(message);
+        }
+        if (isMessage(message)) {
+          return client.submitMessage(message);
+        }
+        throw Error('Trying to send invalid message');
+      })
+    );
+    results = results.concat(innerRes);
+  }
+  return getCounts(results);
+};
+
+const app = new Command();
+
+app.name('farcaster-benchmark-client').description('Farcaster Benchmark').version('0.1.0');
+
+app
+  .requiredOption('-a, --ip-address <address>', 'The IP address of a Hub to submit messages to')
+  .requiredOption('-r, --rpc-port <port>', 'The RPC port of the Hub')
+  .option('-u, --users <count>', 'The number of users to simulate', parseNumber, 100);
+
+app.parse(process.argv);
+const cliOptions = app.opts();
+console.log(cliOptions, [...Array(cliOptions.users)].length, typeof cliOptions.users);
+const family = isIP(cliOptions.ipAddress);
+if (!family) throw new Error('Invalid Hub Address');
+
+const address: AddressInfo = {
+  address: cliOptions.ipAddress,
+  port: cliOptions.rpcPort,
+  family: family == 4 ? 'ip4' : 'ip6',
+};
+console.log(`Using RPC server: ${address.address}/${address.port}`);
+const client = new RPCClient(address);
+
+// generate users
+console.log(`Generating IDRegistry events for ${cliOptions.users} users.`);
+const firstUser = Faker.datatype.number();
+const idRegistryEvents: IDRegistryEvent[] = [];
+const signerAddEvents: SignerAdd[] = [];
+let start = performance.now();
+const userInfos: UserInfo[] = await Promise.all(
+  [...Array(cliOptions.users)].map(async (_value, index) => {
+    const info = await generateUserInfo(firstUser + index);
+    idRegistryEvents.push(await getIDRegistryEvent(info));
+    signerAddEvents.push(await getSignerAdd(info));
+    return info;
+  })
+);
+let stop = performance.now();
+const accountTime = post(`Generated ${cliOptions.users} users. UserInfo has ${userInfos.length} items`, start, stop);
+
+// submit users
+start = performance.now();
+const registryResults = await submitInBatches(idRegistryEvents);
+
+// const registryResults = await Promise.all(idRegistryEvents.map((e) => client.submitIDRegistryEvent(e)));
+stop = performance.now();
+const idRegistryTime = post('IDRegistry Events submitted', start, stop);
+
+console.log(`${registryResults.success} events submitted successfully. ${registryResults.fail} events failed.`);
+console.log('_Waiting a few seconds for the network to synchronize_');
+await sleep(10_000);
+
+start = performance.now();
+const signerResults = await submitInBatches(signerAddEvents);
+
+// const signerResults = await Promise.all(signerAddEvents.map((e) => client.submitMessage(e)));
+stop = performance.now();
+const signerAddsTime = post('Signers submitted', start, stop);
+
+console.log(`${signerResults.success} signers submitted successfully. ${signerResults.fail} signers failed.`);
+
+console.log('_Waiting a few seconds for the network to synchronize_');
+await sleep(10_000);
+
+// generate random data for each user
+console.log(`Generating Casts for ${cliOptions.users} users`);
+start = performance.now();
+const casts = await Promise.all(
+  userInfos.map((user) => {
+    return Factories.CastShort.create({ data: { fid: user.fid } }, { transient: { signer: user.delegateSigner } });
+  })
+);
+stop = performance.now();
+const castTime = post('Generated 1 cast for each user', start, stop);
+
+// submit data
+start = performance.now();
+const castResults = await submitInBatches(casts);
+stop = performance.now();
+post('Casts submitted', start, stop);
+
+console.log(`${castResults.success} Casts submitted successfully. ${castResults.fail} Casts failed.`);
+
+console.log('------------------------------------------');
+console.log('Time \t\t\t\t Task');
+console.log('------------------------------------------');
+console.log(`${accountTime.toFixed(3)}s    \t\t\t Account generation time`);
+console.log(`${idRegistryTime.toFixed(3)}s    \t\t\t IDRegistry Events`);
+console.log(`${signerAddsTime.toFixed(3)}s    \t\t\t Signer Add Messages`);
+console.log(`${castTime.toFixed(3)}s    \t\t\t Cast Messages`);
+console.log(`Total: ${(accountTime + idRegistryTime + signerAddsTime + castTime).toFixed(3)}s`);

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -10,6 +10,16 @@ import { sleep } from '~/utils';
 import { JSONRPCError } from 'jayson/promise';
 import { isIDRegistryEvent, isMessage } from '~/types/typeguards';
 
+/**
+ * Farcaster Benchmark Client
+ *
+ * This file provides a mechanism to benchmark and test a network of Farcaster Hubs
+ *
+ * When executed, it submits a series of events to the Hub network and measures the
+ * time taken for each set of requests to be processed.
+ *
+ */
+
 const post = (msg: string, start: number, stop: number) => {
   const delta = Number((stop - start) / 1000);
   const time = delta.toFixed(3);
@@ -64,8 +74,8 @@ const submitInBatches = async (messages: Message[] | IDRegistryEvent[]) => {
   return getCounts(results);
 };
 
+// Main
 const app = new Command();
-
 app
   .name('farcaster-benchmark-client')
   .description('Farcaster Benchmark')
@@ -111,7 +121,6 @@ const accountTime = post(`Generated ${cliOptions.users} users. UserInfo has ${us
 start = performance.now();
 const registryResults = await submitInBatches(idRegistryEvents);
 
-// const registryResults = await Promise.all(idRegistryEvents.map((e) => client.submitIDRegistryEvent(e)));
 stop = performance.now();
 const idRegistryTime = post('IDRegistry Events submitted', start, stop);
 
@@ -122,7 +131,6 @@ await sleep(10_000);
 start = performance.now();
 const signerResults = await submitInBatches(signerAddEvents);
 
-// const signerResults = await Promise.all(signerAddEvents.map((e) => client.submitMessage(e)));
 stop = performance.now();
 const signerAddsTime = post('Signers submitted', start, stop);
 

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -82,9 +82,9 @@ app
   .version(process.env.npm_package_version ?? '1.0.0');
 
 app
-  .requiredOption('-a, --ip-address <address>', 'The IP address of a Hub to submit messages to')
-  .requiredOption('-r, --rpc-port <port>', 'The RPC port of the Hub')
-  .option('-u, --users <count>', 'The number of users to simulate', parseNumber, 100);
+  .requiredOption('-A, --ip-address <address>', 'The IP address of a Hub to submit messages to')
+  .requiredOption('-R, --rpc-port <port>', 'The RPC port of the Hub')
+  .option('-U, --users <count>', 'The number of users to simulate', parseNumber, 100);
 
 app.parse(process.argv);
 const cliOptions = app.opts();

--- a/src/engine/mock.ts
+++ b/src/engine/mock.ts
@@ -4,7 +4,7 @@ import { generateEd25519Signer, generateEthereumSigner } from '~/utils';
 import Engine from '~/engine';
 import Faker from 'faker';
 
-type UserInfo = {
+export type UserInfo = {
   fid: number;
   ethereumSigner: EthereumSigner;
   delegateSigner: Ed25519Signer;

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -355,6 +355,27 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
     return mergeResult;
   }
 
+  async submitIDRegistryEvent(event: IDRegistryEvent): Promise<Result<void, FarcasterError>> {
+    // push this message into the engine
+    const mergeResult = await this.engine.mergeIDRegistryEvent(event);
+    if (mergeResult.isErr()) {
+      console.log(this.identity, mergeResult.error, 'Received invalid message...');
+      return mergeResult;
+    }
+
+    // push this message onto the gossip network
+    const gossipMesage: GossipMessage<IDRegistryContent> = {
+      content: {
+        message: event,
+        root: '',
+        count: 0,
+      },
+      topics: [NETWORK_TOPIC_PRIMARY],
+    };
+    await this.gossipMessage(gossipMesage);
+    return mergeResult;
+  }
+
   /* Test API */
   async destroyDB() {
     await this.rocksDB.destroy();

--- a/src/network/node.test.ts
+++ b/src/network/node.test.ts
@@ -92,7 +92,7 @@ describe('gossip network', () => {
 
   afterEach(async () => {
     await Promise.all(nodes.map((node) => node.stop()));
-  });
+  }, TEST_TIMEOUT_SHORT);
 
   test(
     'constructs a Gossip network and ensures all nodes are connected',

--- a/src/network/node.ts
+++ b/src/network/node.ts
@@ -116,15 +116,15 @@ export class Node extends TypedEmitter<NodeEvents> {
    */
   async publish(message: GossipMessage) {
     const topics = message.topics;
-    console.log(this.identity, ': Publishing message to topics: ', topics);
+    console.debug(this.identity, ': Publishing message to topics: ', topics);
     const encodedMessage = encodeMessage(message);
     encodedMessage.match(
       async (msg) => {
         const results = await Promise.all(topics.map((topic) => this.gossip?.publish(topic, msg)));
-        console.log(this.identity, ': Published to ' + results.length + ' peers');
+        console.debug(this.identity, ': Published to ' + results.length + ' peers');
       },
       async (err) => {
-        console.log(this.identity, err, '. Failed to publish message.');
+        console.error(this.identity, err, '. Failed to publish message.');
       }
     );
   }
@@ -160,7 +160,7 @@ export class Node extends TypedEmitter<NodeEvents> {
    * @param address The NodeAddress to attempt a connection with
    */
   async connectAddress(address: Multiaddr): Promise<Result<void, FarcasterError>> {
-    console.log(this.identity, 'Attempting to connect to address:', address);
+    console.debug(this.identity, 'Attempting to connect to address:', address);
     try {
       const result = await this._node?.dial(address);
       if (result) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,7 @@ const options: HubOpts = {
   rocksDBName: cliOptions.dbName,
   resetDB: cliOptions.dbReset,
 };
+console.log(cliOptions, options);
 
 const hub = new Hub(options);
 hub.start();

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,7 +24,6 @@ const teardown = async (hub: Hub) => {
 
 app.parse(process.argv);
 const cliOptions = app.opts();
-console.log(cliOptions);
 const options: HubOpts = {
   networkUrl: cliOptions.networkUrl,
   IDRegistryAddress: cliOptions.idRegistryAddress,
@@ -34,7 +33,6 @@ const options: HubOpts = {
   rocksDBName: cliOptions.dbName,
   resetDB: cliOptions.dbReset,
 };
-console.log(cliOptions, options);
 
 const hub = new Hub(options);
 hub.start();

--- a/src/types/typeguards.ts
+++ b/src/types/typeguards.ts
@@ -116,7 +116,7 @@ export const isData = (data: any): data is FC.Data => {
   );
 };
 
-export const isIDRegistryEvent = (msg: FC.IDRegistryEvent): msg is FC.IDRegistryEvent => {
+export const isIDRegistryEvent = (msg: any): msg is FC.IDRegistryEvent => {
   try {
     const { args } = msg;
     return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "forceConsistentCasingInFileNames": true,
 
     /* Use ESM by default instead of CJS*/
-    "module": "ES2020",
+    "module": "ES2022",
 
     "moduleResolution": "Node",
 
@@ -32,7 +32,7 @@
     "strict": true,
 
     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "target": "es2020"
+    "target": "es2022"
   },
   "exclude": ["node_modules", "jest.config.ts"]
 }


### PR DESCRIPTION
## Motivation

We want to be able to test a "real" network of hubs with dummy data

## Change Summary

Added a benchmark script that can generate data for `N` users and broadcast 1 `castShort` for each to the network. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)

## Additional Context

This is just the first pass at the bench client. We'll presumably need more features and changes over time.
