### PR TITLE
Hub config file

### DIFF
--- a/.config/hub.config.ts
+++ b/.config/hub.config.ts
@@ -11,15 +11,15 @@ export const Config = {
   /** Network URL of the IdRegistry Contract */
   // networkUrl: '',
   /** Address of the IdRegistry Contract  */
-  // idRegistryAddress: '',
+  // firAddress: '',
   /** A list of MultiAddrs to use for bootstrapping */
   // bootstrapAddresses: [],
   /** An "allow list" of Peer Ids. Blocks all other connections */
   // allowedPeers: [],
   /** The IP Multi Address libp2p should listen on. */
-  // ip: '/ip4/127.0.0.1/',
+  // multiaddr: '/ip4/127.0.0.1/',
   /** The TCP port libp2p should listen on. */
-  port: 0,
+  gossipPort: 0,
   /** The RPC port to use. */
   rpcPort: 0,
   /** Enable/Disable simple sync */

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,6 +9,7 @@ module.exports = {
     'plugin:security/recommended',
   ],
   plugins: ['prefer-arrow-functions'],
+  ignorePatterns: ['start.config.js'],
   rules: {
     '@typescript-eslint/ban-ts-ignore': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,7 +9,7 @@ module.exports = {
     'plugin:security/recommended',
   ],
   plugins: ['prefer-arrow-functions'],
-  ignorePatterns: ['start.config.js'],
+  ignorePatterns: ['**/.config'],
   rules: {
     '@typescript-eslint/ban-ts-ignore': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,4 @@ coverage/
 .rocks/
 
 # Config
-.hub/*
-!.hub/start.config.ts
+.hub/

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,7 @@ coverage/
 # Databases
 .level/
 .rocks/
-.hub/
+
+# Config
+.hub/*
+!.hub/start.config.ts

--- a/.hub/start.config.ts
+++ b/.hub/start.config.ts
@@ -1,0 +1,31 @@
+/**
+ * A default configuration file to start a Hub
+ *
+ * Update or uncomment config fields as needed.
+ * Note: CLI options take precedence over the options specified in a config file
+ */
+
+export const Config = {
+  /** Path to a PeerId file */
+  id: './.hub/default_id.protobuf',
+  /** Network URL of the IdRegistry Contract */
+  // networkUrl: '',
+  /** Address of the IdRegistry Contract  */
+  // idRegistryAddress: '',
+  /** A list of MultiAddrs to use for bootstrapping */
+  // bootstrapAddresses: [],
+  /** An "allow list" of Peer Ids. Blocks all other connections */
+  // allowedPeers: [],
+  /** The IP Multi Address libp2p should listen on. */
+  // ip: '/ip4/127.0.0.1/',
+  /** The TCP port libp2p should listen on. */
+  port: 0,
+  /** The RPC port to use. */
+  rpcPort: 0,
+  /** Enable/Disable simple sync */
+  simpleSync: true,
+  /** The name of the RocksDB instance */
+  dbName: 'rocks.hub._default',
+  /** Clear the RocksDB instance before starting */
+  dbReset: false,
+};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import { PeerId } from '@libp2p/interface-peer-id';
 
 /** A CLI to accept options from the user and start the Hub */
 
-const DEFAULT_CONFIG_FILE = './.hub/start.config.ts';
+const DEFAULT_CONFIG_FILE = './.config/hub.config.ts';
 const PEER_ID_FILENAME = 'id.protobuf';
 const DEFAULT_PEER_ID_DIR = './.hub';
 const DEFAULT_PEER_ID_FILENAME = `default_${PEER_ID_FILENAME}`;
@@ -47,26 +47,27 @@ app
     };
 
     // try to load the config file
-    const startConfig = (await import(resolve(cliOptions.config))).Config;
+    const hubConfig = (await import(resolve(cliOptions.config))).Config;
 
     let peerId;
     if (cliOptions.id) {
       peerId = await readPeerId(resolve(cliOptions.id));
     } else {
-      peerId = await readPeerId(resolve(startConfig.id));
+      peerId = await readPeerId(resolve(hubConfig.id));
     }
 
     const options: HubOptions = {
-      networkUrl: cliOptions.networkUrl ?? startConfig.networkUrl,
-      IdRegistryAddress: cliOptions.firAddress ?? startConfig.firAddress,
-      bootstrapAddrs: cliOptions.bootstrap ?? startConfig.bootstrap,
-      allowedPeers: cliOptions.allowedPeers ?? startConfig.allowedPeers,
-      IpMultiAddr: cliOptions.multiaddr ?? cliOptions.multiaddr,
-      gossipPort: cliOptions.gossipPort ?? cliOptions.gossipPort,
-      rpcPort: cliOptions.rpcPort ?? cliOptions.rpcPort,
-      simpleSync: cliOptions.simpleSync ?? cliOptions.simpleSync,
-      rocksDBName: cliOptions.dbName ?? cliOptions.dbName,
-      resetDB: cliOptions.dbReset ?? cliOptions.dbReset,
+      peerId,
+      networkUrl: cliOptions.networkUrl ?? hubConfig.networkUrl,
+      IdRegistryAddress: cliOptions.firAddress ?? hubConfig.firAddress,
+      bootstrapAddrs: cliOptions.bootstrap ?? hubConfig.bootstrap,
+      allowedPeers: cliOptions.allowedPeers ?? hubConfig.allowedPeers,
+      IpMultiAddr: cliOptions.multiaddr ?? hubConfig.multiaddr,
+      gossipPort: cliOptions.gossipPort ?? hubConfig.gossipPort,
+      rpcPort: cliOptions.rpcPort ?? hubConfig.rpcPort,
+      simpleSync: cliOptions.simpleSync ?? hubConfig.simpleSync,
+      rocksDBName: cliOptions.dbName ?? hubConfig.dbName,
+      resetDB: cliOptions.dbReset ?? hubConfig.dbReset,
     };
 
     const hub = new Hub(options);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { PeerId } from '@libp2p/interface-peer-id';
 
 /** A CLI to accept options from the user and start the Hub */
 
+const DEFAULT_CONFIG_FILE = './.hub/start.config.ts';
 const PEER_ID_FILENAME = 'id.protobuf';
 const DEFAULT_PEER_ID_DIR = './.hub';
 const DEFAULT_PEER_ID_FILENAME = `default_${PEER_ID_FILENAME}`;
@@ -27,6 +28,7 @@ app
 app
   .command('start')
   .description('Start a Hub')
+  .option('-c, --config <filepath>', 'Path to a config file with options', DEFAULT_CONFIG_FILE)
   .option('-n --network-url <url>', 'ID Registry network URL')
   .option('-f, --fir-address <address>', 'The address of the FIR contract')
   .option('-b, --bootstrap <ip-multiaddrs...>', 'A list of peer multiaddrs to bootstrap libp2p')
@@ -34,28 +36,37 @@ app
   .option('--multiaddr <ip-multiaddr>', 'The IP multiaddr libp2p should listen on. (default: "/ip4/127.0.0.1/")')
   .option('-g, --gossip-port <port>', 'The tcp port libp2p should gossip over. (default: selects one at random)')
   .option('-r, --rpc-port <port>', 'The tcp port that the rpc server should listen on.  (default: random port)')
-  .option('--simple-sync <enabled>', 'Toggle simple sync', true)
-  .option('--db-name <name>', 'The name of the RocksDB instance', 'rocks.hub._default')
-  .option('--db-reset', 'Clears the database before starting', false)
-  .option('-i, --id <filepath>', 'Path to the PeerId file', DEFAULT_PEER_ID_LOCATION)
+  .option('--simple-sync <enabled>', 'Toggle simple sync')
+  .option('--db-name <name>', 'The name of the RocksDB instance')
+  .option('--db-reset', 'Clears the database before starting')
+  .option('-i, --id <filepath>', 'Path to the PeerId file')
   .action(async (cliOptions) => {
     const teardown = async (hub: Hub) => {
       await hub.stop();
       process.exit();
     };
 
+    // try to load the config file
+    const startConfig = (await import(resolve(cliOptions.config))).Config;
+
+    let peerId;
+    if (cliOptions.id) {
+      peerId = await readPeerId(resolve(cliOptions.id));
+    } else {
+      peerId = await readPeerId(resolve(startConfig.id));
+    }
+
     const options: HubOptions = {
-      peerId: await readPeerId(cliOptions.id),
-      networkUrl: cliOptions.networkUrl,
-      IdRegistryAddress: cliOptions.firAddress,
-      bootstrapAddrs: cliOptions.bootstrap,
-      allowedPeers: cliOptions.allowedPeers,
-      IpMultiAddr: cliOptions.multiaddr,
-      gossipPort: cliOptions.gossipPort,
-      rpcPort: cliOptions.rpcPort,
-      simpleSync: cliOptions.simpleSync,
-      rocksDBName: cliOptions.dbName,
-      resetDB: cliOptions.dbReset,
+      networkUrl: cliOptions.networkUrl ?? startConfig.networkUrl,
+      IdRegistryAddress: cliOptions.firAddress ?? startConfig.firAddress,
+      bootstrapAddrs: cliOptions.bootstrap ?? startConfig.bootstrap,
+      allowedPeers: cliOptions.allowedPeers ?? startConfig.allowedPeers,
+      IpMultiAddr: cliOptions.multiaddr ?? cliOptions.multiaddr,
+      gossipPort: cliOptions.gossipPort ?? cliOptions.gossipPort,
+      rpcPort: cliOptions.rpcPort ?? cliOptions.rpcPort,
+      simpleSync: cliOptions.simpleSync ?? cliOptions.simpleSync,
+      rocksDBName: cliOptions.dbName ?? cliOptions.dbName,
+      resetDB: cliOptions.dbReset ?? cliOptions.dbReset,
     };
 
     const hub = new Hub(options);
@@ -148,12 +159,8 @@ app
   .addCommand(verifyIdCommand);
 
 const readPeerId = async (filePath: string) => {
-  try {
-    const proto = await readFile(filePath);
-    return createFromProtobuf(proto);
-  } catch (err: any) {
-    throw new Error(err);
-  }
+  const proto = await readFile(filePath);
+  return createFromProtobuf(proto);
 };
 
 app.parse(process.argv);


### PR DESCRIPTION
## Motivation

Too many knobs to control via cli. A config file lets us define defaults. 


## Change Summary

Add the option to specify a config file to use to start a Hub.

Also, removed `Commander` option defaults as there's no way to differentiate between user specified options and `Commander` defaults in an `action` handler.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
