### PR TITLE
feat: Option to specify Hub IP address

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
-import { Hub, HubOpts } from '~/hub';
+import { Hub, HubOptions } from '~/hub';
 import { createEd25519PeerId, createFromProtobuf, exportToProtobuf } from '@libp2p/peer-id-factory';
 import { writeFile, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
@@ -31,8 +31,9 @@ app
   .option('-A, --id-registry-address <address>', 'ID Registry address')
   .option('-B, --bootstrap-addresses <addresses...>', 'A list of MultiAddrs to use for bootstrapping')
   .option('--allowed-peers <peerIds...>', 'An "allow list" of Peer Ids. Blocks all other connections')
-  .option('--port <port>', 'The port libp2p should listen on. (default: selects one at random')
-  .option('--rpc-port <port>', 'The RPC port to use. (default: selects one at random')
+  .option('--ip <ip-multiaddr>', 'The IP Multi Address libp2p should listen on. (default: "/ip4/127.0.0.1/")')
+  .option('--port <port>', 'The TCP port libp2p should listen on. (default: selects one at random)')
+  .option('--rpc-port <port>', 'The RPC port to use. (default: selects one at random)')
   .option('--simple-sync <enabled>', 'Enable/Disable simple sync', true)
   .option('--db-reset', 'Clear the database before starting', false)
   .option('--db-name <name>', 'The name of the RocksDB instance', 'rocks.hub._default')
@@ -43,12 +44,13 @@ app
       process.exit();
     };
 
-    const options: HubOpts = {
+    const options: HubOptions = {
       peerId: await readPeerId(cliOptions.id),
       networkUrl: cliOptions.networkUrl,
       IDRegistryAddress: cliOptions.idRegistryAddress,
       bootstrapAddrs: cliOptions.bootstrapAddresses,
       allowedPeers: cliOptions.allowedPeers,
+      IPMultiAddr: cliOptions.ip,
       port: cliOptions.port,
       rpcPort: cliOptions.rpcPort,
       simpleSync: cliOptions.simpleSync,

--- a/src/network/p2p/node.test.ts
+++ b/src/network/p2p/node.test.ts
@@ -90,7 +90,7 @@ describe('node unit tests', () => {
       // node 3 has node 1 in its allow list, but not node 2
       const node3 = new Node();
       if (node1.peerId) {
-        await node3.start([], [node1.peerId.toString()]);
+        await node3.start([], { allowedPeerIdStrs: [node1.peerId.toString()] });
       } else {
         throw Error('Node1 not started, no peerId found');
       }
@@ -109,6 +109,25 @@ describe('node unit tests', () => {
         await node2.stop();
         await node3.stop();
       }
+    },
+    TEST_TIMEOUT_SHORT
+  );
+
+  test(
+    'handles invalid start options',
+    async () => {
+      const node = new Node();
+      // port and transport addrs in the IP MultiAddr is not allowed
+      let options = { IPMultiAddr: '/ip4/127.0.0.1/tcp/8080' };
+      await expect(node.start([], options)).rejects.toThrow();
+      expect(node.isStarted()).toBeFalsy();
+      await node.stop();
+
+      // an IPv6 being supplied as an IPv4
+      options = { IPMultiAddr: '/ip4/2600:1700:6cf0:990:2052:a166:fb35:830a' };
+      await expect(node.start([], options)).rejects.toThrow();
+      expect(node.isStarted()).toBeFalsy();
+      await node.stop();
     },
     TEST_TIMEOUT_SHORT
   );

--- a/src/test/e2e/hub.test.ts
+++ b/src/test/e2e/hub.test.ts
@@ -2,7 +2,7 @@ import Faker from 'faker';
 import { AddressInfo } from 'net';
 import { generateUserInfo, getIDRegistryEvent, getSignerAdd, mockFid, populateEngine } from '~/storage/engine/mock';
 import { Factories } from '~/test/factories';
-import { Hub, HubOpts } from '~/hub';
+import { Hub, HubOptions } from '~/hub';
 import { RPCClient } from '~/network/rpc';
 import { sleep } from '~/utils/crypto';
 import { ContactInfoContent, Content, GossipMessage, NETWORK_TOPIC_PRIMARY } from '~/network/p2p/protocol';
@@ -12,7 +12,7 @@ import { jest } from '@jest/globals';
 
 const TEST_TIMEOUT_SHORT = 10 * 1000;
 const TEST_TIMEOUT_LONG = 2 * 60 * 1000;
-const opts: HubOpts = { simpleSync: false };
+const opts: HubOptions = { simpleSync: false };
 
 let hub: Hub;
 


### PR DESCRIPTION
## Motivation

Hub's are identified by their [libp2p MultiAddrs](https://docs.libp2p.io/concepts/addressing/). 

Hub's don't know their public IPs and by default, they will bind to `localhost` and advertise that address in their logs.
For example:
```
/ip4/127.0.0.1/tcp/61597/p2p/12D3KooWSjZrKzRXJWo3ykD1Qa7tvpaztjcumc31GWpEZnyGJw6m
```  

It's useful to share the Hub's MultiAddr with other Hub operators (for bootstrapping) or third parties. 
To make the log a little bit more helpful, we want to be able to specify which address the Hub tries to bind to. 

## Change Summary

Add an option to the cli to specify the Hub's IP address as a MultiAddr format string. 

Example: 
```
$ yarn start --ip /ip6/2600:1700:6cf0:990:2052:a166:fb35:830a
[10:58:23.401] INFO (83011): Starting libp2p
    component: "Node"
    identity: "12D3KooWSjZrKzRXJWo3ykD1Qa7tvpaztjcumc31GWpEZnyGJw6m"
    addresses: [
"/ip6/2600:1700:6cf0:990:2052:a166:fb35:830a/tcp/61597/p2p/12D3KooWSjZrKzRXJWo3ykD1Qa7tvpaztjcumc31GWpEZnyGJw6m"
    ]
```

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
