### PR TITLE
feat: add support for persistent peerIds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ coverage/
 # Databases
 .level/
 .rocks/
+.hub/

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "prepare": "husky install",
     "lint": "eslint  src/ --color --ext .ts",
     "lint:fix": "yarn run lint -- --fix",
-    "start": "tsx src/cli.ts --rpc-port 8080",
+    "start": "tsx src/cli.ts start",
+    "identity": "tsx src/cli.ts identity",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage"
   },
@@ -55,6 +56,7 @@
     "@libp2p/interface-peer-info": "^1.0.2",
     "@libp2p/interfaces": "^3.0.3",
     "@libp2p/mplex": "^5.1.1",
+    "@libp2p/peer-id-factory": "^1.0.18",
     "@libp2p/pubsub-peer-discovery": "^6.0.2",
     "@libp2p/tcp": "^3.0.6",
     "@multiformats/multiaddr": "^10.4.3",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,17 +2,26 @@
 
 import { Command } from 'commander';
 import { Hub, HubOpts } from '~/hub';
+import { createEd25519PeerId, createFromProtobuf, exportToProtobuf } from '@libp2p/peer-id-factory';
+import { dirname } from 'path';
+import { writeFile, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { exit } from 'process';
+import { readFile } from 'fs/promises';
 
 /** A CLI to accept options from the user and start the Hub */
 
-const app = new Command();
+const DEFAULT_PEER_ID_LOCATION = './.hub/id.protobuf';
 
+const app = new Command();
 app
   .name('hub')
   .description('Farcaster Hub')
   .version(process.env.npm_package_version ?? '1.0.0');
 
 app
+  .command('start')
+  .description('Start a Hub')
   .option('-N, --network-url <url>', 'ID Registry network URL')
   .option('-A, --id-registry-address <address>', 'ID Registry address')
   .option('-B, --bootstrap-addresses <addresses...>', 'A list of MultiAddrs to use for bootstrapping')
@@ -20,39 +29,87 @@ app
   .option('--rpc-port <port>', 'The RPC port to use. (default: selects one at random')
   .option('--simple-sync <enabled>', 'Enable/Disable simple sync', true)
   .option('--db-reset', 'Clear the database before starting', false)
-  .option('--db-name <name>', 'The name of the RocksDB instance', 'rocks.hub._default');
+  .option('--db-name <name>', 'The name of the RocksDB instance', 'rocks.hub._default')
+  .option('-I, --id <filepath>', 'Path to the PeerId file', DEFAULT_PEER_ID_LOCATION)
+  .action(async (cliOptions) => {
+    const teardown = async (hub: Hub) => {
+      await hub.stop();
+      process.exit();
+    };
 
-const teardown = async (hub: Hub) => {
-  await hub.stop();
-  process.exit();
+    const options: HubOpts = {
+      peerId: await readPeerId(cliOptions.id),
+      networkUrl: cliOptions.networkUrl,
+      IDRegistryAddress: cliOptions.idRegistryAddress,
+      bootstrapAddrs: cliOptions.bootstrapAddresses,
+      port: cliOptions.port,
+      rpcPort: cliOptions.rpcPort,
+      simpleSync: cliOptions.simpleSync,
+      rocksDBName: cliOptions.dbName,
+      resetDB: cliOptions.dbReset,
+    };
+
+    const hub = new Hub(options);
+    hub.start();
+
+    process.stdin.resume();
+
+    process.on('SIGINT', async () => {
+      await teardown(hub);
+    });
+
+    process.on('SIGTERM', async () => {
+      await teardown(hub);
+    });
+
+    process.on('SIGQUIT', async () => {
+      await teardown(hub);
+    });
+  });
+
+const createIdCommand = new Command('create')
+  .description('Create a new peerId and write it to a file')
+  .option('-I, --id <filepath>', 'Path to the PeerId file', DEFAULT_PEER_ID_LOCATION)
+  .action(async (options) => {
+    // create a new peerId and output it to a file
+    const peerId = await createEd25519PeerId();
+    const filePath = options.id;
+    const proto = exportToProtobuf(peerId);
+    try {
+      const directory = dirname(filePath);
+      if (!existsSync(directory)) {
+        await mkdir(directory, { recursive: true });
+      }
+      await writeFile(filePath, proto, 'binary');
+    } catch (err: any) {
+      throw new Error(err);
+    }
+    console.log(`Successfully Wrote peerId: ${peerId.toString()} to ${filePath}`);
+    exit(0);
+  });
+
+const verifyIdCommand = new Command('verify')
+  .description('Verify a peerId file')
+  .option('-I, --id <filepath>', 'Path to the PeerId file', DEFAULT_PEER_ID_LOCATION)
+  .action(async (options) => {
+    const peerId = await readPeerId(options.id);
+    console.log(`Successfully Read peerId: ${peerId.toString()} from ${options.id}`);
+    exit(0);
+  });
+
+app
+  .command('identity')
+  .description('Create or verify a peerID')
+  .addCommand(createIdCommand)
+  .addCommand(verifyIdCommand);
+
+const readPeerId = async (filePath: string) => {
+  try {
+    const proto = await readFile(filePath);
+    return createFromProtobuf(proto);
+  } catch (err: any) {
+    throw new Error(err);
+  }
 };
 
 app.parse(process.argv);
-const cliOptions = app.opts();
-const options: HubOpts = {
-  networkUrl: cliOptions.networkUrl,
-  IDRegistryAddress: cliOptions.idRegistryAddress,
-  bootstrapAddrs: cliOptions.bootstrapAddresses,
-  port: cliOptions.port,
-  rpcPort: cliOptions.rpcPort,
-  simpleSync: cliOptions.simpleSync,
-  rocksDBName: cliOptions.dbName,
-  resetDB: cliOptions.dbReset,
-};
-
-const hub = new Hub(options);
-hub.start();
-
-process.stdin.resume();
-
-process.on('SIGINT', async () => {
-  await teardown(hub);
-});
-
-process.on('SIGTERM', async () => {
-  await teardown(hub);
-});
-
-process.on('SIGQUIT', async () => {
-  await teardown(hub);
-});

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -2,6 +2,7 @@ import { Multiaddr } from '@multiformats/multiaddr';
 import Engine from '~/storage/engine';
 import { Node } from '~/network/p2p/node';
 import { RPCClient, RPCHandler, RPCServer } from '~/network/rpc';
+import { PeerId } from '@libp2p/interface-peer-id';
 import { Cast, SignerMessage, Reaction, Follow, Verification, IDRegistryEvent, Message } from '~/types';
 import {
   ContactInfoContent,
@@ -21,6 +22,9 @@ import { FarcasterError, ServerError } from '~/utils/errors';
 import { SyncEngine } from '~/network/sync/syncEngine';
 
 export interface HubOpts {
+  /** The PeerId of this Hub */
+  peerId?: PeerId;
+
   /** Addresses to bootstrap the gossip network */
   bootstrapAddrs?: Multiaddr[];
 
@@ -121,7 +125,7 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
       await this.rocksDB.clear();
     }
 
-    await this.gossipNode.start(this.options.bootstrapAddrs ?? [], this.options.port);
+    await this.gossipNode.start(this.options.bootstrapAddrs ?? [], this.options.peerId, this.options.port);
     await this.rpcServer.start(this.options.rpcPort ? this.options.rpcPort : 0);
     this.registerEventHandlers();
 

--- a/src/network/p2p/node.ts
+++ b/src/network/p2p/node.ts
@@ -66,8 +66,8 @@ export class Node extends TypedEmitter<NodeEvents> {
   /**
    * Creates and Starts the underlying libp2p node. Nodes must be started prior to any network configuration or communication.
    */
-  async start(bootstrapAddrs: Multiaddr[], port?: number) {
-    this._node = await createNode(port);
+  async start(bootstrapAddrs: Multiaddr[], peerId?: PeerId, port?: number) {
+    this._node = await createNode(peerId, port);
     this.registerListeners();
 
     await this._node.start();
@@ -219,13 +219,16 @@ export class Node extends TypedEmitter<NodeEvents> {
  *
  * @bootstrapAddrs: A list of NodeAddresses to use for bootstrapping over tcp
  */
-const createNode = async (port?: number) => {
+const createNode = async (peerId?: PeerId, port?: number) => {
   const gossip = new GossipSub({
     emitSelf: false,
     allowPublishToZeroPeers: true,
+    globalSignaturePolicy: 'StrictSign',
   });
 
   const node = await createLibp2p({
+    // setting peerId to `undefined` throws an error, only set it if it's defined
+    ...(peerId && { peerId }),
     addresses: {
       listen: [`${MultiaddrLocalHost}/${port ?? 0}`],
     },


### PR DESCRIPTION
## Motivation

Hubs use libp2p PeerIds to identify each other. Currently Hubs just generate a new keypair and corresponding PeerId every time they are started up. 

This means it's not possible to enforce which Hubs are allowed to participate in a network. 

By persisting PeerIds we ensure that Hubs always use the same identity to participate on the p2p network

## Change Summary

- Add a command to generate a new peerId file
- Add a command to verify an existing peerId file
- Add a command to pass in a peerId file to a Hub

fixes https://github.com/farcasterxyz/hub/issues/156

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
