### PR TITLE
chore: upgrade node to v18.7.0 to sync with other farcaster repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Restore cached dependencies for Node modules.
         id: module-cache

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/farcasterxyz/node-playground#readme",
   "engines": {
-    "node": "^16.17.0"
+    "node": "^18.7.0"
   },
   "devDependencies": {
     "@types/faker": "5.5.9",


### PR DESCRIPTION
## Motivation

Upgrading Node to the latest, stable, current version to bring it in sync with other Farcaster repos

## Change Summary

Upgrade node version from 16.17 to 18.7

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
