### PR TITLE
fix: broken package.json commands, broken named imports due to node --experimental-modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   },
   "type": "module",
   "scripts": {
-    "bench": "tsx src/bench.ts",
+    "bench": "tsx src/test/perf/bench.ts",
     "build": "yarn clean && tsc --project ./tsconfig.json",
     "clean": "rm -rf ./build",
     "check:types": "tsc --noEmit",
-    "dev": "tsx watch src/server.ts",
+    "dev": "tsx watch src/cli.ts",
     "prepare": "husky install",
     "lint": "eslint  src/ --color --ext .ts",
     "lint:fix": "yarn run lint -- --fix",

--- a/src/network/rpc/index.ts
+++ b/src/network/rpc/index.ts
@@ -2,6 +2,10 @@
 
 import { RPCClient } from './client';
 import { RPCServer } from './server';
-import { RPCHandler } from './interfaces';
 
-export { RPCClient, RPCServer, RPCHandler };
+// node --experimental-modules does not play nicely with exports and refuses to import a default interface even when
+// implementing the fix described here: https://github.com/ardatan/graphql-tools/issues/913
+// Requires further investigating, but export * seems like a decent workaround for now
+export * from './interfaces';
+
+export { RPCClient, RPCServer };


### PR DESCRIPTION
## Motivation

After the previous #149, `yarn start` was broken with the following error: 

```
SyntaxError: The requested module './interfaces' does not provide an export named 'RPCHandler'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:123:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:189:5)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:541:24)
    at async loadESM (node:internal/process/esm_loader:91:5)
    at async handleMainPromise (node:internal/modules/run_main:65:12)
```

Also `yarn dev` and `yarn bench` were broken since they didn't point to the newly refactored file names.

## Change Summary

The core issue is that node --experimental-modules has bad support for named exports, and seems to always fail on exporting a named interface. The hacky fix was to use `export *` for the file exporting the interface to unblock this. Further investigation is needed to see if there is a more robust fix. 

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)

## Additional Context

* https://github.com/standard-things/esm/issues/868
* https://github.com/ardatan/graphql-tools/issues/913
