### PR TITLE
fix: allow configuration of libp2p listen port

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ app
   .option('-N, --network-url <url>', 'ID Registry network URL')
   .option('-A, --id-registry-address <address>', 'ID Registry address')
   .option('-B, --bootstrap-addresses <addresses...>', 'A list of MultiAddrs to use for bootstrapping')
+  .option('--port <port>', 'The port libp2p should listen on. (default: selects one at random')
   .option('--rpc-port <port>', 'The RPC port to use. (default: selects one at random')
   .option('--simple-sync <enabled>', 'Enable/Disable simple sync', true)
   .option('--db-reset', 'Clear the database before starting', false)
@@ -32,7 +33,8 @@ const options: HubOpts = {
   networkUrl: cliOptions.networkUrl,
   IDRegistryAddress: cliOptions.idRegistryAddress,
   bootstrapAddrs: cliOptions.bootstrapAddresses,
-  port: cliOptions.rpcPort,
+  port: cliOptions.port,
+  rpcPort: cliOptions.rpcPort,
   simpleSync: cliOptions.simpleSync,
   rocksDBName: cliOptions.dbName,
   resetDB: cliOptions.dbReset,

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -24,8 +24,11 @@ export interface HubOpts {
   /** Addresses to bootstrap the gossip network */
   bootstrapAddrs?: Multiaddr[];
 
-  /** Port for the RPC Client */
+  /** Port for libp2p to listen on */
   port?: number;
+
+  /** Port for the RPC Client */
+  rpcPort?: number;
 
   /** Network URL of the IdRegistry Contract */
   networkUrl?: string;
@@ -118,8 +121,8 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
       await this.rocksDB.clear();
     }
 
-    await this.gossipNode.start(this.options.bootstrapAddrs ?? []);
-    await this.rpcServer.start(this.options.port ? this.options.port : 0);
+    await this.gossipNode.start(this.options.bootstrapAddrs ?? [], this.options.port);
+    await this.rpcServer.start(this.options.rpcPort ? this.options.rpcPort : 0);
     this.registerEventHandlers();
 
     // Publishes this Node's information to the gossip network

--- a/src/network/p2p/node.ts
+++ b/src/network/p2p/node.ts
@@ -12,7 +12,7 @@ import { TypedEmitter } from 'tiny-typed-emitter';
 import { FarcasterError, ServerError } from '~/utils/errors';
 import { decodeMessage, encodeMessage, GossipMessage, GOSSIP_TOPICS } from '~/network/p2p/protocol';
 
-const MultiaddrLocalHost = '/ip4/127.0.0.1/tcp/0';
+const MultiaddrLocalHost = '/ip4/127.0.0.1/tcp';
 
 interface NodeEvents {
   /**
@@ -66,8 +66,8 @@ export class Node extends TypedEmitter<NodeEvents> {
   /**
    * Creates and Starts the underlying libp2p node. Nodes must be started prior to any network configuration or communication.
    */
-  async start(bootstrapAddrs: Multiaddr[]) {
-    this._node = await createNode();
+  async start(bootstrapAddrs: Multiaddr[], port?: number) {
+    this._node = await createNode(port);
     this.registerListeners();
 
     await this._node.start();
@@ -219,7 +219,7 @@ export class Node extends TypedEmitter<NodeEvents> {
  *
  * @bootstrapAddrs: A list of NodeAddresses to use for bootstrapping over tcp
  */
-const createNode = async () => {
+const createNode = async (port?: number) => {
   const gossip = new GossipSub({
     emitSelf: false,
     allowPublishToZeroPeers: true,
@@ -227,7 +227,7 @@ const createNode = async () => {
 
   const node = await createLibp2p({
     addresses: {
-      listen: [MultiaddrLocalHost],
+      listen: [`${MultiaddrLocalHost}/${port ?? 0}`],
     },
     transports: [new TCP()],
     streamMuxers: [new Mplex()],

--- a/src/storage/engine/engine.mock.test.ts
+++ b/src/storage/engine/engine.mock.test.ts
@@ -6,35 +6,40 @@ import { mockEvents, MockFCEvent, mockFid, populateEngine } from '~/storage/engi
 const testDb = jestRocksDB('engine.mock.test');
 const engine = new Engine(testDb);
 
-const TEST_TIMEOUT = 2 * 60 * 1000; // 2 min timeout
+const TEST_TIMEOUT_SHORT = 10 * 1000; // 10 sec timeout
+const TEST_TIMEOUT_LONG = 2 * 60 * 1000; // 2 min timeout
 
 beforeEach(async () => {
   await engine._reset();
 });
 
 describe('mock engine events', () => {
-  test('generates a pair of mock events of each type', async () => {
-    const fid = Faker.datatype.number();
-    const user = await mockFid(engine, fid);
-    const users = await engine.getUsers();
-    expect(users.size).toEqual(1);
+  test(
+    'generates a pair of mock events of each type',
+    async () => {
+      const fid = Faker.datatype.number();
+      const user = await mockFid(engine, fid);
+      const users = await engine.getUsers();
+      expect(users.size).toEqual(1);
 
-    await mockEvents(engine, [user], 1, MockFCEvent.Cast);
-    const casts = await engine.getAllCastsByUser(fid);
-    expect(casts.size).toEqual(2);
+      await mockEvents(engine, [user], 1, MockFCEvent.Cast);
+      const casts = await engine.getAllCastsByUser(fid);
+      expect(casts.size).toEqual(2);
 
-    await mockEvents(engine, [user], 1, MockFCEvent.Follow);
-    const follows = await engine.getAllFollowsByUser(fid);
-    expect(follows.size).toEqual(2);
+      await mockEvents(engine, [user], 1, MockFCEvent.Follow);
+      const follows = await engine.getAllFollowsByUser(fid);
+      expect(follows.size).toEqual(2);
 
-    await mockEvents(engine, [user], 1, MockFCEvent.Verification);
-    const verifications = await engine.getAllVerificationsByUser(fid);
-    expect(verifications.size).toEqual(2);
+      await mockEvents(engine, [user], 1, MockFCEvent.Verification);
+      const verifications = await engine.getAllVerificationsByUser(fid);
+      expect(verifications.size).toEqual(2);
 
-    await mockEvents(engine, [user], 1, MockFCEvent.Reaction);
-    const reactions = await engine.getAllReactionsByUser(fid);
-    expect(reactions.size).toEqual(2);
-  });
+      await mockEvents(engine, [user], 1, MockFCEvent.Reaction);
+      const reactions = await engine.getAllReactionsByUser(fid);
+      expect(reactions.size).toEqual(2);
+    },
+    TEST_TIMEOUT_SHORT
+  );
 
   test(
     'populates an engine with selected config',
@@ -59,6 +64,6 @@ describe('mock engine events', () => {
         expect(reactions.size).toEqual(4 * 2);
       }
     },
-    TEST_TIMEOUT
+    TEST_TIMEOUT_LONG
   );
 });


### PR DESCRIPTION
## Motivation

Hub operators need to know exactly which ports to make externally reachable. 
Just like RPC, the libp2p listen port also needs to be configurable.

## Change Summary

Add an option to configure which port libp2p binds to

## Merge Checklist


- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
