### PR TITLE
refactor: IDRegistry to IdRegistry to align with protocol naming

### DIFF
--- a/src/network/p2p/protocol.test.ts
+++ b/src/network/p2p/protocol.test.ts
@@ -1,21 +1,21 @@
 import { Factories } from '~/test/factories';
-import { CastShort, IDRegistryEvent } from '~/types';
+import { CastShort, IdRegistryEvent } from '~/types';
 import {
   ContactInfoContent,
   decodeMessage,
   encodeMessage,
   GossipMessage,
-  IDRegistryContent,
+  IdRegistryContent,
   UserContent,
 } from '~/network/p2p/protocol';
 import { isGossipMessage } from '~/types/typeguards';
 
 let cast: CastShort;
-let idRegistryEvent: IDRegistryEvent;
+let idRegistryEvent: IdRegistryEvent;
 
 beforeAll(async () => {
   cast = await Factories.CastShort.create();
-  idRegistryEvent = await Factories.IDRegistryEvent.create();
+  idRegistryEvent = await Factories.IdRegistryEvent.create();
 });
 
 describe('gossip protocol', () => {
@@ -31,8 +31,8 @@ describe('gossip protocol', () => {
     expect(message).toBeDefined();
   });
 
-  test('constructs a Gossip Message from an IDRegistryEvent', () => {
-    const message: GossipMessage<IDRegistryContent> = {
+  test('constructs a Gossip Message from an IdRegistryEvent', () => {
+    const message: GossipMessage<IdRegistryContent> = {
       content: {
         message: idRegistryEvent,
         root: '',
@@ -79,8 +79,8 @@ describe('encode/decode', () => {
     expect(decoded._unsafeUnwrap()).toStrictEqual(message);
   });
 
-  test('encode and decode a IDRegistry message', () => {
-    const message: GossipMessage<IDRegistryContent> = {
+  test('encode and decode a IdRegistry message', () => {
+    const message: GossipMessage<IdRegistryContent> = {
       content: {
         message: idRegistryEvent,
         root: '',

--- a/src/network/p2p/protocol.ts
+++ b/src/network/p2p/protocol.ts
@@ -1,7 +1,7 @@
 import { AddressInfo } from 'net';
 import { err, ok, Result } from 'neverthrow';
 import { isGossipMessage } from '~/types/typeguards';
-import { IDRegistryEvent, Message } from '~/types';
+import { IdRegistryEvent, Message } from '~/types';
 
 // Network topic for all FC protocol messages
 export const NETWORK_TOPIC_PRIMARY = 'f_network_topic_primary';
@@ -24,7 +24,7 @@ export type GossipMessage<T = Content> = {
   topics: string[];
 };
 
-export type Content = IDRegistryContent | UserContent | ContactInfoContent;
+export type Content = IdRegistryContent | UserContent | ContactInfoContent;
 
 /**
  * UserContent defines the structure of the primary message type that is published
@@ -41,15 +41,15 @@ export type UserContent = {
 };
 
 /**
- * IDRegistryContent defines the structure of the IDRegistry Events that are published
+ * IdRegistryContent defines the structure of the IdRegistry Events that are published
  * over the gossip network.
  *
- * @message - The Farcaster IDRegistryEvent that needs to be sent
+ * @message - The Farcaster IdRegistryEvent that needs to be sent
  * @root - The current merkle root of the sender's trie
  * @count - The number of messages under the root
  */
-export type IDRegistryContent = {
-  message: IDRegistryEvent;
+export type IdRegistryContent = {
+  message: IdRegistryEvent;
   root: string;
   count: number;
 };

--- a/src/network/rpc/client.ts
+++ b/src/network/rpc/client.ts
@@ -1,7 +1,7 @@
 import { AddressInfo } from 'net';
 import { Err, Ok, Result } from 'neverthrow';
 import jayson, { JSONRPCError } from 'jayson/promise';
-import { Cast, Follow, IDRegistryEvent, Message, Reaction, Verification } from '~/types';
+import { Cast, Follow, IdRegistryEvent, Message, Reaction, Verification } from '~/types';
 import { replacer, reviver, RPCRequest } from './interfaces';
 
 export class RPCClient {
@@ -63,7 +63,7 @@ export class RPCClient {
     return new Ok(response.result);
   }
 
-  async getCustodyEventByUser(fid: number): Promise<Result<IDRegistryEvent, JSONRPCError>> {
+  async getCustodyEventByUser(fid: number): Promise<Result<IdRegistryEvent, JSONRPCError>> {
     const response = await this._tcpClient.request(RPCRequest.GetCustodyEventByUser, { fid });
     if (response.error) {
       return new Err(response.error);
@@ -79,8 +79,8 @@ export class RPCClient {
     return new Ok(undefined);
   }
 
-  async submitIDRegistryEvent(event: IDRegistryEvent): Promise<Result<void, JSONRPCError>> {
-    const response = await this._tcpClient.request(RPCRequest.SubmitIDRegistryEvent, { event });
+  async submitIdRegistryEvent(event: IdRegistryEvent): Promise<Result<void, JSONRPCError>> {
+    const response = await this._tcpClient.request(RPCRequest.SubmitIdRegistryEvent, { event });
     if (response.error) {
       return new Err(response.error);
     }

--- a/src/network/rpc/interfaces.ts
+++ b/src/network/rpc/interfaces.ts
@@ -1,5 +1,5 @@
 import { Result } from 'neverthrow';
-import { Cast, Follow, IDRegistryEvent, Message, Reaction, SignerMessage, Verification } from '~/types';
+import { Cast, Follow, IdRegistryEvent, Message, Reaction, SignerMessage, Verification } from '~/types';
 import { FarcasterError } from '~/utils/errors';
 
 export type Port = number;
@@ -13,7 +13,7 @@ export enum RPCRequest {
   GetAllVerificationsByUser = 'getAllVerificationsByUser',
   GetCustodyEventByUser = 'getCustodyEventByUser',
   SubmitMessage = 'submitMessage',
-  SubmitIDRegistryEvent = 'submitIDRegistryEvent',
+  SubmitIdRegistryEvent = 'submitIdRegistryEvent',
 }
 
 export interface RPCHandler {
@@ -23,9 +23,9 @@ export interface RPCHandler {
   getAllReactionsByUser(fid: number): Promise<Set<Reaction>>;
   getAllFollowsByUser(fid: number): Promise<Set<Follow>>;
   getAllVerificationsByUser(fid: number): Promise<Set<Verification>>;
-  getCustodyEventByUser(fid: number): Promise<Result<IDRegistryEvent, FarcasterError>>;
+  getCustodyEventByUser(fid: number): Promise<Result<IdRegistryEvent, FarcasterError>>;
   submitMessage(message: Message): Promise<Result<void, FarcasterError>>;
-  submitIDRegistryEvent?(event: IDRegistryEvent): Promise<Result<void, FarcasterError>>;
+  submitIdRegistryEvent?(event: IdRegistryEvent): Promise<Result<void, FarcasterError>>;
 }
 
 export const replacer = (_key: any, value: any) => {

--- a/src/network/rpc/rpc.test.ts
+++ b/src/network/rpc/rpc.test.ts
@@ -7,7 +7,7 @@ import {
   Follow,
   FollowAdd,
   FollowRemove,
-  IDRegistryEvent,
+  IdRegistryEvent,
   Message,
   MessageSigner,
   Reaction,
@@ -33,7 +33,7 @@ const testDb = jestRocksDB('rpc.test');
 const engine = new Engine(testDb);
 
 let aliceCustodySigner: EthereumSigner;
-let aliceCustodyRegister: IDRegistryEvent;
+let aliceCustodyRegister: IdRegistryEvent;
 let aliceDelegateSigner: MessageSigner;
 
 let cast: CastShort;
@@ -68,7 +68,7 @@ class mockRPCHandler implements RPCHandler {
   getAllVerificationsByUser(fid: number): Promise<Set<Verification>> {
     return engine.getAllVerificationsByUser(fid);
   }
-  getCustodyEventByUser(fid: number): Promise<Result<IDRegistryEvent, FarcasterError>> {
+  getCustodyEventByUser(fid: number): Promise<Result<IdRegistryEvent, FarcasterError>> {
     return engine.getCustodyEventByUser(fid);
   }
   async submitMessage(message: Message): Promise<Result<void, FarcasterError>> {
@@ -105,7 +105,7 @@ describe('rpc', () => {
 
     // setup alices prereqs
     aliceCustodySigner = await generateEthereumSigner();
-    aliceCustodyRegister = await Factories.IDRegistryEvent.create({
+    aliceCustodyRegister = await Factories.IdRegistryEvent.create({
       args: { to: aliceCustodySigner.signerKey, id: aliceFid },
       name: 'Register',
     });
@@ -135,7 +135,7 @@ describe('rpc', () => {
 
   beforeEach(async () => {
     engine._reset();
-    await engine.mergeIDRegistryEvent(aliceCustodyRegister);
+    await engine.mergeIdRegistryEvent(aliceCustodyRegister);
     await engine.mergeMessage(addDelegateSigner);
   });
 

--- a/src/network/rpc/server.ts
+++ b/src/network/rpc/server.ts
@@ -77,14 +77,14 @@ export class RPCServer {
           },
         }),
 
-        [RPCRequest.SubmitIDRegistryEvent]: new jayson.Method({
+        [RPCRequest.SubmitIdRegistryEvent]: new jayson.Method({
           handler: async (args: any) => {
-            if (!rpcHandler.submitIDRegistryEvent) {
+            if (!rpcHandler.submitIdRegistryEvent) {
               const fcError = new ServerError('Request not implemented on Server');
               throw rpcError(fcError.statusCode, fcError.message);
             }
 
-            const result = await rpcHandler.submitIDRegistryEvent(args.event);
+            const result = await rpcHandler.submitIdRegistryEvent(args.event);
             if (result.isErr()) throw rpcError(result.error.statusCode, result.error.message);
             return result.value;
           },

--- a/src/storage/db/signer.ts
+++ b/src/storage/db/signer.ts
@@ -1,7 +1,7 @@
 import { ResultAsync } from 'neverthrow';
 import { Transaction } from '~/storage/db/rocksdb';
-import { IDRegistryEvent, SignerAdd, SignerMessage, SignerRemove } from '~/types';
-import { isIDRegistryEvent } from '~/types/typeguards';
+import { IdRegistryEvent, SignerAdd, SignerMessage, SignerRemove } from '~/types';
+import { isIdRegistryEvent } from '~/types/typeguards';
 import { sanitizeSigner } from '~/utils/crypto';
 import MessageDB from '~/storage/db/message';
 
@@ -15,7 +15,7 @@ import MessageDB from '~/storage/db/message';
  * - fid!<fid>!custody!<custody address>!signerRemoves!<delegate pub key>: <SignerRemove hash>
  *
  * Custody events are stored in this schema:
- * - custodyEvents!<fid>: <IDRegistryEvent>
+ * - custodyEvents!<fid>: <IdRegistryEvent>
  *
  * Note that the SignerDB implements the constraint that a single target can only exist in either signerAdds
  * or signerRemoves for a given custody address. Therefore, _putSignerAdd also deletes the SignerRemove for the same
@@ -39,17 +39,17 @@ class SignerDB extends MessageDB {
     return fids;
   }
 
-  async getCustodyEvent(fid: number): Promise<IDRegistryEvent> {
+  async getCustodyEvent(fid: number): Promise<IdRegistryEvent> {
     const value = await this._db.get(this.custodyEventKey(fid));
 
     const json = JSON.parse(value);
 
-    if (!isIDRegistryEvent(json)) throw new Error('malformed value');
+    if (!isIdRegistryEvent(json)) throw new Error('malformed value');
 
     return json;
   }
 
-  async putCustodyEvent(event: IDRegistryEvent): Promise<void> {
+  async putCustodyEvent(event: IdRegistryEvent): Promise<void> {
     const tsx = this._putCustodyEvent(this._db.transaction(), event);
     return this._db.commit(tsx);
   }
@@ -142,7 +142,7 @@ class SignerDB extends MessageDB {
   /*                         Private Transaction Methods                        */
   /* -------------------------------------------------------------------------- */
 
-  private _putCustodyEvent(tsx: Transaction, event: IDRegistryEvent): Transaction {
+  private _putCustodyEvent(tsx: Transaction, event: IdRegistryEvent): Transaction {
     return tsx.put(this.custodyEventKey(event.args.id), JSON.stringify(event));
   }
 

--- a/src/storage/engine/engine.cast.test.ts
+++ b/src/storage/engine/engine.cast.test.ts
@@ -1,7 +1,7 @@
 import Faker from 'faker';
 import Engine from '~/storage/engine';
 import { Factories } from '~/test/factories';
-import { Cast, CastShort, EthereumSigner, IDRegistryEvent, MessageSigner, SignerAdd, SignerRemove } from '~/types';
+import { Cast, CastShort, EthereumSigner, IdRegistryEvent, MessageSigner, SignerAdd, SignerRemove } from '~/types';
 import { generateEd25519Signer, generateEthereumSigner } from '~/utils/crypto';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import CastDB from '~/storage/db/cast';
@@ -16,7 +16,7 @@ const aliceAdds = async () => new Set(await castDb.getCastAddsByUser(aliceFid));
 
 describe('mergeCast', () => {
   let aliceCustodySigner: EthereumSigner;
-  let aliceCustodyRegister: IDRegistryEvent;
+  let aliceCustodyRegister: IdRegistryEvent;
   let aliceDelegateSigner: MessageSigner;
   let cast: CastShort;
   let addDelegateSigner: SignerAdd;
@@ -24,7 +24,7 @@ describe('mergeCast', () => {
 
   beforeAll(async () => {
     aliceCustodySigner = await generateEthereumSigner();
-    aliceCustodyRegister = await Factories.IDRegistryEvent.create({
+    aliceCustodyRegister = await Factories.IdRegistryEvent.create({
       args: { to: aliceCustodySigner.signerKey, id: aliceFid },
       name: 'Register',
     });
@@ -64,7 +64,7 @@ describe('mergeCast', () => {
 
     describe('with custody address', () => {
       beforeEach(async () => {
-        await engine.mergeIDRegistryEvent(aliceCustodyRegister);
+        await engine.mergeIdRegistryEvent(aliceCustodyRegister);
       });
 
       test('fails if signer is custody address', async () => {
@@ -136,7 +136,7 @@ describe('mergeCast', () => {
 
   describe('with signers', () => {
     beforeEach(async () => {
-      await engine.mergeIDRegistryEvent(aliceCustodyRegister);
+      await engine.mergeIdRegistryEvent(aliceCustodyRegister);
       await engine.mergeMessage(addDelegateSigner);
     });
 

--- a/src/storage/engine/engine.follow.test.ts
+++ b/src/storage/engine/engine.follow.test.ts
@@ -7,7 +7,7 @@ import {
   Follow,
   FollowAdd,
   FollowRemove,
-  IDRegistryEvent,
+  IdRegistryEvent,
   MessageFactoryTransientParams,
   SignerAdd,
 } from '~/types';
@@ -23,7 +23,7 @@ const aliceFid = Faker.datatype.number();
 
 describe('mergeFollow', () => {
   let aliceCustody: EthereumSigner;
-  let aliceCustodyRegister: IDRegistryEvent;
+  let aliceCustodyRegister: IdRegistryEvent;
   let aliceSigner: Ed25519Signer;
   let aliceSignerAdd: SignerAdd;
   let follow: FollowAdd;
@@ -37,7 +37,7 @@ describe('mergeFollow', () => {
 
   beforeAll(async () => {
     aliceCustody = await generateEthereumSigner();
-    aliceCustodyRegister = await Factories.IDRegistryEvent.create({
+    aliceCustodyRegister = await Factories.IdRegistryEvent.create({
       args: { to: aliceCustody.signerKey, id: aliceFid },
       name: 'Register',
     });
@@ -66,7 +66,7 @@ describe('mergeFollow', () => {
 
   describe('with signers', () => {
     beforeEach(async () => {
-      await engine.mergeIDRegistryEvent(aliceCustodyRegister);
+      await engine.mergeIdRegistryEvent(aliceCustodyRegister);
       await engine.mergeMessage(aliceSignerAdd);
     });
 

--- a/src/storage/engine/engine.reaction.test.ts
+++ b/src/storage/engine/engine.reaction.test.ts
@@ -7,7 +7,7 @@ import { Factories } from '~/test/factories';
 import {
   Ed25519Signer,
   EthereumSigner,
-  IDRegistryEvent,
+  IdRegistryEvent,
   MessageFactoryTransientParams,
   Reaction,
   ReactionRemove,
@@ -31,7 +31,7 @@ const aliceRemoves = async () => {
 
 describe('mergeReaction', () => {
   let aliceCustody: EthereumSigner;
-  let aliceCustodyRegister: IDRegistryEvent;
+  let aliceCustodyRegister: IdRegistryEvent;
   let aliceSigner: Ed25519Signer;
   let aliceSignerAdd: SignerAdd;
   let reaction: Reaction;
@@ -40,7 +40,7 @@ describe('mergeReaction', () => {
 
   beforeAll(async () => {
     aliceCustody = await generateEthereumSigner();
-    aliceCustodyRegister = await Factories.IDRegistryEvent.create({
+    aliceCustodyRegister = await Factories.IdRegistryEvent.create({
       args: { to: aliceCustody.signerKey, id: aliceFid },
       name: 'Register',
     });
@@ -68,7 +68,7 @@ describe('mergeReaction', () => {
   describe('with signers', () => {
     beforeEach(async () => {
       engine._reset();
-      await engine.mergeIDRegistryEvent(aliceCustodyRegister);
+      await engine.mergeIdRegistryEvent(aliceCustodyRegister);
       await engine.mergeMessage(aliceSignerAdd);
     });
 

--- a/src/storage/engine/engine.revoke.test.ts
+++ b/src/storage/engine/engine.revoke.test.ts
@@ -6,7 +6,7 @@ import Engine from '~/storage/engine';
 import { Factories } from '~/test/factories';
 import {
   CastShort,
-  IDRegistryEvent,
+  IdRegistryEvent,
   Ed25519Signer,
   EthereumSigner,
   SignerAdd,
@@ -44,7 +44,7 @@ const aliceVerifications = () => engine.getAllVerificationsByUser(aliceFid);
 const aliceFollows = () => engine.getAllFollowsByUser(aliceFid);
 
 let aliceCustody: EthereumSigner;
-let aliceCustodyRegister: IDRegistryEvent;
+let aliceCustodyRegister: IdRegistryEvent;
 let aliceSigner: Ed25519Signer;
 let aliceSignerAdd: SignerAdd;
 let aliceCast: CastShort;
@@ -54,7 +54,7 @@ let aliceFollow: FollowAdd;
 
 beforeAll(async () => {
   aliceCustody = await generateEthereumSigner();
-  aliceCustodyRegister = await Factories.IDRegistryEvent.create({
+  aliceCustodyRegister = await Factories.IdRegistryEvent.create({
     args: { to: aliceCustody.signerKey, id: aliceFid },
     name: 'Register',
   });
@@ -78,7 +78,7 @@ beforeAll(async () => {
 describe('revokeSigner', () => {
   describe('with messages signed by delegate', () => {
     beforeEach(async () => {
-      await engine.mergeIDRegistryEvent(aliceCustodyRegister);
+      await engine.mergeIdRegistryEvent(aliceCustodyRegister);
       await engine.mergeMessage(aliceSignerAdd);
       await engine.mergeMessage(aliceCast);
       await engine.mergeMessage(aliceReaction);

--- a/src/storage/engine/engine.signer.test.ts
+++ b/src/storage/engine/engine.signer.test.ts
@@ -6,7 +6,7 @@ import SignerDB from '~/storage/db/signer';
 import Engine from '~/storage/engine';
 import { BadRequestError, NotFoundError } from '~/utils/errors';
 import { Factories } from '~/test/factories';
-import { Ed25519Signer, EthereumSigner, SignerAdd, SignerMessage, SignerRemove, IDRegistryEvent } from '~/types';
+import { Ed25519Signer, EthereumSigner, SignerAdd, SignerMessage, SignerRemove, IdRegistryEvent } from '~/types';
 import { generateEd25519Signer, generateEthereumSigner, hashFCObject } from '~/utils/crypto';
 
 const testDb = jestRocksDB(`engine.signer.test`);
@@ -27,14 +27,14 @@ const aliceSigners = async (): Promise<Set<SignerAdd>> => {
 
 describe('mergeSignerMessage', () => {
   let aliceCustodySigner: EthereumSigner;
-  let aliceCustodyRegister: IDRegistryEvent;
+  let aliceCustodyRegister: IdRegistryEvent;
   let aliceDelegateSigner: Ed25519Signer;
   let aliceSignerAddDelegate: SignerAdd;
   let aliceSignerRemoveDelegate: SignerRemove;
 
   beforeAll(async () => {
     aliceCustodySigner = await generateEthereumSigner();
-    aliceCustodyRegister = await Factories.IDRegistryEvent.create({
+    aliceCustodyRegister = await Factories.IdRegistryEvent.create({
       args: { to: aliceCustodySigner.signerKey, id: aliceFid },
       name: 'Register',
     });
@@ -58,7 +58,7 @@ describe('mergeSignerMessage', () => {
 
   describe('with a custody address', () => {
     beforeEach(async () => {
-      await engine.mergeIDRegistryEvent(aliceCustodyRegister);
+      await engine.mergeIdRegistryEvent(aliceCustodyRegister);
     });
 
     test('fails with invalid message type', async () => {

--- a/src/storage/engine/engine.verification.test.ts
+++ b/src/storage/engine/engine.verification.test.ts
@@ -8,7 +8,7 @@ import {
   VerificationEthereumAddressFactoryTransientParams,
   VerificationEthereumAddress,
   VerificationEthereumAddressClaim,
-  IDRegistryEvent,
+  IdRegistryEvent,
   SignatureAlgorithm,
   CastShort,
   CastRecast,
@@ -44,7 +44,7 @@ const aliceCastAdds = async (): Promise<Set<CastShort | CastRecast>> => {
 
 describe('mergeVerification', () => {
   let aliceCustody: EthereumSigner;
-  let aliceCustodyRegister: IDRegistryEvent;
+  let aliceCustodyRegister: IdRegistryEvent;
   let aliceSigner: Ed25519Signer;
   let aliceSignerAdd: SignerAdd;
   let aliceBlockHash: string;
@@ -56,7 +56,7 @@ describe('mergeVerification', () => {
 
   beforeAll(async () => {
     aliceCustody = await generateEthereumSigner();
-    aliceCustodyRegister = await Factories.IDRegistryEvent.create({
+    aliceCustodyRegister = await Factories.IdRegistryEvent.create({
       args: { to: aliceCustody.signerKey, id: aliceFid },
       name: 'Register',
     });
@@ -99,7 +99,7 @@ describe('mergeVerification', () => {
 
   beforeEach(async () => {
     engine._reset();
-    await engine.mergeIDRegistryEvent(aliceCustodyRegister);
+    await engine.mergeIdRegistryEvent(aliceCustodyRegister);
     await engine.mergeMessage(aliceSignerAdd);
   });
 

--- a/src/storage/engine/index.ts
+++ b/src/storage/engine/index.ts
@@ -8,7 +8,7 @@ import {
   SignatureAlgorithm,
   SignerMessage,
   HashAlgorithm,
-  IDRegistryEvent,
+  IdRegistryEvent,
   Follow,
   CastShort,
   CastRecast,
@@ -39,7 +39,7 @@ import SignerSet from '~/storage/sets/signerSet';
 import FollowSet from '~/storage/sets/followSet';
 import { CastURL, ChainAccountURL, parseUrl, UserURL } from '~/urls';
 import { Web2URL } from '~/urls/web2Url';
-import IDRegistryProvider from '~/storage/provider/idRegistryProvider';
+import IdRegistryProvider from '~/storage/provider/idRegistryProvider';
 import { CastHash } from '~/urls/castUrl';
 import RocksDB from '~/storage/db/rocksdb';
 import { BadRequestError, FarcasterError, ServerError } from '~/utils/errors';
@@ -61,11 +61,11 @@ class Engine extends TypedEmitter<EngineEvents> {
   private _reactionSet: ReactionSet;
   private _verificationSet: VerificationSet;
 
-  private _IDRegistryProvider?: IDRegistryProvider;
+  private _IdRegistryProvider?: IdRegistryProvider;
 
   private _supportedChainIDs = new Set(['eip155:1']);
 
-  constructor(db: RocksDB, networkUrl?: string, IDRegistryAddress?: string) {
+  constructor(db: RocksDB, networkUrl?: string, IdRegistryAddress?: string) {
     super();
     this._db = db;
     this._castSet = new CastSet(db);
@@ -81,9 +81,9 @@ class Engine extends TypedEmitter<EngineEvents> {
     );
 
     /** Optionally, initialize ID Registry provider */
-    if (networkUrl && IDRegistryAddress) {
-      this._IDRegistryProvider = new IDRegistryProvider(networkUrl, IDRegistryAddress);
-      this._IDRegistryProvider.on('confirm', (event: IDRegistryEvent) => this.mergeIDRegistryEvent(event));
+    if (networkUrl && IdRegistryAddress) {
+      this._IdRegistryProvider = new IdRegistryProvider(networkUrl, IdRegistryAddress);
+      this._IdRegistryProvider.on('confirm', (event: IdRegistryEvent) => this.mergeIdRegistryEvent(event));
     }
   }
 
@@ -182,13 +182,13 @@ class Engine extends TypedEmitter<EngineEvents> {
   /*                               Signer Methods                               */
   /* -------------------------------------------------------------------------- */
 
-  async mergeIDRegistryEvent(event: IDRegistryEvent): Promise<Result<void, FarcasterError>> {
-    if (this._IDRegistryProvider) {
-      const isEventValidResult = await this._IDRegistryProvider.validateIDRegistryEvent(event);
+  async mergeIdRegistryEvent(event: IdRegistryEvent): Promise<Result<void, FarcasterError>> {
+    if (this._IdRegistryProvider) {
+      const isEventValidResult = await this._IdRegistryProvider.validateIdRegistryEvent(event);
       if (isEventValidResult.isErr()) return err(isEventValidResult.error);
     }
 
-    return ResultAsync.fromPromise(this._signerSet.mergeIDRegistryEvent(event), (e) => e as FarcasterError);
+    return ResultAsync.fromPromise(this._signerSet.mergeIdRegistryEvent(event), (e) => e as FarcasterError);
   }
 
   /** Get the entire set of signers for an Fid */
@@ -196,8 +196,8 @@ class Engine extends TypedEmitter<EngineEvents> {
     return this._signerSet.getAllSignerMessagesByUser(fid);
   }
 
-  // async getCustodyEventByUser(fid: number): Promise<IDRegistryEvent> {
-  async getCustodyEventByUser(fid: number): Promise<Result<IDRegistryEvent, FarcasterError>> {
+  // async getCustodyEventByUser(fid: number): Promise<IdRegistryEvent> {
+  async getCustodyEventByUser(fid: number): Promise<Result<IdRegistryEvent, FarcasterError>> {
     return ResultAsync.fromPromise(this._signerSet.getCustodyEvent(fid), (e) => e as FarcasterError);
   }
 

--- a/src/storage/engine/mock.ts
+++ b/src/storage/engine/mock.ts
@@ -58,10 +58,10 @@ export const populateEngine = async (
  */
 export const mockFid = async (engine: Engine, fid: number) => {
   const userInfo = await generateUserInfo(fid);
-  const custodyRegister = await getIDRegistryEvent(userInfo);
+  const custodyRegister = await getIdRegistryEvent(userInfo);
   const addDelegateSigner = await getSignerAdd(userInfo);
   // register the user
-  let result = await engine.mergeIDRegistryEvent(custodyRegister);
+  let result = await engine.mergeIdRegistryEvent(custodyRegister);
   expect(result.isOk()).toBeTruthy();
   result = await engine.mergeMessage(addDelegateSigner);
   expect(result.isOk()).toBeTruthy();
@@ -78,10 +78,10 @@ export const generateUserInfo = async (fid: number): Promise<UserInfo> => {
 };
 
 /**
- * Generate an IDRegistryEvent for the given userInfo
+ * Generate an IdRegistryEvent for the given userInfo
  */
-export const getIDRegistryEvent = async (userInfo: UserInfo) => {
-  const custodyRegister = await Factories.IDRegistryEvent.create({
+export const getIdRegistryEvent = async (userInfo: UserInfo) => {
+  const custodyRegister = await Factories.IdRegistryEvent.create({
     args: { to: userInfo.ethereumSigner.signerKey, id: userInfo.fid },
     name: 'Register',
   });

--- a/src/storage/provider/abis.ts
+++ b/src/storage/provider/abis.ts
@@ -1,4 +1,4 @@
-export const IDRegistry = {
+export const IdRegistry = {
   abi: [
     {
       inputs: [

--- a/src/storage/sets/signerSet.test.ts
+++ b/src/storage/sets/signerSet.test.ts
@@ -1,5 +1,5 @@
 import Faker from 'faker';
-import { SignerAdd, SignerRemove, EthereumSigner, Ed25519Signer, IDRegistryEvent } from '~/types';
+import { SignerAdd, SignerRemove, EthereumSigner, Ed25519Signer, IdRegistryEvent } from '~/types';
 import SignerSet, { SignerSetEvents } from '~/storage/sets/signerSet';
 import { Factories } from '~/test/factories';
 import { generateEd25519Signer, generateEthereumSigner } from '~/utils/crypto';
@@ -35,8 +35,8 @@ let custody1: EthereumSigner;
 let custody2: EthereumSigner;
 
 // Custody Address Events
-let custody1Register: IDRegistryEvent;
-let custody2Transfer: IDRegistryEvent;
+let custody1Register: IdRegistryEvent;
+let custody2Transfer: IdRegistryEvent;
 
 // Signers
 let a: Ed25519Signer;
@@ -51,9 +51,9 @@ let addBTo1: SignerAdd;
 
 beforeAll(async () => {
   custody1 = await generateEthereumSigner();
-  custody1Register = await Factories.IDRegistryEvent.create({ args: { to: custody1.signerKey, id: fid } }, {});
+  custody1Register = await Factories.IdRegistryEvent.create({ args: { to: custody1.signerKey, id: fid } }, {});
   custody2 = await generateEthereumSigner();
-  custody2Transfer = await Factories.IDRegistryEvent.create({
+  custody2Transfer = await Factories.IdRegistryEvent.create({
     args: { to: custody2.signerKey, id: fid },
     blockNumber: custody1Register.blockNumber + 1,
   });
@@ -87,14 +87,14 @@ describe('getCustodyAddress', () => {
   });
 
   test('succeeds when custody event has been added', async () => {
-    await set.mergeIDRegistryEvent(custody1Register);
+    await set.mergeIdRegistryEvent(custody1Register);
     const res = set.getCustodyAddress(fid);
     await expect(res).resolves.toEqual(custody1.signerKey);
   });
 
   test('succeeds after custody address has been changed', async () => {
-    await set.mergeIDRegistryEvent(custody1Register);
-    await set.mergeIDRegistryEvent(custody2Transfer);
+    await set.mergeIdRegistryEvent(custody1Register);
+    await set.mergeIdRegistryEvent(custody2Transfer);
     const res = set.getCustodyAddress(fid);
     await expect(res).resolves.toEqual(custody2.signerKey);
   });
@@ -108,7 +108,7 @@ describe('getSigners', () => {
 
   describe('when custody address exists', () => {
     beforeEach(async () => {
-      await set.mergeIDRegistryEvent(custody1Register);
+      await set.mergeIdRegistryEvent(custody1Register);
     });
 
     test('succeeds ', async () => {
@@ -144,14 +144,14 @@ describe('getSigners', () => {
 
     test('succeeds when signer is added and custody address is changed', async () => {
       await set.merge(addATo1);
-      await set.mergeIDRegistryEvent(custody2Transfer);
+      await set.mergeIdRegistryEvent(custody2Transfer);
       const res = set.getSigners(fid);
       await expect(res).resolves.toEqual(new Set());
     });
 
     test('succeeds when signer is added and custody address is changed and another signer is added', async () => {
       await set.merge(addATo1);
-      await set.mergeIDRegistryEvent(custody2Transfer);
+      await set.mergeIdRegistryEvent(custody2Transfer);
       await set.merge(addATo2);
       const res = set.getSigners(fid);
       await expect(res).resolves.toEqual(new Set([addATo2]));
@@ -166,7 +166,7 @@ describe('getSigner', () => {
   });
 
   test('fails when called with a custody address', async () => {
-    await set.mergeIDRegistryEvent(custody1Register);
+    await set.mergeIdRegistryEvent(custody1Register);
     const res = set.getSigner(fid, custody1.signerKey);
     await expect(res).rejects.toThrow();
   });
@@ -177,14 +177,14 @@ describe('getSigner', () => {
   });
 
   test('returns SignerAdd when delegate signer has been added', async () => {
-    await set.mergeIDRegistryEvent(custody1Register);
+    await set.mergeIdRegistryEvent(custody1Register);
     await set.merge(addATo1);
     const res = set.getSigner(fid, a.signerKey);
     await expect(res).resolves.toEqual(addATo1);
   });
 
   test('fails when delegate signer has been removed', async () => {
-    await set.mergeIDRegistryEvent(custody1Register);
+    await set.mergeIdRegistryEvent(custody1Register);
     await set.merge(addATo1);
     await set.merge(remAFrom1);
     const res = set.getSigner(fid, a.signerKey);
@@ -192,18 +192,18 @@ describe('getSigner', () => {
   });
 
   test('fails when custody address has been changed', async () => {
-    await set.mergeIDRegistryEvent(custody1Register);
+    await set.mergeIdRegistryEvent(custody1Register);
     await set.merge(addATo1);
-    await set.mergeIDRegistryEvent(custody2Transfer);
+    await set.mergeIdRegistryEvent(custody2Transfer);
     const res = set.getSigner(fid, a.signerKey);
     await expect(res).rejects.toThrow();
   });
 });
 
-describe('mergeIDRegistryEvent', () => {
+describe('mergeIdRegistryEvent', () => {
   describe('when custody is registered', () => {
     beforeEach(async () => {
-      await set.mergeIDRegistryEvent(custody1Register);
+      await set.mergeIdRegistryEvent(custody1Register);
     });
 
     test('succeeds ', async () => {
@@ -214,11 +214,11 @@ describe('mergeIDRegistryEvent', () => {
 
     test('succeeds if a custody is registered to another fid', async () => {
       const fid2 = Faker.datatype.number();
-      const custody2Register = await Factories.IDRegistryEvent.create(
+      const custody2Register = await Factories.IdRegistryEvent.create(
         { args: { to: custody2.signerKey, id: fid2 } },
         {}
       );
-      await expect(set.mergeIDRegistryEvent(custody2Register)).resolves.toEqual(undefined);
+      await expect(set.mergeIdRegistryEvent(custody2Register)).resolves.toEqual(undefined);
 
       await expect(custodyAddress()).resolves.toEqual(custody1.signerKey);
       await expect(signersByCustody(custody1.signerKey)).resolves.toEqual({ adds: new Map(), removes: new Map() });
@@ -229,7 +229,7 @@ describe('mergeIDRegistryEvent', () => {
     });
 
     test('succeeds when custody is transferred', async () => {
-      await expect(set.mergeIDRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
+      await expect(set.mergeIdRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
       await expect(custodyAddress()).resolves.toEqual(custody2.signerKey);
       await expect(signersByCustody(custody1.signerKey)).resolves.toEqual({ adds: new Map(), removes: new Map() });
       await expect(signersByCustody(custody2.signerKey)).resolves.toEqual({ adds: new Map(), removes: new Map() });
@@ -240,42 +240,42 @@ describe('mergeIDRegistryEvent', () => {
     });
 
     test('succeeds (no-ops) if duplicate registration is provided', async () => {
-      await expect(set.mergeIDRegistryEvent(custody1Register)).resolves.toEqual(undefined);
+      await expect(set.mergeIdRegistryEvent(custody1Register)).resolves.toEqual(undefined);
       await expect(custodyAddress()).resolves.toEqual(custody1.signerKey);
       await expect(signersByCustody(custody1.signerKey)).resolves.toEqual({ adds: new Map(), removes: new Map() });
       expect(events).toEqual([['changeCustody', fid, custody1.signerKey, custody1Register]]);
     });
 
     test('succeeds (no-ops) if transferred in same block, earlier log index', async () => {
-      const addSameBlockEarlierLog: IDRegistryEvent = {
+      const addSameBlockEarlierLog: IdRegistryEvent = {
         ...custody2Transfer,
         blockNumber: custody1Register.blockNumber,
         logIndex: custody1Register.logIndex - 1,
       };
-      await expect(set.mergeIDRegistryEvent(addSameBlockEarlierLog)).resolves.toEqual(undefined);
+      await expect(set.mergeIdRegistryEvent(addSameBlockEarlierLog)).resolves.toEqual(undefined);
       await expect(custodyAddress()).resolves.toEqual(custody1.signerKey);
       await expect(signersByCustody(custody1.signerKey)).resolves.toEqual({ adds: new Map(), removes: new Map() });
       expect(events).toEqual([['changeCustody', fid, custody1.signerKey, custody1Register]]);
     });
 
     test('succeeds (no-ops) if transferred in an earlier block', async () => {
-      const addSameBlockEarlierLog: IDRegistryEvent = {
+      const addSameBlockEarlierLog: IdRegistryEvent = {
         ...custody2Transfer,
         blockNumber: custody1Register.blockNumber - 1,
       };
-      await expect(set.mergeIDRegistryEvent(addSameBlockEarlierLog)).resolves.toEqual(undefined);
+      await expect(set.mergeIdRegistryEvent(addSameBlockEarlierLog)).resolves.toEqual(undefined);
       await expect(custodyAddress()).resolves.toEqual(custody1.signerKey);
       await expect(signersByCustody(custody1.signerKey)).resolves.toEqual({ adds: new Map(), removes: new Map() });
       expect(events).toEqual([['changeCustody', fid, custody1.signerKey, custody1Register]]);
     });
 
     test('succeeds if transferred in the same block, later log index', async () => {
-      const addSameBlockLaterLog: IDRegistryEvent = {
+      const addSameBlockLaterLog: IdRegistryEvent = {
         ...custody2Transfer,
         blockNumber: custody1Register.blockNumber,
         logIndex: custody1Register.logIndex + 1,
       };
-      await expect(set.mergeIDRegistryEvent(addSameBlockLaterLog)).resolves.toEqual(undefined);
+      await expect(set.mergeIdRegistryEvent(addSameBlockLaterLog)).resolves.toEqual(undefined);
       await expect(custodyAddress()).resolves.toEqual(custody2.signerKey);
       await expect(signersByCustody(custody2.signerKey)).resolves.toEqual({ adds: new Map(), removes: new Map() });
       expect(events).toEqual([
@@ -285,13 +285,13 @@ describe('mergeIDRegistryEvent', () => {
     });
 
     test('succeeds if transferred twice in successive blocks', async () => {
-      await expect(set.mergeIDRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
-      const custody1Transfer: IDRegistryEvent = {
+      await expect(set.mergeIdRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
+      const custody1Transfer: IdRegistryEvent = {
         ...custody1Register,
         name: 'Transfer',
         blockNumber: custody2Transfer.blockNumber + 1,
       };
-      await expect(set.mergeIDRegistryEvent(custody1Transfer)).resolves.toEqual(undefined);
+      await expect(set.mergeIdRegistryEvent(custody1Transfer)).resolves.toEqual(undefined);
       await expect(custodyAddress()).resolves.toEqual(custody1.signerKey);
       await expect(signersByCustody(custody1.signerKey)).resolves.toEqual({ adds: new Map(), removes: new Map() });
       await expect(signersByCustody(custody2.signerKey)).resolves.toEqual({ adds: new Map(), removes: new Map() });
@@ -308,7 +308,7 @@ describe('mergeIDRegistryEvent', () => {
       });
 
       test('succeeds if transferred and emits removeSigner event', async () => {
-        await expect(set.mergeIDRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
+        await expect(set.mergeIdRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
         await expect(custodyAddress()).resolves.toEqual(custody2.signerKey);
         await expect(signersByCustody(custody2.signerKey)).resolves.toEqual({ adds: new Map(), removes: new Map() });
         expect(events).toEqual([
@@ -321,7 +321,7 @@ describe('mergeIDRegistryEvent', () => {
 
       test('succeeds if signer removed before transfer and does not emit new event', async () => {
         await expect(set.merge(remAFrom1)).resolves.toEqual(undefined);
-        await expect(set.mergeIDRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
+        await expect(set.mergeIdRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
         await expect(custodyAddress()).resolves.toEqual(custody2.signerKey);
         await expect(signersByCustody(custody2.signerKey)).resolves.toEqual({ adds: new Map(), removes: new Map() });
         expect(events).toEqual([
@@ -339,7 +339,7 @@ describe('mergeIDRegistryEvent', () => {
       });
 
       test('succeeds if transferred and emits addSigner event', async () => {
-        await expect(set.mergeIDRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
+        await expect(set.mergeIdRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
         await expect(custodyAddress()).resolves.toEqual(custody2.signerKey);
         await expect(signersByCustody(custody2.signerKey)).resolves.toEqual({
           adds: new Map([[a.signerKey, addATo2.hash]]),
@@ -354,7 +354,7 @@ describe('mergeIDRegistryEvent', () => {
 
       test('succeeds and does not emit addSigner event when signer has been removed', async () => {
         await expect(set.merge(remAFrom2)).resolves.toEqual(undefined);
-        await expect(set.mergeIDRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
+        await expect(set.mergeIdRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
         await expect(custodyAddress()).resolves.toEqual(custody2.signerKey);
         await expect(signersByCustody(custody2.signerKey)).resolves.toEqual({
           adds: new Map(),
@@ -373,7 +373,7 @@ describe('mergeIDRegistryEvent', () => {
       });
 
       test('succeeds if transferred and does not emit any events', async () => {
-        await expect(set.mergeIDRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
+        await expect(set.mergeIdRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
         await expect(custodyAddress()).resolves.toEqual(custody2.signerKey);
         await expect(signersByCustody(custody2.signerKey)).resolves.toEqual({
           adds: new Map(),
@@ -387,7 +387,7 @@ describe('mergeIDRegistryEvent', () => {
 
       test('succeeds if transferred and signer add is received and does not emit events ', async () => {
         await expect(set.merge(addATo2)).resolves.toEqual(undefined);
-        await expect(set.mergeIDRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
+        await expect(set.mergeIdRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
         await expect(custodyAddress()).resolves.toEqual(custody2.signerKey);
         await expect(signersByCustody(custody2.signerKey)).resolves.toEqual({
           adds: new Map(),
@@ -403,7 +403,7 @@ describe('mergeIDRegistryEvent', () => {
     test('succeeds and emits addSigner event when the same signer was added by both custody addresses', async () => {
       await expect(set.merge(addATo1)).resolves.toEqual(undefined);
       await expect(set.merge(addATo2)).resolves.toEqual(undefined);
-      await expect(set.mergeIDRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
+      await expect(set.mergeIdRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
       await expect(custodyAddress()).resolves.toEqual(custody2.signerKey);
       await expect(signersByCustody(custody2.signerKey)).resolves.toEqual({
         adds: new Map([[a.signerKey, addATo2.hash]]),
@@ -420,15 +420,15 @@ describe('mergeIDRegistryEvent', () => {
 
   describe('when custody is transferred before beng registered', () => {
     test('succeeds ', async () => {
-      await expect(set.mergeIDRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
+      await expect(set.mergeIdRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
       await expect(custodyAddress()).resolves.toEqual(custody2.signerKey);
       await expect(signersByCustody(custody1.signerKey)).resolves.toEqual({ adds: new Map(), removes: new Map() });
       expect(events).toEqual([['changeCustody', fid, custody2.signerKey, custody2Transfer]]);
     });
 
     test('succeeds (no-ops) if duplicate transfer is provided', async () => {
-      await expect(set.mergeIDRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
-      await expect(set.mergeIDRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
+      await expect(set.mergeIdRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
+      await expect(set.mergeIdRegistryEvent(custody2Transfer)).resolves.toEqual(undefined);
 
       await expect(custodyAddress()).resolves.toEqual(custody2.signerKey);
       await expect(signersByCustody(custody1.signerKey)).resolves.toEqual({ adds: new Map(), removes: new Map() });
@@ -472,7 +472,7 @@ describe('merge', () => {
 
   describe('with custody address', () => {
     beforeEach(async () => {
-      await set.mergeIDRegistryEvent(custody1Register);
+      await set.mergeIdRegistryEvent(custody1Register);
     });
 
     describe('mergeSignerAdd', () => {
@@ -534,7 +534,7 @@ describe('merge', () => {
 
       describe('when signer was already added by a different custody address', () => {
         beforeEach(async () => {
-          await set.mergeIDRegistryEvent(custody2Transfer);
+          await set.mergeIdRegistryEvent(custody2Transfer);
         });
 
         test('succeeds if added by causally later custody address', async () => {
@@ -652,7 +652,7 @@ describe('merge', () => {
 
       describe('when signer was removed by a causally earlier custody address', () => {
         beforeEach(async () => {
-          await set.mergeIDRegistryEvent(custody2Transfer);
+          await set.mergeIdRegistryEvent(custody2Transfer);
           await expect(set.merge(remAFrom1)).resolves.toEqual(undefined);
         });
 
@@ -707,7 +707,7 @@ describe('merge', () => {
 
       describe('when signer was removed by a causally later custody address', () => {
         beforeEach(async () => {
-          await set.mergeIDRegistryEvent(custody2Transfer);
+          await set.mergeIdRegistryEvent(custody2Transfer);
           await expect(set.merge(remAFrom2)).resolves.toEqual(undefined);
         });
 
@@ -823,7 +823,7 @@ describe('merge', () => {
 
       describe('when signer is added and removed by two different custody addresses', () => {
         beforeEach(async () => {
-          await set.mergeIDRegistryEvent(custody2Transfer);
+          await set.mergeIdRegistryEvent(custody2Transfer);
         });
 
         afterEach(async () => {
@@ -931,7 +931,7 @@ describe('merge', () => {
 
       describe('when signer was already added by a causally earlier custody address', () => {
         beforeEach(async () => {
-          await set.mergeIDRegistryEvent(custody2Transfer);
+          await set.mergeIdRegistryEvent(custody2Transfer);
           await expect(set.merge(addATo1)).resolves.toEqual(undefined);
         });
 
@@ -986,7 +986,7 @@ describe('merge', () => {
 
       describe('when signer was already added by a causally later custody address', () => {
         beforeEach(async () => {
-          await set.mergeIDRegistryEvent(custody2Transfer);
+          await set.mergeIdRegistryEvent(custody2Transfer);
           await expect(set.merge(addATo2)).resolves.toEqual(undefined);
         });
 
@@ -1098,7 +1098,7 @@ describe('merge', () => {
 
       describe('when signer was already removed by a different custody address', () => {
         beforeEach(async () => {
-          await set.mergeIDRegistryEvent(custody2Transfer);
+          await set.mergeIdRegistryEvent(custody2Transfer);
         });
 
         test('succeeds if removed by causally earlier custody address', async () => {

--- a/src/storage/sets/signerSet.ts
+++ b/src/storage/sets/signerSet.ts
@@ -1,6 +1,6 @@
 import { TypedEmitter } from 'tiny-typed-emitter';
 import { ResultAsync } from 'neverthrow';
-import { IDRegistryEvent, SignerAdd, SignerMessage, SignerRemove } from '~/types';
+import { IdRegistryEvent, SignerAdd, SignerMessage, SignerRemove } from '~/types';
 import { isSignerAdd, isSignerRemove } from '~/types/typeguards';
 import { hashCompare, sanitizeSigner } from '~/utils/crypto';
 import RocksDB from '~/storage/db/rocksdb';
@@ -8,7 +8,7 @@ import SignerDB from '~/storage/db/signer';
 
 export type SignerSetEvents = {
   /** Emitted when a new Register or Transfer event is received from the Farcaster ID Registry */
-  changeCustody: (fid: number, custodyAddress: string, event: IDRegistryEvent) => void;
+  changeCustody: (fid: number, custodyAddress: string, event: IdRegistryEvent) => void;
 
   /**
    * Emitted when a delegate signer becomes valid which happens when:
@@ -68,7 +68,7 @@ class SignerSet extends TypedEmitter<SignerSetEvents> {
     return sanitizeSigner(event.args.to);
   }
 
-  async getCustodyEvent(fid: number): Promise<IDRegistryEvent> {
+  async getCustodyEvent(fid: number): Promise<IdRegistryEvent> {
     return this._db.getCustodyEvent(fid);
   }
 
@@ -107,11 +107,11 @@ class SignerSet extends TypedEmitter<SignerSetEvents> {
   /**
    * Merge a new event from the Farcaster ID Registry into the SignerSet.
    *
-   * mergeIDRegistryEvent will update the custody address, validate or invalidate delegate signers and emit events.
-   * The IDRegistryEvent must be accurate otherwise local state will diverge from blockchain state. If IDRegistryEvents
+   * mergeIdRegistryEvent will update the custody address, validate or invalidate delegate signers and emit events.
+   * The IdRegistryEvent must be accurate otherwise local state will diverge from blockchain state. If IdRegistryEvents
    * are received out of order, some events may not be emitted.
    */
-  async mergeIDRegistryEvent(event: IDRegistryEvent): Promise<void> {
+  async mergeIdRegistryEvent(event: IdRegistryEvent): Promise<void> {
     const fid = event.args.id;
 
     // If new event is a duplicate or occurred before the existing custodyEvent, no-op
@@ -167,7 +167,7 @@ class SignerSet extends TypedEmitter<SignerSetEvents> {
    * transactionHash. A value of -1 means a occurs before b, 1 means a occurs * after b, and 0 means a and b are the
    * same with identical block number, log index and transactionHash.
    */
-  private eventCompare(a: IDRegistryEvent, b: IDRegistryEvent): number {
+  private eventCompare(a: IdRegistryEvent, b: IdRegistryEvent): number {
     // Compare blockNumber
     if (a.blockNumber < b.blockNumber) {
       return -1;

--- a/src/test/e2e/hub.test.ts
+++ b/src/test/e2e/hub.test.ts
@@ -1,6 +1,6 @@
 import Faker from 'faker';
 import { AddressInfo } from 'net';
-import { generateUserInfo, getIDRegistryEvent, getSignerAdd, mockFid, populateEngine } from '~/storage/engine/mock';
+import { generateUserInfo, getIdRegistryEvent, getSignerAdd, mockFid, populateEngine } from '~/storage/engine/mock';
 import { Factories } from '~/test/factories';
 import { Hub, HubOptions } from '~/hub';
 import { RPCClient } from '~/network/rpc';
@@ -123,15 +123,15 @@ describe('Hub running tests', () => {
   test('hub handles various valid gossip messages', async () => {
     const aliceFid = Faker.datatype.number();
     const aliceInfo = await generateUserInfo(aliceFid);
-    const IDRegistryEvent: GossipMessage<Content> = {
+    const IdRegistryEvent: GossipMessage<Content> = {
       content: {
-        message: await getIDRegistryEvent(aliceInfo),
+        message: await getIdRegistryEvent(aliceInfo),
         root: '',
         count: 0,
       },
       topics: [NETWORK_TOPIC_PRIMARY],
     };
-    const idRegistryResult = await hub.handleGossipMessage(IDRegistryEvent);
+    const idRegistryResult = await hub.handleGossipMessage(IdRegistryEvent);
     expect(idRegistryResult.isOk());
 
     await testMessage(await getSignerAdd(aliceInfo));

--- a/src/test/e2e/rpcSync.test.ts
+++ b/src/test/e2e/rpcSync.test.ts
@@ -3,7 +3,7 @@ import { RPCServer, RPCHandler, RPCClient } from '~/network/rpc';
 import Engine from '~/storage/engine';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import { populateEngine } from '~/storage/engine/mock';
-import { Cast, Follow, IDRegistryEvent, Message, Reaction, SignerMessage, Verification } from '~/types';
+import { Cast, Follow, IdRegistryEvent, Message, Reaction, SignerMessage, Verification } from '~/types';
 import { Result } from 'neverthrow';
 import { FarcasterError } from '~/utils/errors';
 
@@ -32,7 +32,7 @@ class mockRPCHandler implements RPCHandler {
   getAllVerificationsByUser(fid: number): Promise<Set<Verification>> {
     return serverEngine.getAllVerificationsByUser(fid);
   }
-  getCustodyEventByUser(fid: number): Promise<Result<IDRegistryEvent, FarcasterError>> {
+  getCustodyEventByUser(fid: number): Promise<Result<IdRegistryEvent, FarcasterError>> {
     return serverEngine.getCustodyEventByUser(fid);
   }
   async submitMessage(message: Message): Promise<Result<void, FarcasterError>> {
@@ -86,7 +86,7 @@ describe('rpcSync', () => {
         // get the signer messages first so we can prepare to ingest the remaining messages later
         const custodyEventResult = await client.getCustodyEventByUser(user);
         expect(custodyEventResult.isOk()).toBeTruthy();
-        const custodyResult = await clientEngine.mergeIDRegistryEvent(custodyEventResult._unsafeUnwrap());
+        const custodyResult = await clientEngine.mergeIdRegistryEvent(custodyEventResult._unsafeUnwrap());
         expect(custodyResult.isOk()).toBeTruthy();
         const signerMessagesResult = await client.getAllSignerMessagesByUser(user);
         expect(signerMessagesResult.isOk()).toBeTruthy();

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -16,7 +16,7 @@ import {
   MessageFactoryTransientParams,
   MessageSigner,
   HashAlgorithm,
-  IDRegistryEvent,
+  IdRegistryEvent,
   EthAddressUrlFactoryTransientParams,
   SignerMessageFactoryTransientParams,
   MessageType,
@@ -280,8 +280,8 @@ export const Factories = {
     }
   ),
 
-  /** Generate a valid IDRegistryEvent with randomized properties */
-  IDRegistryEvent: Factory.define<IDRegistryEvent, any, IDRegistryEvent>(({ onCreate }) => {
+  /** Generate a valid IdRegistryEvent with randomized properties */
+  IdRegistryEvent: Factory.define<IdRegistryEvent, any, IdRegistryEvent>(({ onCreate }) => {
     onCreate(async (props) => {
       return props;
     });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -246,8 +246,8 @@ export type SignerMessageFactoryTransientParams = MessageFactoryTransientParams 
   signer: EthereumSigner;
 };
 
-export type IDRegistryEvent = {
-  args: IDRegistryArgs;
+export type IdRegistryEvent = {
+  args: IdRegistryArgs;
   blockNumber: number;
   blockHash: string;
   transactionHash: string;
@@ -255,7 +255,7 @@ export type IDRegistryEvent = {
   name: 'Register' | 'Transfer';
 };
 
-export type IDRegistryArgs = {
+export type IdRegistryArgs = {
   to: string;
   id: number;
 };

--- a/src/types/typeguards.ts
+++ b/src/types/typeguards.ts
@@ -1,5 +1,5 @@
 import * as FC from '~/types';
-import { ContactInfoContent, Content, GossipMessage, IDRegistryContent, UserContent } from '~/network/p2p/protocol';
+import { ContactInfoContent, Content, GossipMessage, IdRegistryContent, UserContent } from '~/network/p2p/protocol';
 
 export const isCast = (msg: FC.Message): msg is FC.Cast => isCastShort(msg) || isCastRemove(msg) || isCastRecast(msg);
 
@@ -119,7 +119,7 @@ export const isData = (data: any): data is FC.Data => {
   );
 };
 
-export const isIDRegistryEvent = (msg: any): msg is FC.IDRegistryEvent => {
+export const isIdRegistryEvent = (msg: any): msg is FC.IdRegistryEvent => {
   try {
     const { args } = msg;
     return (
@@ -142,7 +142,7 @@ export const isIDRegistryEvent = (msg: any): msg is FC.IDRegistryEvent => {
 export const isGossipMessage = (msg: any): msg is GossipMessage => {
   try {
     const { content, topics } = msg;
-    const validType = isUserContent(content) || isIDRegistryContent(content) || isContactInfo(content);
+    const validType = isUserContent(content) || isIdRegistryContent(content) || isContactInfo(content);
 
     return validType && Array.isArray(topics) && topics.every((t) => typeof t === 'string');
   } catch (error) {
@@ -159,10 +159,10 @@ export const isUserContent = (content: Content): content is UserContent => {
   }
 };
 
-export const isIDRegistryContent = (content: Content): content is IDRegistryContent => {
+export const isIdRegistryContent = (content: Content): content is IdRegistryContent => {
   try {
-    const { message, root, count } = content as IDRegistryContent;
-    return isIDRegistryEvent(message) && typeof root === 'string' && typeof count === 'number';
+    const { message, root, count } = content as IdRegistryContent;
+    return isIdRegistryEvent(message) && typeof root === 'string' && typeof count === 'number';
   } catch (error) {
     return false;
   }


### PR DESCRIPTION
## Motivation

Hub was not using strict camel casing for naming, while protocol was (IDRegistry vs IdRegistry)

## Change Summary

All instances of IDRegistry are now IdRegistry

## Merge Checklist


- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
