### PR TITLE
chore: add Dockerfile to build container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+**/node_modules/
+**/.git
+**/README.md
+**/LICENSE
+**/.vscode
+**/npm-debug.log
+**/coverage
+**/.env
+**/.editorconfig
+**/.aws
+**/.github
+**/.rocks
+**/build
+**/.husky
+**/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,27 @@
-FROM node:16
+FROM node:18
 
-# Uncomment and set this to the relevant Farcaster node port
-# EXPOSE 8000
+# Set non-root user and expose port 8080
+USER node
+EXPOSE 8080
 
-COPY . .
-RUN yarn install
+WORKDIR /home/node/app
+
+# Copy dependency information and install dependencies
+COPY --chown=node:node tsconfig.json package.json yarn.lock ./
+
+# Use the frozen lockfile to speed up the install and prevent package drift
+RUN yarn install --frozen-lockfile 
+
+# Copy source code (and all other relevant files)
+COPY --chown=node:node src ./src
+
+# Build code
 RUN yarn build
 
-CMD ["yarn", "server"]
+CMD [ "yarn", "start" ]
+
+# TODO: Use a multi-stage build as describe below to improve security and reduce build sizes
+# https://github.com/goldbergyoni/nodebestpractices/blob/master/sections/docker/multi_stage_builds.md
+#
+# This is hard to implement today because of our dependency on the tsx runner which 
+# cannot be invoked on a compiled js file and instead requires the entire src folder to be available.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prepare": "husky install",
     "lint": "eslint  src/ --color --ext .ts",
     "lint:fix": "yarn run lint -- --fix",
-    "start": "tsx src/cli.ts",
+    "start": "tsx src/cli.ts --rpc-port 8080",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage"
   },


### PR DESCRIPTION
## Motivation

Prepare the application to be deployed on AWS

## Change Summary

Add a Dockerfile that can be use to start a container with a running node and expose relevant ports.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged
