### PR TITLE
feat: profile CRDT

### DIFF
--- a/src/storage/db/profile.test.ts
+++ b/src/storage/db/profile.test.ts
@@ -1,0 +1,54 @@
+import Faker from 'faker';
+import { Factories } from '~/test/factories';
+import { ProfileMeta } from '~/types';
+import { jestRocksDB } from '~/storage/db/jestUtils';
+import { NotFoundError } from '~/utils/errors';
+import ProfileDB from '~/storage/db/profile';
+
+const rocks = jestRocksDB('db.profile.test');
+const db = new ProfileDB(rocks);
+
+/** Test data */
+const fid = Faker.datatype.number();
+
+let meta1: ProfileMeta;
+let meta2: ProfileMeta;
+
+beforeAll(async () => {
+  meta1 = await Factories.ProfileMeta.create({ data: { fid } });
+  meta2 = await Factories.ProfileMeta.create({ data: { fid, body: { type: meta1.data.body.type } } });
+});
+
+describe('putProfileMeta', () => {
+  test('stores profile meta', async () => {
+    await expect(db.putProfileMeta(meta1)).resolves.toEqual(undefined);
+    await expect(db.getProfileMeta(fid, meta1.data.body.type)).resolves.toEqual(meta1);
+  });
+
+  test('deletes overwritten message', async () => {
+    await db.putProfileMeta(meta1);
+    await expect(db.putProfileMeta(meta2)).resolves.toEqual(undefined);
+    await expect(db.getMessage(meta1.hash)).rejects.toThrow(NotFoundError);
+  });
+});
+
+describe('getProfileMeta', () => {
+  test('returns a profile meta message', async () => {
+    await db.putProfileMeta(meta1);
+    await expect(db.getProfileMeta(fid, meta1.data.body.type)).resolves.toEqual(meta1);
+  });
+
+  test('fails if profile meta not found', async () => {
+    await expect(db.getProfileMeta(fid, meta1.data.body.type)).rejects.toThrow(NotFoundError);
+  });
+});
+
+describe('deleteAllProfileMessagesBySigner', () => {
+  test('deletes all messages from a signer', async () => {
+    await db.putProfileMeta(meta1);
+
+    await expect(db.getMessagesBySigner(fid, meta1.signer)).resolves.toEqual([meta1]);
+    await expect(db.deleteAllProfileMessagesBySigner(fid, meta1.signer)).resolves.toEqual(undefined);
+    await expect(db.getMessagesBySigner(fid, meta1.signer)).resolves.toEqual([]);
+  });
+});

--- a/src/storage/db/profile.ts
+++ b/src/storage/db/profile.ts
@@ -1,0 +1,83 @@
+import { ResultAsync } from 'neverthrow';
+import { Transaction } from '~/storage/db/rocksdb';
+import { MessageType, ProfileMeta, ProfileMetaType } from '~/types';
+import MessageDB from '~/storage/db/message';
+
+/**
+ * ProfileDB extends MessageDB and provides methods for getting and putting ProfileMeta messages
+ * from a RocksDB instance.
+ *
+ * Profile metadata are stored in this schema:
+ * - <extends message schema>
+ * - fid!<fid>!profile!<profile meta type>: <ProfileMeta hash>
+ */
+class ProfileDB extends MessageDB {
+  async getProfileMeta(fid: number, type: ProfileMetaType): Promise<ProfileMeta> {
+    const messageHash = await this._db.get(this.profileMetaKey(fid, type));
+    return this.getMessage<ProfileMeta>(messageHash);
+  }
+
+  async getProfileMetaByUser(fid: number): Promise<ProfileMeta[]> {
+    const hashes = await this.getMessageHashesByPrefix(this.profileMetaPrefix(fid));
+    return this.getMessages<ProfileMeta>(hashes);
+  }
+
+  async deleteAllProfileMessagesBySigner(fid: number, signer: string): Promise<void> {
+    const tsx = await this._deleteAllProfileMessagesBySigner(this._db.transaction(), fid, signer);
+    return this._db.commit(tsx);
+  }
+
+  async putProfileMeta(message: ProfileMeta): Promise<void> {
+    const tsx = await this._putProfileMeta(this._db.transaction(), message);
+    return this._db.commit(tsx);
+  }
+
+  /* -------------------------------------------------------------------------- */
+  /*                             Private Key Methods                            */
+  /* -------------------------------------------------------------------------- */
+
+  private profileMetaPrefix(fid: number) {
+    return `fid!${fid}!profile!`;
+  }
+
+  private profileMetaKey(fid: number, type: ProfileMetaType) {
+    return `${this.profileMetaPrefix(fid)}${type}`;
+  }
+
+  /* -------------------------------------------------------------------------- */
+  /*                         Private Transaction Methods                        */
+  /* -------------------------------------------------------------------------- */
+
+  private async _putProfileMeta(tsx: Transaction, message: ProfileMeta): Promise<Transaction> {
+    tsx = this._putMessage(tsx, message);
+
+    // If an existing message exists, delete it
+    const existingMeta = await ResultAsync.fromPromise(
+      this.getProfileMeta(message.data.fid, message.data.body.type),
+      () => undefined
+    );
+    if (existingMeta.isOk()) {
+      tsx = this._deleteMessage(tsx, existingMeta.value);
+    }
+
+    tsx = tsx.put(this.profileMetaKey(message.data.fid, message.data.body.type), message.hash);
+
+    return tsx;
+  }
+
+  private _deleteProfileMeta(tsx: Transaction, message: ProfileMeta): Transaction {
+    tsx = tsx.del(this.profileMetaKey(message.data.fid, message.data.body.type));
+
+    return this._deleteMessage(tsx, message);
+  }
+
+  private async _deleteAllProfileMessagesBySigner(tsx: Transaction, fid: number, signer: string): Promise<Transaction> {
+    const messages = await this.getMessagesBySigner<ProfileMeta>(fid, signer, MessageType.ProfileMeta);
+    for (const message of messages) {
+      tsx = this._deleteProfileMeta(tsx, message);
+    }
+    return tsx;
+  }
+}
+
+export default ProfileDB;

--- a/src/storage/engine/engine.profile.test.ts
+++ b/src/storage/engine/engine.profile.test.ts
@@ -1,0 +1,187 @@
+import Engine from '~/storage/engine';
+import Faker from 'faker';
+import { Factories } from '~/test/factories';
+import {
+  Ed25519Signer,
+  EthereumSigner,
+  IDRegistryEvent,
+  MessageFactoryTransientParams,
+  ProfileMeta,
+  ProfileMetaType,
+  SignerAdd,
+} from '~/types';
+import { generateEd25519Signer, generateEthereumSigner } from '~/utils/crypto';
+import { jestRocksDB } from '~/storage/db/jestUtils';
+import { BadRequestError } from '~/utils/errors';
+import ProfileDB from '../db/profile';
+
+const testDb = jestRocksDB(`engine.profile.test`);
+const profileDb = new ProfileDB(testDb);
+const engine = new Engine(testDb);
+
+const aliceFid = Faker.datatype.number();
+
+describe('mergeProfileMessage', () => {
+  let aliceCustody: EthereumSigner;
+  let aliceCustodyRegister: IDRegistryEvent;
+  let aliceSigner: Ed25519Signer;
+  let aliceSignerAdd: SignerAdd;
+  let profileMeta: ProfileMeta;
+  let transientParams: { transient: MessageFactoryTransientParams };
+
+  const aliceMetas = async () => {
+    const metas = await profileDb.getProfileMetaByUser(aliceFid);
+    return new Set(metas);
+  };
+
+  beforeAll(async () => {
+    aliceCustody = await generateEthereumSigner();
+    aliceCustodyRegister = await Factories.IDRegistryEvent.create({
+      args: { to: aliceCustody.signerKey, id: aliceFid },
+      name: 'Register',
+    });
+    aliceSigner = await generateEd25519Signer();
+    aliceSignerAdd = await Factories.SignerAdd.create(
+      { data: { fid: aliceFid } },
+      { transient: { signer: aliceCustody, delegateSigner: aliceSigner } }
+    );
+    transientParams = { transient: { signer: aliceSigner } };
+    profileMeta = await Factories.ProfileMeta.create({ data: { fid: aliceFid } }, transientParams);
+  });
+
+  beforeEach(async () => {
+    await engine._reset();
+  });
+
+  test('fails if there are no known signers', async () => {
+    const result = await engine.mergeMessage(profileMeta);
+    expect(result._unsafeUnwrapErr()).toMatchObject(new BadRequestError('validateMessage: unknown user'));
+    await expect(aliceMetas()).resolves.toEqual(new Set());
+  });
+
+  describe('with signers', () => {
+    beforeEach(async () => {
+      await engine.mergeIDRegistryEvent(aliceCustodyRegister);
+      await engine.mergeMessage(aliceSignerAdd);
+    });
+
+    describe('signer validation', () => {
+      afterEach(async () => {
+        await expect(aliceMetas()).resolves.toEqual(new Set());
+      });
+
+      test('fails if the signer is not valid', async () => {
+        // Calling Factory without specifying a signing key makes Faker choose a random one
+        const newSignerMessage = await Factories.ProfileMeta.create({
+          data: {
+            fid: aliceFid,
+          },
+        });
+        const result = await engine.mergeMessage(newSignerMessage);
+        expect(result._unsafeUnwrapErr()).toMatchObject(new BadRequestError('validateMessage: invalid signer'));
+      });
+
+      test('fails if the signer is valid, but the fid is invalid', async () => {
+        const unknownUserMessage = await Factories.ProfileMeta.create({ data: { fid: aliceFid + 1 } }, transientParams);
+        const res = await engine.mergeMessage(unknownUserMessage);
+        expect(res._unsafeUnwrapErr()).toMatchObject(new BadRequestError('validateMessage: unknown user'));
+      });
+    });
+
+    describe('message validation', () => {
+      afterEach(async () => {
+        await expect(aliceMetas()).resolves.toEqual(new Set());
+      });
+
+      test('fails if the hash is invalid', async () => {
+        const invalidHashMessage: ProfileMeta = { ...profileMeta, hash: profileMeta.hash + 'foo' };
+        const res = await engine.mergeMessage(invalidHashMessage);
+        expect(res._unsafeUnwrapErr()).toMatchObject(new BadRequestError('validateMessage: invalid hash'));
+      });
+
+      test('fails if the signature is invalid', async () => {
+        const invalidSignatureMessage: ProfileMeta = { ...profileMeta, signature: Faker.datatype.hexaDecimal(128) };
+        const res = await engine.mergeMessage(invalidSignatureMessage);
+        expect(res._unsafeUnwrapErr()).toMatchObject(new BadRequestError('validateMessage: invalid signature'));
+      });
+
+      test('fails if signedAt is > current time + safety margin', async () => {
+        const elevenMinutesAhead = Date.now() + 11 * 60 * 1000;
+        const futureMessage = await Factories.ProfileMeta.create(
+          {
+            data: {
+              fid: aliceFid,
+              signedAt: elevenMinutesAhead,
+            },
+          },
+          transientParams
+        );
+        const res = await engine.mergeMessage(futureMessage);
+        expect(res._unsafeUnwrapErr()).toMatchObject(
+          new BadRequestError('validateMessage: signedAt more than 10 mins in the future')
+        );
+      });
+    });
+
+    describe('ProfileMeta', () => {
+      test('succeeds with a valid ProfileMeta message', async () => {
+        expect((await engine.mergeMessage(profileMeta)).isOk()).toBe(true);
+        await expect(aliceMetas()).resolves.toEqual(new Set([profileMeta]));
+      });
+
+      describe('fails', () => {
+        let invalidMessage: ProfileMeta;
+
+        afterEach(async () => {
+          const result = await engine.mergeMessage(invalidMessage);
+          expect(result._unsafeUnwrapErr().statusCode).toEqual(400);
+        });
+
+        test('with pfp > 256 characters', async () => {
+          invalidMessage = await Factories.ProfileMeta.create(
+            {
+              data: { fid: aliceFid, body: { type: ProfileMetaType.Pfp, value: Faker.random.alphaNumeric(257) } },
+            },
+            transientParams
+          );
+        });
+
+        test('with display > 32 characters', async () => {
+          invalidMessage = await Factories.ProfileMeta.create(
+            {
+              data: { fid: aliceFid, body: { type: ProfileMetaType.Display, value: Faker.random.alphaNumeric(33) } },
+            },
+            transientParams
+          );
+        });
+
+        test('with bio > 256 characters', async () => {
+          invalidMessage = await Factories.ProfileMeta.create(
+            {
+              data: { fid: aliceFid, body: { type: ProfileMetaType.Bio, value: Faker.random.alphaNumeric(257) } },
+            },
+            transientParams
+          );
+        });
+
+        test('with location > 64 characters', async () => {
+          invalidMessage = await Factories.ProfileMeta.create(
+            {
+              data: { fid: aliceFid, body: { type: ProfileMetaType.Location, value: Faker.random.alphaNumeric(65) } },
+            },
+            transientParams
+          );
+        });
+
+        test('with url > 256 characters', async () => {
+          invalidMessage = await Factories.ProfileMeta.create(
+            {
+              data: { fid: aliceFid, body: { type: ProfileMetaType.Url, value: Faker.random.alphaNumeric(257) } },
+            },
+            transientParams
+          );
+        });
+      });
+    });
+  });
+});

--- a/src/storage/sets/profileSet.test.ts
+++ b/src/storage/sets/profileSet.test.ts
@@ -1,0 +1,96 @@
+import { Factories } from '~/test/factories';
+import Faker from 'faker';
+import { Ed25519Signer, ProfileMeta, ProfileMetaType } from '~/types';
+import { generateEd25519Signer } from '~/utils/crypto';
+import { jestRocksDB } from '~/storage/db/jestUtils';
+import { BadRequestError } from '~/utils/errors';
+import ProfileSet from '~/storage/sets/profileSet';
+
+const testDb = jestRocksDB('profileSet.test');
+
+const set = new ProfileSet(testDb);
+
+const fid = Faker.datatype.number();
+
+const metas = () => set.getProfileMetaByUser(fid);
+
+let signer: Ed25519Signer;
+let addDisplay: ProfileMeta;
+let addBio: ProfileMeta;
+
+beforeAll(async () => {
+  signer = await generateEd25519Signer();
+  addDisplay = await Factories.ProfileMeta.create(
+    { data: { fid, body: { type: ProfileMetaType.Display } } },
+    { transient: { signer } }
+  );
+  addBio = await Factories.ProfileMeta.create(
+    { data: { fid, body: { type: ProfileMetaType.Bio } } },
+    { transient: { signer } }
+  );
+});
+
+describe('merge', () => {
+  test('fails with invalid message format', async () => {
+    const invalidMessage = (await Factories.CastShort.create()) as unknown as ProfileMeta;
+    await expect(set.merge(invalidMessage)).rejects.toThrow(BadRequestError);
+    await expect(metas()).resolves.toEqual(new Set());
+  });
+
+  test('succeeds with valid ProfileMeta', async () => {
+    await expect(set.merge(addDisplay)).resolves.toEqual(undefined);
+    await expect(metas()).resolves.toEqual(new Set([addDisplay]));
+  });
+
+  test('succeeds (no-op) with duplicate messages', async () => {
+    await expect(set.merge(addDisplay)).resolves.toEqual(undefined);
+    await expect(set.merge(addDisplay)).resolves.toEqual(undefined);
+    await expect(metas()).resolves.toEqual(new Set([addDisplay]));
+  });
+
+  test('succeeds with multiple valid messages', async () => {
+    await expect(set.merge(addDisplay)).resolves.toEqual(undefined);
+    await expect(set.merge(addBio)).resolves.toEqual(undefined);
+    await expect(metas()).resolves.toEqual(new Set([addDisplay, addBio]));
+  });
+
+  describe('when another message exists with the same type', () => {
+    beforeEach(async () => {
+      await set.merge(addDisplay);
+    });
+
+    test('succeeds with later timestamp', async () => {
+      const addDisplayLater: ProfileMeta = {
+        ...addDisplay,
+        hash: Faker.datatype.hexaDecimal(128),
+        data: { ...addDisplay.data, signedAt: addDisplay.data.signedAt + 1 },
+      };
+      await expect(set.merge(addDisplayLater)).resolves.toEqual(undefined);
+      await expect(metas()).resolves.toEqual(new Set([addDisplayLater]));
+    });
+
+    test('succeeds (no-op) with earlier timestamp', async () => {
+      const addDisplayEarlier: ProfileMeta = {
+        ...addDisplay,
+        hash: Faker.datatype.hexaDecimal(128),
+        data: { ...addDisplay.data, signedAt: addDisplay.data.signedAt - 1 },
+      };
+      await expect(set.merge(addDisplayEarlier)).resolves.toEqual(undefined);
+      await expect(metas()).resolves.toEqual(new Set([addDisplay]));
+    });
+
+    describe('with the same timestamp', () => {
+      test('succeeds with a higher hash order', async () => {
+        const addDisplayHigherHash: ProfileMeta = { ...addDisplay, hash: addDisplay.hash + 'a' };
+        await expect(set.merge(addDisplayHigherHash)).resolves.toEqual(undefined);
+        await expect(metas()).resolves.toEqual(new Set([addDisplayHigherHash]));
+      });
+
+      test('succeeds (no-op) with a lower hash order', async () => {
+        const addDisplayLowerHash: ProfileMeta = { ...addDisplay, hash: addDisplay.hash.slice(0, -1) };
+        await expect(set.merge(addDisplayLowerHash)).resolves.toEqual(undefined);
+        await expect(metas()).resolves.toEqual(new Set([addDisplay]));
+      });
+    });
+  });
+});

--- a/src/storage/sets/profileSet.ts
+++ b/src/storage/sets/profileSet.ts
@@ -1,0 +1,88 @@
+import { ResultAsync } from 'neverthrow';
+import RocksDB from '~/storage/db/rocksdb';
+import { BadRequestError } from '~/utils/errors';
+import { ProfileMeta, ProfileMetaType } from '~/types';
+import { isProfileMeta } from '~/types/typeguards';
+import { hashCompare } from '~/utils/crypto';
+import ProfileDB from '../db/profile';
+
+/**
+ * ProfileSet is a modified LWW set that stores and fetches follow actions. ProfileMeta messages
+ * are stored in the ProfileDB.
+ *
+ * Conflicts between two messages with the same type and fid are resolved in this order (see
+ * profileMessageCompare for implementation):
+ * 1. Later timestamp wins
+ * 2. Higher message hash lexicographic order wins
+ */
+class ProfileSet {
+  private _db: ProfileDB;
+
+  constructor(db: RocksDB) {
+    this._db = new ProfileDB(db);
+  }
+
+  /** Get a ProfileMeta message by its fid and type */
+  getProfileMeta(fid: number, type: ProfileMetaType): Promise<ProfileMeta> {
+    return this._db.getProfileMeta(fid, type);
+  }
+
+  async getProfileMetaByUser(fid: number): Promise<Set<ProfileMeta>> {
+    const messages = await this._db.getProfileMetaByUser(fid);
+    return new Set(messages);
+  }
+
+  async revokeSigner(fid: number, signer: string): Promise<void> {
+    return this._db.deleteAllProfileMessagesBySigner(fid, signer);
+  }
+
+  /** Merge a new message into the set */
+  async merge(message: ProfileMeta): Promise<void> {
+    if (isProfileMeta(message)) {
+      return this.mergeProfileMeta(message);
+    }
+
+    throw new BadRequestError('ProfileSet.merge: invalid message format');
+  }
+
+  /* -------------------------------------------------------------------------- */
+  /*                               Private Methods                              */
+  /* -------------------------------------------------------------------------- */
+
+  /**
+   * profileMessageCompare returns an order (-1, 0, 1) for two ProfileMeta messages (a and b). If a occurs before
+   * b, return -1. If a occurs after b, return 1. If a and b cannot be ordered (i.e. they are the same
+   * message), return 0.
+   */
+  private profileMessageCompare(a: ProfileMeta, b: ProfileMeta): number {
+    // If they are the same message, return 0
+    if (a.hash === b.hash) return 0;
+
+    // Compare signedAt timestamps
+    if (a.data.signedAt > b.data.signedAt) {
+      return 1;
+    } else if (a.data.signedAt < b.data.signedAt) {
+      return -1;
+    }
+
+    // Compare lexicographical order of hash
+    return hashCompare(a.hash, b.hash);
+  }
+
+  /** mergeFollowAdd tries to add a FollowAdd message to the set */
+  private async mergeProfileMeta(message: ProfileMeta): Promise<void> {
+    const { type } = message.data.body;
+    const { fid } = message.data;
+
+    // Check if a value already exists for the type
+    const existingMeta = await ResultAsync.fromPromise(this._db.getProfileMeta(fid, type), () => undefined);
+    if (existingMeta.isOk() && this.profileMessageCompare(message, existingMeta.value) <= 0) {
+      return undefined;
+    }
+
+    // Add the message to the db
+    return this._db.putProfileMeta(message);
+  }
+}
+
+export default ProfileSet;

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -26,6 +26,8 @@ import {
   FollowAdd,
   FollowRemove,
   Cast,
+  ProfileMeta,
+  ProfileMetaType,
 } from '~/types';
 import { hashMessage, signEd25519, hashFCObject, generateEd25519Signer, generateEthereumSigner } from '~/utils/crypto';
 import { CastURL, CastId, ChainAccountURL, UserId, UserURL } from '~/urls';
@@ -424,6 +426,33 @@ export const Factories = {
           signedAt: Faker.time.recent(),
           fid: Faker.datatype.number(),
           type: MessageType.VerificationRemove,
+          network: FarcasterNetwork.Testnet,
+        },
+        hash: '',
+        hashType: HashAlgorithm.Blake2b,
+        signature: '',
+        signatureType: SignatureAlgorithm.Ed25519,
+        signer: '',
+      };
+    }
+  ),
+
+  /** Generate a valid ProfileMeta with randomized properties */
+  ProfileMeta: Factory.define<ProfileMeta, MessageFactoryTransientParams, ProfileMeta>(
+    ({ onCreate, transientParams }) => {
+      onCreate(async (props) => {
+        return (await addEnvelopeToMessage(props, transientParams)) as ProfileMeta;
+      });
+
+      return {
+        data: {
+          body: {
+            type: ProfileMetaType.Display,
+            value: Faker.name.firstName(),
+          },
+          signedAt: Faker.time.recent(),
+          fid: Faker.datatype.number(),
+          type: MessageType.ProfileMeta,
           network: FarcasterNetwork.Testnet,
         },
         hash: '',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,7 @@ export enum MessageType {
   VerificationRemove = 9,
   SignerAdd = 10,
   SignerRemove = 11,
+  ProfileMeta = 12,
 }
 
 /**
@@ -59,7 +60,8 @@ export type Body =
   | VerificationEthereumAddressBody
   | VerificationRemoveBody
   | SignerMessageBody
-  | FollowBody;
+  | FollowBody
+  | ProfileMetaBody;
 
 /* -------------------------------------------------------------------------- */
 /*                                 Cast Types                                 */
@@ -259,6 +261,31 @@ export type IDRegistryArgs = {
   to: string;
   id: number;
 };
+
+/* -------------------------------------------------------------------------- */
+/*                                Profile Types                               */
+/* -------------------------------------------------------------------------- */
+
+export type ProfileMeta = Message<MessageType.ProfileMeta, ProfileMetaBody>;
+
+/**
+ * ProfileMetaBody represents an update to the profile for an fid
+ *
+ * @type - number indicating the part of the profile to update
+ * @value - value for the type, not passing value indicates removal
+ */
+export type ProfileMetaBody = {
+  type: ProfileMetaType;
+  value?: string;
+};
+
+export enum ProfileMetaType {
+  Pfp = 1,
+  Display = 2,
+  Bio = 3,
+  Location = 4,
+  Url = 5,
+}
 
 /* -------------------------------------------------------------------------- */
 /*                                  URI Types                                 */

--- a/src/types/typeguards.ts
+++ b/src/types/typeguards.ts
@@ -95,6 +95,16 @@ export const isFollowRemove = (msg: FC.Message): msg is FC.FollowRemove => {
   return type === FC.MessageType.FollowRemove && body && typeof body.targetUri === 'string';
 };
 
+export const isProfileMeta = (msg: FC.Message): msg is FC.ProfileMeta => {
+  const { body, type } = (msg as FC.ProfileMeta).data;
+  return (
+    type === FC.MessageType.ProfileMeta &&
+    body &&
+    typeof body.type === 'number' &&
+    (body.value ? typeof body.value === 'string' : true)
+  );
+};
+
 export const isMessage = (msg: any): msg is FC.Message => {
   const { data, hash, hashType, signature, signatureType, signer } = msg as FC.Message;
   return (


### PR DESCRIPTION
## Motivation

Implements https://github.com/farcasterxyz/hub/issues/120

## Change Summary

* Adds `ProfileMeta` message type with `ProfileMetaType` representing each profile key (i.e. 1 = pfp)
* Add ProfileDB and ProfileSet to store profile messages and resolve conflicts between messages (LWW)
* Add profile methods to storage engine and validate length of value fields for each profile type

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged
