### PR TITLE
chore: use IP address strings to specify hub address

### DIFF
--- a/.config/hub.config.ts
+++ b/.config/hub.config.ts
@@ -16,8 +16,8 @@ export const Config = {
   // bootstrapAddresses: [],
   /** An "allow list" of Peer Ids. Blocks all other connections */
   // allowedPeers: [],
-  /** The IP Multi Address libp2p should listen on. */
-  // multiaddr: '/ip4/127.0.0.1/',
+  /** The IP address libp2p should listen on. */
+  ip: '127.0.0.1',
   /** The TCP port libp2p should listen on. */
   gossipPort: 0,
   /** The RPC port to use. */

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -33,7 +33,7 @@ export interface HubOptions {
   allowedPeers?: string[];
 
   /** IP address string in MultiAddr format to bind to */
-  IpMultiAddr?: string;
+  ipMultiAddr?: string;
 
   /** Port for libp2p to listen for gossip */
   gossipPort?: number;
@@ -138,7 +138,7 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
 
     await this.gossipNode.start(this.options.bootstrapAddrs ?? [], {
       peerId: this.options.peerId,
-      IpMultiAddr: this.options.IpMultiAddr,
+      ipMultiAddr: this.options.ipMultiAddr,
       gossipPort: this.options.gossipPort,
       allowedPeerIdStrs: this.options.allowedPeers,
     });

--- a/src/network/p2p/node.test.ts
+++ b/src/network/p2p/node.test.ts
@@ -115,7 +115,7 @@ describe('node unit tests', () => {
 
   test('port and transport addrs in the Ip MultiAddr is not allowed', async () => {
     const node = new Node();
-    const options = { IpMultiAddr: '/ip4/127.0.0.1/tcp/8080' };
+    const options = { ipMultiAddr: '/ip4/127.0.0.1/tcp/8080' };
     await expect(node.start([], options)).rejects.toThrow();
     expect(node.isStarted()).toBeFalsy();
     await node.stop();
@@ -124,7 +124,7 @@ describe('node unit tests', () => {
   test('invalid multiaddr format is not allowed', async () => {
     const node = new Node();
     // an IPv6 being supplied as an IPv4
-    const options = { IpMultiAddr: '/ip4/2600:1700:6cf0:990:2052:a166:fb35:830a' };
+    const options = { ipMultiAddr: '/ip4/2600:1700:6cf0:990:2052:a166:fb35:830a' };
     await expect(node.start([], options)).rejects.toThrow();
     expect(node.isStarted()).toBeFalsy();
     await node.stop();

--- a/src/network/p2p/node.ts
+++ b/src/network/p2p/node.ts
@@ -36,7 +36,7 @@ interface NodeOptions {
   /** PeerId to use as the Node's Identity. Generates a new ephemeral PeerId if not specified*/
   peerId?: PeerId | undefined;
   /** IP address in MultiAddr format to bind to */
-  IpMultiAddr?: string | undefined;
+  ipMultiAddr?: string | undefined;
   /** Port to listen for gossip. Picks a port at random if not specified. This is combined with the IPMultiAddr */
   gossipPort?: number | undefined;
   /** A list of addresses to peer with. PeersIds outside of this list will not be able to connect to this node */
@@ -240,7 +240,7 @@ export class Node extends TypedEmitter<NodeEvents> {
    * Creates a Libp2p node with GossipSub
    */
   private async createNode(options: NodeOptions) {
-    const listenIPMultiAddr = options.IpMultiAddr ?? MultiaddrLocalHost;
+    const listenIPMultiAddr = options.ipMultiAddr ?? MultiaddrLocalHost;
     const listenPort = options.gossipPort ?? 0;
     const listenMultiAddrStr = `${listenIPMultiAddr}/tcp/${listenPort}`;
     checkNodeAddrs(listenIPMultiAddr, listenMultiAddrStr).match(

--- a/src/test/perf/bench.ts
+++ b/src/test/perf/bench.ts
@@ -1,6 +1,5 @@
 import { Command } from 'commander';
 import { RPCClient } from '~/network/rpc';
-import { AddressInfo, isIP } from 'net';
 import { generateUserInfo, getIdRegistryEvent, getSignerAdd, UserInfo } from '~/storage/engine/mock';
 import Faker from 'faker';
 import { IdRegistryEvent, Message, SignerAdd } from '~/types';

--- a/src/utils/p2p.test.ts
+++ b/src/utils/p2p.test.ts
@@ -1,4 +1,5 @@
-import { parseAddress, checkNodeAddrs } from '~/utils/p2p';
+import { multiaddr } from '@multiformats/multiaddr';
+import { parseAddress, checkNodeAddrs, getAddressInfo, ipMultiAddrStrFromAddressInfo } from '~/utils/p2p';
 
 describe('p2p utils tests', () => {
   test('parse a valid multiaddr', async () => {
@@ -28,5 +29,37 @@ describe('p2p utils tests', () => {
       '/ip4/2600:1700:6cf0:990:2052:a166:fb35:830a',
       '/ip4/2600:1700:6cf0:990:2052:a166:fb35:830a/tcp/8080'
     );
+  });
+
+  test('AddressInfo from valid IPv4 inputs', async () => {
+    const result = getAddressInfo('127.0.0.1', 0);
+    expect(result.isOk()).toBeTruthy();
+    const info = result._unsafeUnwrap();
+    expect(info.address).toEqual('127.0.0.1');
+    expect(info.family).toEqual('ip4');
+  });
+
+  test('AddressInfo from valid IPv6 inputs', async () => {
+    const result = getAddressInfo('2600:1700:6cf0:990:2052:a166:fb35:830a', 12345);
+    expect(result.isOk()).toBeTruthy();
+    const info = result._unsafeUnwrap();
+    expect(info.address).toEqual('2600:1700:6cf0:990:2052:a166:fb35:830a');
+    expect(info.family).toEqual('ip6');
+  });
+
+  test('AddressInfo fails on invalid inputs', async () => {
+    const result = getAddressInfo('clearlyNotAnIP', 12345);
+    expect(result.isErr()).toBeTruthy();
+  });
+
+  test('valid multiaddr from addressInfo', async () => {
+    const addressInfo = getAddressInfo('127.0.0.1', 0);
+    expect(addressInfo.isOk()).toBeTruthy();
+
+    const multiAddrStr = ipMultiAddrStrFromAddressInfo(addressInfo._unsafeUnwrap());
+    expect(multiAddrStr).toEqual('/ip4/127.0.0.1');
+
+    const multiAddr = multiaddr(multiAddrStr);
+    expect(multiAddr).toBeDefined();
   });
 });

--- a/src/utils/p2p.ts
+++ b/src/utils/p2p.ts
@@ -1,4 +1,5 @@
 import { Multiaddr, multiaddr } from '@multiformats/multiaddr';
+import { AddressInfo, isIP } from 'net';
 import { err, ok, Result } from 'neverthrow';
 import { FarcasterError, ServerError } from '~/utils/errors';
 
@@ -50,4 +51,28 @@ export const checkNodeAddrs = (listenIPAddr: string, listenCombinedAddr: string)
   );
 
   return result;
+};
+
+/** Get an AddressInfo object for a given IP and port  */
+export const getAddressInfo = (address: string, port: number) => {
+  const family = isIP(address);
+  if (!family) return err(new ServerError('Not an IP address'));
+
+  const addrInfo: AddressInfo = {
+    address,
+    port,
+    family: family == 4 ? 'ip4' : 'ip6',
+  };
+  return ok(addrInfo);
+};
+
+/**
+ *
+ * Creates an IP-only multiaddr formatted string from an AddressInfo
+ *
+ * Does not preserve port or transport information
+ */
+export const ipMultiAddrStrFromAddressInfo = (addressInfo: AddressInfo) => {
+  const multiaddrStr = `/${addressInfo.family}/${addressInfo.address}`;
+  return multiaddrStr;
 };


### PR DESCRIPTION
## Change Summary

- Added the `--ip` option to Hub. IP addresses can be specified as regular strings now instead of multiaddrs
- Removed the `--multiaddr` option from Hub. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
