### PR TITLE
fix: rewrite perf test

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { readFile } from 'fs/promises';
 import { logger } from '~/utils/logger';
 import { dirname, resolve } from 'path';
 import { PeerId } from '@libp2p/interface-peer-id';
-import { addressInfoFromParts, ipMultiAddrStrFromAddressInfo } from './utils/p2p';
+import { addressInfoFromParts, ipMultiAddrStrFromAddressInfo } from '~/utils/p2p';
 
 /** A CLI to accept options from the user and start the Hub */
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { readFile } from 'fs/promises';
 import { logger } from '~/utils/logger';
 import { dirname, resolve } from 'path';
 import { PeerId } from '@libp2p/interface-peer-id';
-import { getAddressInfo, ipMultiAddrStrFromAddressInfo } from './utils/p2p';
+import { addressInfoFromParts, ipMultiAddrStrFromAddressInfo } from './utils/p2p';
 
 /** A CLI to accept options from the user and start the Hub */
 
@@ -32,7 +32,7 @@ app
   .option('-c, --config <filepath>', 'Path to a config file with options', DEFAULT_CONFIG_FILE)
   .option('-n --network-url <url>', 'ID Registry network URL')
   .option('-f, --fir-address <address>', 'The address of the FIR contract')
-  .option('-b, --bootstrap <ip-multiaddrs...>', 'A list of peer multiaddrs to bootstrap libp2p')
+  .option('-b, --bootstrap <peer-multiaddrs...>', 'A list of peer multiaddrs to bootstrap libp2p')
   .option('-a, --allowed-peers <peerIds...>', 'An allow-list of peer ids permitted to connect to the hub')
   .option('--ip <ip-address>', 'The IP address libp2p should listen on. (default: "127.0.0.1")')
   .option('-g, --gossip-port <port>', 'The tcp port libp2p should gossip over. (default: random port)')
@@ -57,7 +57,10 @@ app
       peerId = await readPeerId(resolve(hubConfig.id));
     }
 
-    const hubAddressInfo = getAddressInfo(cliOptions.ip ?? hubConfig.ip, cliOptions.gossipPort ?? hubConfig.gossipPort);
+    const hubAddressInfo = addressInfoFromParts(
+      cliOptions.ip ?? hubConfig.ip,
+      cliOptions.gossipPort ?? hubConfig.gossipPort
+    );
     if (hubAddressInfo.isErr()) {
       throw hubAddressInfo.error;
     }

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -3,7 +3,7 @@ import Engine from '~/storage/engine';
 import { Node } from '~/network/p2p/node';
 import { RPCClient, RPCHandler, RPCServer } from '~/network/rpc';
 import { PeerId } from '@libp2p/interface-peer-id';
-import { Cast, SignerMessage, Reaction, Follow, Verification, IdRegistryEvent, Message } from '~/types';
+import { Cast, SignerMessage, Reaction, Follow, Verification, IdRegistryEvent, Message, MessageType } from '~/types';
 import {
   ContactInfoContent,
   GossipMessage,
@@ -358,8 +358,8 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
       log.error(mergeResult.error, 'received invalid message');
       return mergeResult;
     }
-
-    log.info({ hash: message.hash, fid: message.data.fid, type: message.data.type }, 'merged message');
+    // eslint-disable-next-line security/detect-object-injection
+    log.info({ hash: message.hash, fid: message.data.fid, type: MessageType[message.data.type] }, 'merged message');
 
     // push this message onto the gossip network
     const gossipMessage: GossipMessage<UserContent> = {

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -176,13 +176,16 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
 
   async handleGossipMessage(gossipMessage: GossipMessage) {
     let result: Result<void, FarcasterError> = err(new ServerError('Invalid message type'));
-
     if (isUserContent(gossipMessage.content)) {
       const message = (gossipMessage.content as UserContent).message;
       result = await this.engine.mergeMessage(message);
+      if (result.isOk()) {
+        log.info({ hash: message.hash, fid: message.data.fid, type: MessageType[message.data.type] }, 'merged message');
+      }
     } else if (isIdRegistryContent(gossipMessage.content)) {
       const message = (gossipMessage.content as IdRegistryContent).message;
       result = await this.engine.mergeIdRegistryEvent(message);
+      if (result.isOk()) log.info({ event: message }, 'merged id registry event');
     } else if (isContactInfo(gossipMessage.content)) {
       // TODO: Maybe we need a ContactInfo CRDT?
       // Check if we need sync and if we do, use this peer do it.
@@ -204,7 +207,10 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
     if (this.syncState != SimpleSyncState.Pending) return;
 
     this.emit('syncStart');
-    log.info({ function: 'simpleSyncFromPeer', identity: this.identity, peer: peer }, `syncing from peer: ${peer}`);
+    log.info(
+      { function: 'simpleSyncFromPeer', identity: this.identity, peer: peer },
+      `syncing from peer: ${peer.peerId}`
+    );
     /*
      * Find the peer's addrs from our peer list because we cannot use the address
      * in the contact info directly
@@ -240,7 +246,7 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
     const nodeAddress = peerAddress.addresses[0].multiaddr.nodeAddress();
     const rpcClient = new RPCClient({
       address: nodeAddress.address,
-      family: nodeAddress.family == 4 ? 'ip4' : 'ip6',
+      family: nodeAddress.family == 4 ? 'IPv4' : 'IPv6',
       // Use the gossip rpc port instead of the port used by libp2p
       port: peer.rpcAddress.port,
     });
@@ -355,9 +361,17 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
     // push this message into the engine
     const mergeResult = await this.engine.mergeMessage(message);
     if (mergeResult.isErr()) {
-      log.error(mergeResult.error, 'received invalid message');
+      // Safe to disable because the type is being checked to be within bounds
+      // eslint-disable-next-line security/detect-object-injection
+      log.error(
+        mergeResult.error,
+        `received invalid message of type: ${
+          message.data.type <= MessageType.SignerRemove ? MessageType[message.data.type] : 'unknown'
+        }`
+      );
       return mergeResult;
     }
+    // It's safe to convert the message type to its enum string since the message has already been validated.
     // eslint-disable-next-line security/detect-object-injection
     log.info({ hash: message.hash, fid: message.data.fid, type: MessageType[message.data.type] }, 'merged message');
 

--- a/src/network/p2p/node.ts
+++ b/src/network/p2p/node.ts
@@ -65,6 +65,7 @@ export class Node extends TypedEmitter<NodeEvents> {
    * checked for reachability prior to establishing connections
    */
   get multiaddrs() {
+    this._node?.peerStore;
     return this._node?.getMultiaddrs();
   }
 

--- a/src/network/p2p/node.ts
+++ b/src/network/p2p/node.ts
@@ -65,7 +65,6 @@ export class Node extends TypedEmitter<NodeEvents> {
    * checked for reachability prior to establishing connections
    */
   get multiaddrs() {
-    this._node?.peerStore;
     return this._node?.getMultiaddrs();
   }
 
@@ -145,7 +144,7 @@ export class Node extends TypedEmitter<NodeEvents> {
     encodedMessage.match(
       async (msg) => {
         const results = await Promise.all(topics.map((topic) => this.gossip?.publish(topic, msg)));
-        log.debug({ identity: this.identity }, 'Published to ' + results.length + ' peers');
+        log.debug({ identity: this.identity, results }, 'Published to gossip peers');
       },
       async (err) => {
         log.error(err, 'Failed to publish message.');
@@ -216,19 +215,19 @@ export class Node extends TypedEmitter<NodeEvents> {
   registerDebugListeners() {
     // Debug
     this._node?.addEventListener('peer:discovery', (event) => {
-      log.debug({ identity: this.identity }, `Found peer: ${event.detail.multiaddrs}`);
+      log.info({ identity: this.identity }, `Found peer: ${event.detail.multiaddrs}`);
     });
     this._node?.connectionManager.addEventListener('peer:connect', (event) => {
-      log.debug({ identity: this.identity }, `Connection established to: ${event.detail.remotePeer.toString()}`);
+      log.info({ identity: this.identity }, `Connection established to: ${event.detail.remotePeer.toString()}`);
     });
     this._node?.connectionManager.addEventListener('peer:disconnect', (event) => {
-      log.debug({ identity: this.identity }, `Disconnected from: ${event.detail.remotePeer.toString()}`);
+      log.info({ identity: this.identity }, `Disconnected from: ${event.detail.remotePeer.toString()}`);
     });
     this.gossip?.addEventListener('message', (event) => {
-      log.debug({ identity: this.identity }, `Received message for topic: ${event.detail.topic}`);
+      log.info({ identity: this.identity }, `Received message for topic: ${event.detail.topic}`);
     });
     this.gossip?.addEventListener('subscription-change', (event) => {
-      log.debug(
+      log.info(
         { identity: this.identity },
         `Subscription change: ${event.detail.subscriptions.map((value) => {
           value.topic;

--- a/src/network/rpc/client.ts
+++ b/src/network/rpc/client.ts
@@ -7,10 +7,10 @@ import { ipMultiAddrStrFromAddressInfo } from '~/utils/p2p';
 
 export class RPCClient {
   private _tcpClient!: jayson.client;
-  private _serverMultiAddrStr: string;
+  private _serverMultiAddr: string;
 
   constructor(address: AddressInfo) {
-    if (address.family != 'IPv6' && address.family != 'IPv4') throw Error('Invalid Address Info');
+    if (address.family != 'IPv6' && address.family != 'IPv4') throw `Invalid Address Family: ${address.family}`;
     this._tcpClient = jayson.Client.tcp({
       port: address.port,
       host: address.address,
@@ -18,12 +18,12 @@ export class RPCClient {
       replacer,
       reviver,
     });
-    this._serverMultiAddrStr = `${ipMultiAddrStrFromAddressInfo(address)}/tcp/${address.port}`;
+    this._serverMultiAddr = `${ipMultiAddrStrFromAddressInfo(address)}/tcp/${address.port}`;
   }
 
   /** Returns a multiaddr of the RPC server this client is connected to */
-  getServerMultiaddr() {
-    return this._serverMultiAddrStr;
+  get serverMultiaddr() {
+    return this._serverMultiAddr;
   }
 
   async getUsers(): Promise<Result<Set<number>, JSONRPCError>> {

--- a/src/network/rpc/rpc.test.ts
+++ b/src/network/rpc/rpc.test.ts
@@ -27,6 +27,7 @@ import Faker from 'faker';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import { FarcasterError } from '~/utils/errors';
 import { Result } from 'neverthrow';
+import { multiaddr } from '@multiformats/multiaddr';
 
 const aliceFid = Faker.datatype.number();
 const testDb = jestRocksDB('rpc.test');
@@ -168,6 +169,13 @@ describe('rpc', () => {
     const response = await client.getAllCastsByUser(aliceFid);
     expect(response.isOk()).toBeTruthy();
     expect(response._unsafeUnwrap()).toEqual(new Set([]));
+  });
+
+  test('check which server the client is configured for', async () => {
+    const serverAddr = client.serverMultiaddr;
+    expect(serverAddr).toBeTruthy();
+    const parsedAddr = multiaddr(serverAddr);
+    expect(parsedAddr).toBeTruthy();
   });
 
   describe('test user generated content', () => {

--- a/src/network/rpc/server.ts
+++ b/src/network/rpc/server.ts
@@ -119,9 +119,8 @@ export class RPCServer {
 
   get address() {
     const addr = this.tcp?.address();
-    if (!addr) return undefined;
     // We always use IP sockets so this is a safe cast
-    return addr as AddressInfo;
+    return addr ? (addr as AddressInfo) : undefined;
   }
 
   async stop(): Promise<void> {

--- a/src/test/perf/bench.ts
+++ b/src/test/perf/bench.ts
@@ -1,15 +1,10 @@
 import { Command } from 'commander';
 import { RPCClient } from '~/network/rpc';
-import { generateUserInfo, getIdRegistryEvent, getSignerAdd, UserInfo } from '~/storage/engine/mock';
-import Faker from 'faker';
-import { IdRegistryEvent, Message, SignerAdd } from '~/types';
-import { Factories } from '~/test/factories';
-import { Result } from 'neverthrow';
-import { sleep } from '~/utils/crypto';
-import { JSONRPCError } from 'jayson/promise';
-import { isIdRegistryEvent, isMessage } from '~/types/typeguards';
-import { logger } from '~/utils/logger';
-import { getAddressInfo } from '~/utils/p2p';
+import { SetupMode, setupNetwork } from '~/test/perf/setup';
+import { addressInfoFromNodeAddress } from '~/utils/p2p';
+import { multiaddr } from '@multiformats/multiaddr';
+import { makeBasicScenario, playback, PlaybackOrder } from '~/test/perf/playback';
+import { waitForSync } from '~/test/perf/verify';
 
 /**
  * Farcaster Benchmark Client
@@ -21,58 +16,10 @@ import { getAddressInfo } from '~/utils/p2p';
  *
  */
 
-const post = (msg: string, start: number, stop: number) => {
-  const delta = Number((stop - start) / 1000);
-  const time = delta.toFixed(3);
-  logger.info(`Time ${time}s : ${msg}`);
-  return delta;
-};
-
 const parseNumber = (string: string) => {
   const number = Number(string);
   if (isNaN(number)) throw new Error('Not a number.');
   return number;
-};
-
-const getCounts = (results: Result<any, any>[]): SubmitCounts => {
-  const counts = results
-    .map((r) => [Number(r.isOk()), Number(r.isErr())])
-    .reduce((results, result) => {
-      results[0] += result[0];
-      results[1] += result[1];
-      return results;
-    });
-  return {
-    success: counts[0],
-    fail: counts[1],
-  };
-};
-
-type SubmitCounts = {
-  success: number;
-  fail: number;
-};
-
-const submitInBatches = async (messages: Message[] | IdRegistryEvent[]) => {
-  // limits what we try to do in parallel. If this number is too large, we'll run out of sockets to use for tcp
-  const BATCH_SIZE = 100;
-  let results: Result<void, JSONRPCError>[] = [];
-  for (let i = 0; i < messages.length; i += BATCH_SIZE) {
-    const batch = messages.slice(i, i + BATCH_SIZE);
-    const innerRes = await Promise.all(
-      batch.map((message) => {
-        if (isIdRegistryEvent(message)) {
-          return client.submitIdRegistryEvent(message);
-        }
-        if (isMessage(message)) {
-          return client.submitMessage(message);
-        }
-        throw Error('Trying to send invalid message');
-      })
-    );
-    results = results.concat(innerRes);
-  }
-  return getCounts(results);
 };
 
 // Main
@@ -83,82 +30,27 @@ app
   .version(process.env.npm_package_version ?? '1.0.0');
 
 app
-  .requiredOption('-a, --multiaddr <multiaddr>', 'The IP multiaddr of the Hub to submit messages to')
-  .requiredOption('-r, --rpc-port <port>', 'The RPC port of the Hub')
-  .option('-U, --users <count>', 'The number of users to simulate', parseNumber, 100);
+  .requiredOption(
+    '-l, --hubs <rpc-multiaddrs...>',
+    'A list of RPC multiaddrs of Hubs on the network (example:"/ip4/192.168.1.255/tcp/9090")'
+  )
+  .option('-u, --users <count>', 'The number of users to simulate', parseNumber, 10);
 
 app.parse(process.argv);
 const cliOptions = app.opts();
-logger.info({ options: cliOptions, optionsSize: [...Array(cliOptions.users)].length, type: typeof cliOptions.users });
-const addressInfo = getAddressInfo(cliOptions.ipAddress, cliOptions.rpcPort);
-if (addressInfo.isErr()) throw addressInfo.error;
 
-logger.info(`Using RPC server: ${addressInfo.value.address}/${addressInfo.value.port}`);
-const client = new RPCClient(addressInfo.value);
+// make a list of RPCClients for each Hub
+const rpcMultiAddrs: string[] = cliOptions.hubs;
+const rpcClients = rpcMultiAddrs.map((addr) => {
+  const address = multiaddr(addr);
+  return new RPCClient(addressInfoFromNodeAddress(address.nodeAddress()));
+});
 
-// generate users
-logger.info(`Generating IdRegistry events for ${cliOptions.users} users.`);
-const firstUser = Faker.datatype.number();
-const idRegistryEvents: IdRegistryEvent[] = [];
-const signerAddEvents: SignerAdd[] = [];
-let start = performance.now();
-const userInfos: UserInfo[] = await Promise.all(
-  [...Array(cliOptions.users)].map(async (_value, index) => {
-    const info = await generateUserInfo(firstUser + index);
-    idRegistryEvents.push(await getIdRegistryEvent(info));
-    signerAddEvents.push(await getSignerAdd(info));
-    return info;
-  })
-);
-let stop = performance.now();
-const accountTime = post(`Generated ${cliOptions.users} users. UserInfo has ${userInfos.length} items`, start, stop);
-
-// submit users
-start = performance.now();
-const registryResults = await submitInBatches(idRegistryEvents);
-
-stop = performance.now();
-const idRegistryTime = post('IdRegistry Events submitted', start, stop);
-
-logger.info(`${registryResults.success} events submitted successfully. ${registryResults.fail} events failed.`);
-logger.info('_Waiting a few seconds for the network to synchronize_');
-await sleep(10_000);
-
-start = performance.now();
-const signerResults = await submitInBatches(signerAddEvents);
-
-stop = performance.now();
-const signerAddsTime = post('Signers submitted', start, stop);
-
-logger.info(`${signerResults.success} signers submitted successfully. ${signerResults.fail} signers failed.`);
-
-logger.info('_Waiting a few seconds for the network to synchronize_');
-await sleep(10_000);
-
-// generate random data for each user
-logger.info(`Generating Casts for ${cliOptions.users} users`);
-start = performance.now();
-const casts = await Promise.all(
-  userInfos.map((user) => {
-    return Factories.CastShort.create({ data: { fid: user.fid } }, { transient: { signer: user.delegateSigner } });
-  })
-);
-stop = performance.now();
-const castTime = post('Generated 1 cast for each user', start, stop);
-
-// submit data
-start = performance.now();
-const castResults = await submitInBatches(casts);
-stop = performance.now();
-post('Casts submitted', start, stop);
-
-logger.info(`${castResults.success} Casts submitted successfully. ${castResults.fail} Casts failed.`);
-
-logger.info('------------------------------------------');
-logger.info('Time \t\t\t\t Task');
-logger.info('------------------------------------------');
-logger.info(`${accountTime.toFixed(3)}s    \t\t\t Account generation time`);
-logger.info(`${idRegistryTime.toFixed(3)}s    \t\t\t IdRegistry Events`);
-logger.info(`${signerAddsTime.toFixed(3)}s    \t\t\t Signer Add Messages`);
-logger.info(`${castTime.toFixed(3)}s    \t\t\t Cast Messages`);
-logger.info(`Total: ${(accountTime + idRegistryTime + signerAddsTime + castTime).toFixed(3)}s`);
+// setup hubs
+const userInfos = await setupNetwork(rpcClients, { users: cliOptions.users, mode: SetupMode.RANDOM_SINGLE });
+// create cast data
+const messages = await makeBasicScenario(userInfos);
+// submit data to the first RPC (should allow random playback);
+await playback(rpcClients[0], messages, { order: PlaybackOrder.RND });
+// verify network sync
+await waitForSync(rpcClients);

--- a/src/test/perf/bench.ts
+++ b/src/test/perf/bench.ts
@@ -51,6 +51,6 @@ const userInfos = await setupNetwork(rpcClients, { users: cliOptions.users, mode
 // creates scenario data
 const scenario = await makeBasicScenario(rpcClients[0], userInfos);
 // submits the scenario for playback
-await playback(scenario, { order: PlaybackOrder.SEQ });
+await playback(scenario, { order: PlaybackOrder.RND });
 // verifies network sync
 await waitForSync(rpcClients);

--- a/src/test/perf/playback.ts
+++ b/src/test/perf/playback.ts
@@ -1,8 +1,5 @@
-import { RPCClient } from '~/network/rpc';
-import { Message } from '~/types';
+import { Scenario } from '~/test/perf/scenario';
 import { logger } from '~/utils/logger';
-import { Factories } from '~/test/factories';
-import { MockFCEvent, UserInfo } from '~/storage/engine/mock';
 import { post, shuffleMessages, submitInBatches } from '~/test/perf/utils';
 
 export enum PlaybackOrder {
@@ -17,156 +14,25 @@ export interface PlaybackConfig {
   order: PlaybackOrder;
 }
 
-export const playback = async (client: RPCClient, messages: Message[], config: PlaybackConfig) => {
-  logger.info(`Using RPC server: ${client.getServerMultiaddr()} for playback`);
-
-  const start = performance.now();
+export const playback = async (scenario: Scenario, config: PlaybackConfig) => {
   let counts;
-  switch (config.order) {
-    case PlaybackOrder.SEQ:
-      counts = await submitInBatches(client, messages);
-      break;
-    case PlaybackOrder.RND:
-      counts = await submitInBatches(client, shuffleMessages(messages));
-      break;
-    default:
-      throw 'Unknown Message Playback Order';
+
+  for (const task of scenario.tasks) {
+    const start = performance.now();
+    logger.info(`Using RPC server: ${task.rpcClient.serverMultiaddr} for task playback`);
+    switch (config.order) {
+      case PlaybackOrder.SEQ:
+        counts = await submitInBatches(task.rpcClient, task.messages);
+        break;
+      case PlaybackOrder.RND:
+        counts = await submitInBatches(task.rpcClient, shuffleMessages(task.messages));
+        break;
+      default:
+        throw 'Unknown Message Playback Order';
+    }
+    const stop = performance.now();
+    post(`Submitted ${task.messages.length} messages to ${task.rpcClient.serverMultiaddr}`, start, stop);
   }
-  const stop = performance.now();
+
   logger.info({ playback: counts, msg: 'Playback completed' });
-  post(`Submitted ${messages.length} messages to ${client.getServerMultiaddr()}`, start, stop);
-};
-
-// TODO maybe refactor engine.mock to use this utility
-export type ScenarioConfig = {
-  Adds: number;
-  Removes: number;
-  RemovesWithoutAdds: number;
-};
-
-export const makeBasicScenario = async (
-  userInfos: UserInfo[],
-  config: ScenarioConfig = {
-    Adds: 10,
-    Removes: 2,
-    RemovesWithoutAdds: 2,
-  }
-) => {
-  let messages: Message[] = [];
-  const casts = await makeMessages(userInfos, config, MockFCEvent.Cast);
-  messages = messages.concat(casts);
-  const follows = await makeMessages(userInfos, config, MockFCEvent.Follow);
-  messages = messages.concat(follows);
-  const reactions = await makeMessages(userInfos, config, MockFCEvent.Reaction);
-  messages = messages.concat(reactions);
-  const verifications = await makeMessages(userInfos, config, MockFCEvent.Verification);
-  messages = messages.concat(verifications);
-
-  logger.info(`Created ${messages.length} messages for Basic scenario`);
-  return messages;
-};
-
-const makeMessages = async (userInfos: UserInfo[], config: ScenarioConfig, event: MockFCEvent) => {
-  // eslint-disable-next-line security/detect-object-injection
-  logger.info(`Generating ${MockFCEvent[event]}s for ${userInfos.length} users`);
-
-  const messages: Message[] = [];
-  for (const userInfo of userInfos) {
-    const removeReference: string[] = [];
-    const createParams = { data: { fid: userInfo.fid } };
-    const createOptions = { transient: { signer: userInfo.delegateSigner } };
-
-    for (let i = 0; i < config.Adds; i++) {
-      let add;
-      let reference;
-      switch (event) {
-        case MockFCEvent.Cast:
-          add = await Factories.CastShort.create(createParams, createOptions);
-          reference = add.hash;
-          break;
-        case MockFCEvent.Follow:
-          add = await Factories.FollowAdd.create(createParams, createOptions);
-          reference = add.data.body.targetUri;
-          break;
-        case MockFCEvent.Reaction:
-          add = await Factories.ReactionAdd.create(createParams, createOptions);
-          reference = add.data.body.targetUri;
-          break;
-        case MockFCEvent.Verification:
-          // creating these a offset time
-          add = await Factories.VerificationEthereumAddress.create(
-            { ...createParams, data: { signedAt: Date.now() - 1000 } },
-            createOptions
-          );
-          reference = add.data.body.claimHash;
-          break;
-        default:
-          throw Error('Unknown message type');
-      }
-      if (removeReference.length < config.Removes) {
-        // collect target hashes
-        removeReference.push(reference);
-      }
-      messages.push(add);
-    }
-    for (let i = 0; i < config.Removes; i++) {
-      // related removes
-      const reference = removeReference.pop();
-      if (!reference) throw Error('No more target hashes to remove');
-
-      let remove;
-      switch (event) {
-        case MockFCEvent.Cast:
-          remove = await Factories.CastRemove.create(
-            { ...createParams, data: { body: { targetHash: reference } } },
-            createOptions
-          );
-          break;
-        case MockFCEvent.Follow:
-          remove = await Factories.FollowRemove.create(
-            { ...createParams, data: { body: { targetUri: reference } } },
-            createOptions
-          );
-          break;
-        case MockFCEvent.Reaction:
-          remove = await Factories.ReactionRemove.create(
-            { ...createParams, data: { body: { targetUri: reference } } },
-            createOptions
-          );
-          break;
-        case MockFCEvent.Verification:
-          remove = await Factories.VerificationRemove.create(
-            { ...createParams, data: { signedAt: Date.now(), body: { claimHash: reference } } },
-            createOptions
-          );
-          break;
-        default:
-          throw Error('Unknown message type');
-      }
-      messages.push(remove);
-    }
-    for (let i = 0; i < config.RemovesWithoutAdds; i++) {
-      // unrelated removes
-      messages.push(await Factories.CastRemove.create(createParams, createOptions));
-
-      switch (event) {
-        case MockFCEvent.Cast:
-          messages.push(await Factories.CastRemove.create(createParams, createOptions));
-          break;
-        case MockFCEvent.Follow:
-          messages.push(await Factories.FollowRemove.create(createParams, createOptions));
-          break;
-        case MockFCEvent.Reaction:
-          messages.push(await Factories.ReactionRemove.create(createParams, createOptions));
-          break;
-        case MockFCEvent.Verification:
-          messages.push(await Factories.VerificationRemove.create(createParams, createOptions));
-          break;
-        default:
-          throw Error('Unknown message type');
-      }
-    }
-  }
-
-  return messages;
 };

--- a/src/test/perf/playback.ts
+++ b/src/test/perf/playback.ts
@@ -1,0 +1,172 @@
+import { RPCClient } from '~/network/rpc';
+import { Message } from '~/types';
+import { logger } from '~/utils/logger';
+import { Factories } from '~/test/factories';
+import { MockFCEvent, UserInfo } from '~/storage/engine/mock';
+import { post, shuffleMessages, submitInBatches } from '~/test/perf/utils';
+
+export enum PlaybackOrder {
+  /** Playback messages in order */
+  SEQ,
+  /** Playback messages in a random order */
+  RND,
+}
+
+export interface PlaybackConfig {
+  /** The order in which the messages should be sent to the Hub */
+  order: PlaybackOrder;
+}
+
+export const playback = async (client: RPCClient, messages: Message[], config: PlaybackConfig) => {
+  logger.info(`Using RPC server: ${client.getServerMultiaddr()} for playback`);
+
+  const start = performance.now();
+  let counts;
+  switch (config.order) {
+    case PlaybackOrder.SEQ:
+      counts = await submitInBatches(client, messages);
+      break;
+    case PlaybackOrder.RND:
+      counts = await submitInBatches(client, shuffleMessages(messages));
+      break;
+    default:
+      throw 'Unknown Message Playback Order';
+  }
+  const stop = performance.now();
+  logger.info({ playback: counts, msg: 'Playback completed' });
+  post(`Submitted ${messages.length} messages to ${client.getServerMultiaddr()}`, start, stop);
+};
+
+// TODO maybe refactor engine.mock to use this utility
+export type ScenarioConfig = {
+  Adds: number;
+  Removes: number;
+  RemovesWithoutAdds: number;
+};
+
+export const makeBasicScenario = async (
+  userInfos: UserInfo[],
+  config: ScenarioConfig = {
+    Adds: 10,
+    Removes: 2,
+    RemovesWithoutAdds: 2,
+  }
+) => {
+  let messages: Message[] = [];
+  const casts = await makeMessages(userInfos, config, MockFCEvent.Cast);
+  messages = messages.concat(casts);
+  const follows = await makeMessages(userInfos, config, MockFCEvent.Follow);
+  messages = messages.concat(follows);
+  const reactions = await makeMessages(userInfos, config, MockFCEvent.Reaction);
+  messages = messages.concat(reactions);
+  const verifications = await makeMessages(userInfos, config, MockFCEvent.Verification);
+  messages = messages.concat(verifications);
+
+  logger.info(`Created ${messages.length} messages for Basic scenario`);
+  return messages;
+};
+
+const makeMessages = async (userInfos: UserInfo[], config: ScenarioConfig, event: MockFCEvent) => {
+  // eslint-disable-next-line security/detect-object-injection
+  logger.info(`Generating ${MockFCEvent[event]}s for ${userInfos.length} users`);
+
+  const messages: Message[] = [];
+  for (const userInfo of userInfos) {
+    const removeReference: string[] = [];
+    const createParams = { data: { fid: userInfo.fid } };
+    const createOptions = { transient: { signer: userInfo.delegateSigner } };
+
+    for (let i = 0; i < config.Adds; i++) {
+      let add;
+      let reference;
+      switch (event) {
+        case MockFCEvent.Cast:
+          add = await Factories.CastShort.create(createParams, createOptions);
+          reference = add.hash;
+          break;
+        case MockFCEvent.Follow:
+          add = await Factories.FollowAdd.create(createParams, createOptions);
+          reference = add.data.body.targetUri;
+          break;
+        case MockFCEvent.Reaction:
+          add = await Factories.ReactionAdd.create(createParams, createOptions);
+          reference = add.data.body.targetUri;
+          break;
+        case MockFCEvent.Verification:
+          // creating these a offset time
+          add = await Factories.VerificationEthereumAddress.create(
+            { ...createParams, data: { signedAt: Date.now() - 1000 } },
+            createOptions
+          );
+          reference = add.data.body.claimHash;
+          break;
+        default:
+          throw Error('Unknown message type');
+      }
+      if (removeReference.length < config.Removes) {
+        // collect target hashes
+        removeReference.push(reference);
+      }
+      messages.push(add);
+    }
+    for (let i = 0; i < config.Removes; i++) {
+      // related removes
+      const reference = removeReference.pop();
+      if (!reference) throw Error('No more target hashes to remove');
+
+      let remove;
+      switch (event) {
+        case MockFCEvent.Cast:
+          remove = await Factories.CastRemove.create(
+            { ...createParams, data: { body: { targetHash: reference } } },
+            createOptions
+          );
+          break;
+        case MockFCEvent.Follow:
+          remove = await Factories.FollowRemove.create(
+            { ...createParams, data: { body: { targetUri: reference } } },
+            createOptions
+          );
+          break;
+        case MockFCEvent.Reaction:
+          remove = await Factories.ReactionRemove.create(
+            { ...createParams, data: { body: { targetUri: reference } } },
+            createOptions
+          );
+          break;
+        case MockFCEvent.Verification:
+          remove = await Factories.VerificationRemove.create(
+            { ...createParams, data: { signedAt: Date.now(), body: { claimHash: reference } } },
+            createOptions
+          );
+          break;
+        default:
+          throw Error('Unknown message type');
+      }
+      messages.push(remove);
+    }
+    for (let i = 0; i < config.RemovesWithoutAdds; i++) {
+      // unrelated removes
+      messages.push(await Factories.CastRemove.create(createParams, createOptions));
+
+      switch (event) {
+        case MockFCEvent.Cast:
+          messages.push(await Factories.CastRemove.create(createParams, createOptions));
+          break;
+        case MockFCEvent.Follow:
+          messages.push(await Factories.FollowRemove.create(createParams, createOptions));
+          break;
+        case MockFCEvent.Reaction:
+          messages.push(await Factories.ReactionRemove.create(createParams, createOptions));
+          break;
+        case MockFCEvent.Verification:
+          messages.push(await Factories.VerificationRemove.create(createParams, createOptions));
+          break;
+        default:
+          throw Error('Unknown message type');
+      }
+    }
+  }
+
+  return messages;
+};

--- a/src/test/perf/scenario.ts
+++ b/src/test/perf/scenario.ts
@@ -34,9 +34,9 @@ export const makeBasicScenario = async (
   rpcClient: RPCClient,
   userInfos: UserInfo[],
   config: ScenarioConfig = {
-    Adds: 2,
+    Adds: 5,
     Removes: 1,
-    RemovesWithoutAdds: 0,
+    RemovesWithoutAdds: 5,
   }
 ): Promise<Scenario> => {
   let messages: Message[] = [];

--- a/src/test/perf/scenario.ts
+++ b/src/test/perf/scenario.ts
@@ -1,0 +1,169 @@
+import { MockFCEvent, UserInfo } from '~/storage/engine/mock';
+import { Message } from '~/types';
+import { Factories } from '~/test/factories';
+import { RPCClient } from '~/network/rpc';
+import { logger } from '~/utils/logger';
+
+/** Describes a list of tasks */
+export interface Scenario {
+  tasks: Task[];
+  name: string;
+  config: ScenarioConfig;
+}
+
+/** Describes a list of messages that must be sent to a Hub via an RPCClient */
+interface Task {
+  // TODO add Hub metadata to tasks
+  rpcClient: RPCClient;
+  messages: Message[];
+}
+
+// TODO refactor engine.mock to use this utility
+//** Describes the messages to add to a scenario */
+export type ScenarioConfig = {
+  // Number of Add messages for each Message type (Cast, Reaction, Follow, etc)
+  Adds: number;
+  // Number of Adds to remove for each Message type
+  Removes: number;
+  // Number of new Removes (without Adds) for each Message type
+  RemovesWithoutAdds: number;
+};
+
+/** creates a Basic scennario with the specified configuration */
+export const makeBasicScenario = async (
+  rpcClient: RPCClient,
+  userInfos: UserInfo[],
+  config: ScenarioConfig = {
+    Adds: 2,
+    Removes: 1,
+    RemovesWithoutAdds: 0,
+  }
+): Promise<Scenario> => {
+  let messages: Message[] = [];
+  const casts = await makeMessages(userInfos, config, MockFCEvent.Cast);
+  messages = messages.concat(casts);
+  const follows = await makeMessages(userInfos, config, MockFCEvent.Follow);
+  messages = messages.concat(follows);
+  const reactions = await makeMessages(userInfos, config, MockFCEvent.Reaction);
+  messages = messages.concat(reactions);
+  const verifications = await makeMessages(userInfos, config, MockFCEvent.Verification);
+  messages = messages.concat(verifications);
+  logger.info(`Created ${messages.length} messages for Basic scenario`);
+
+  const task = {
+    rpcClient,
+    messages,
+  };
+  return {
+    name: 'Basic Scenario',
+    tasks: [task],
+    config,
+  };
+};
+
+const makeMessages = async (userInfos: UserInfo[], config: ScenarioConfig, event: MockFCEvent) => {
+  if (event > MockFCEvent.Verification) throw 'Invalid event type for messages';
+  // safe to disable here since `event` is validated above
+  // eslint-disable-next-line security/detect-object-injection
+  logger.info(`Generating ${MockFCEvent[event]}s for ${userInfos.length} users`);
+
+  const messages: Message[] = [];
+  for (const userInfo of userInfos) {
+    const removeReference: string[] = [];
+    const createParams = { data: { fid: userInfo.fid } };
+    const createOptions = { transient: { signer: userInfo.delegateSigner } };
+
+    for (let i = 0; i < config.Adds; i++) {
+      let add;
+      let reference;
+      switch (event) {
+        case MockFCEvent.Cast:
+          add = await Factories.CastShort.create(createParams, createOptions);
+          reference = add.hash;
+          break;
+        case MockFCEvent.Follow:
+          add = await Factories.FollowAdd.create(createParams, createOptions);
+          reference = add.data.body.targetUri;
+          break;
+        case MockFCEvent.Reaction:
+          add = await Factories.ReactionAdd.create(createParams, createOptions);
+          reference = add.data.body.targetUri;
+          break;
+        case MockFCEvent.Verification:
+          // creating these a offset time
+          add = await Factories.VerificationEthereumAddress.create(
+            { ...createParams, data: { signedAt: Date.now() - 1000 } },
+            createOptions
+          );
+          reference = add.data.body.claimHash;
+          break;
+        default:
+          throw Error('Unknown message type');
+      }
+      if (removeReference.length < config.Removes) {
+        // collect target hashes
+        removeReference.push(reference);
+      }
+      messages.push(add);
+    }
+    for (let i = 0; i < config.Removes; i++) {
+      // related removes
+      const reference = removeReference.pop();
+      if (!reference) throw Error('No more target hashes to remove');
+
+      let remove;
+      switch (event) {
+        case MockFCEvent.Cast:
+          remove = await Factories.CastRemove.create(
+            { ...createParams, data: { body: { targetHash: reference } } },
+            createOptions
+          );
+          break;
+        case MockFCEvent.Follow:
+          remove = await Factories.FollowRemove.create(
+            { ...createParams, data: { body: { targetUri: reference } } },
+            createOptions
+          );
+          break;
+        case MockFCEvent.Reaction:
+          remove = await Factories.ReactionRemove.create(
+            { ...createParams, data: { body: { targetUri: reference } } },
+            createOptions
+          );
+          break;
+        case MockFCEvent.Verification:
+          remove = await Factories.VerificationRemove.create(
+            { ...createParams, data: { signedAt: Date.now(), body: { claimHash: reference } } },
+            createOptions
+          );
+          break;
+        default:
+          throw Error('Unknown message type');
+      }
+      messages.push(remove);
+    }
+    for (let i = 0; i < config.RemovesWithoutAdds; i++) {
+      // unrelated removes
+      messages.push(await Factories.CastRemove.create(createParams, createOptions));
+
+      switch (event) {
+        case MockFCEvent.Cast:
+          messages.push(await Factories.CastRemove.create(createParams, createOptions));
+          break;
+        case MockFCEvent.Follow:
+          messages.push(await Factories.FollowRemove.create(createParams, createOptions));
+          break;
+        case MockFCEvent.Reaction:
+          messages.push(await Factories.ReactionRemove.create(createParams, createOptions));
+          break;
+        case MockFCEvent.Verification:
+          messages.push(await Factories.VerificationRemove.create(createParams, createOptions));
+          break;
+        default:
+          throw Error('Unknown message type');
+      }
+    }
+  }
+
+  return messages;
+};

--- a/src/test/perf/setup.ts
+++ b/src/test/perf/setup.ts
@@ -1,0 +1,77 @@
+import { RPCClient } from '~/network/rpc';
+import { logger } from '~/utils/logger';
+import Faker from 'faker';
+import { IdRegistryEvent, SignerAdd } from '~/types';
+import { generateUserInfo, getSignerAdd, UserInfo, getIdRegistryEvent } from '~/storage/engine/mock';
+import { submitInBatches, post } from '~/test/perf/utils';
+import { sleep } from '~/utils/crypto';
+
+export enum SetupMode {
+  /** Pick a Hub at random and perform setup with it */
+  RANDOM_SINGLE,
+  /** Pick a Hub at random for each stage of the setup it */
+  RANDOM_MULTIPLE,
+  /** Send all the messages to every Hub manually */
+  ALL,
+}
+
+export interface SetupConfig {
+  mode: SetupMode;
+  users: number;
+}
+
+/**
+ * Sets up a network of Hubs with user registrations
+ *
+ * For each user, setup will post a IdRegistryEvent and a SignerAdd message.
+ * It waits some seconds at each stage to let the network synchronize.
+ *
+ * @Return A list of UserInfos containing an Eth Signer and a Delegate Signer for each fid
+ */
+export const setupNetwork = async (rpcClients: RPCClient[], config: SetupConfig) => {
+  if (config.users === 0) return [];
+
+  // generate users
+  logger.info(`Generating IdRegistry events for ${config.users} users.`);
+  const firstUser = Faker.datatype.number();
+  const idRegistryEvents: IdRegistryEvent[] = [];
+  const signerAddEvents: SignerAdd[] = [];
+  let start = performance.now();
+  const userInfos: UserInfo[] = await Promise.all(
+    [...Array(config.users)].map(async (_value, index) => {
+      const info = await generateUserInfo(firstUser + index);
+      idRegistryEvents.push(await getIdRegistryEvent(info));
+      signerAddEvents.push(await getSignerAdd(info));
+      return info;
+    })
+  );
+  let stop = performance.now();
+  post(`Generated ${config.users} users. UserInfo has ${userInfos.length} items`, start, stop);
+
+  // pick a random RPC node
+  const client = rpcClients[Math.floor(Math.random() * rpcClients.length)];
+
+  // submit users
+  start = performance.now();
+  const registryResults = await submitInBatches(client, idRegistryEvents);
+
+  stop = performance.now();
+  post('IdRegistry Events submitted', start, stop);
+
+  logger.info(`${registryResults.success} events submitted successfully. ${registryResults.fail} events failed.`);
+  logger.info('_Waiting a few seconds for the network to synchronize_');
+  await sleep(10_000);
+
+  start = performance.now();
+  const signerResults = await submitInBatches(client, signerAddEvents);
+
+  stop = performance.now();
+  post('Signers submitted', start, stop);
+
+  logger.info(`${signerResults.success} signers submitted successfully. ${signerResults.fail} signers failed.`);
+
+  logger.info('_Waiting a few seconds for the network to synchronize_');
+  await sleep(10_000);
+
+  return userInfos;
+};

--- a/src/test/perf/utils.ts
+++ b/src/test/perf/utils.ts
@@ -1,0 +1,64 @@
+import { JSONRPCError } from 'jayson/promise';
+import { Result } from 'neverthrow';
+import { RPCClient } from '~/network/rpc';
+import { IdRegistryEvent, Message } from '~/types';
+import { isIdRegistryEvent, isMessage } from '~/types/typeguards';
+import { logger } from '~/utils/logger';
+
+const getCounts = (results: Result<any, any>[]): SubmitCounts => {
+  const counts = results
+    .map((r) => [Number(r.isOk()), Number(r.isErr())])
+    .reduce((results, result) => {
+      results[0] += result[0];
+      results[1] += result[1];
+      return results;
+    });
+  return {
+    success: counts[0],
+    fail: counts[1],
+  };
+};
+
+export type SubmitCounts = {
+  success: number;
+  fail: number;
+};
+
+export const submitInBatches = async (rpcClient: RPCClient, messages: Message[] | IdRegistryEvent[]) => {
+  // limits what we try to do in parallel. If this number is too large, we'll run out of sockets to use for tcp
+  const BATCH_SIZE = 100;
+  let results: Result<void, JSONRPCError>[] = [];
+  for (let i = 0; i < messages.length; i += BATCH_SIZE) {
+    const batch = messages.slice(i, i + BATCH_SIZE);
+    const innerRes = await Promise.all(
+      batch.map((message) => {
+        if (isIdRegistryEvent(message)) {
+          return rpcClient.submitIdRegistryEvent(message);
+        }
+        if (isMessage(message)) {
+          return rpcClient.submitMessage(message);
+        }
+        throw Error('Trying to send invalid message');
+      })
+    );
+    results = results.concat(innerRes);
+  }
+  return getCounts(results);
+};
+
+export const post = (msg: string, start: number, stop: number) => {
+  const delta = Number((stop - start) / 1000);
+  const time = delta.toFixed(3);
+  logger.info({ time, msg });
+  return delta;
+};
+
+export const shuffleMessages = (messages: Message[]) => {
+  const shuffledMessages = [...messages];
+  for (let i = shuffledMessages.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    // eslint-disable-next-line security/detect-object-injection
+    [shuffledMessages[i], shuffledMessages[j]] = [shuffledMessages[j], shuffledMessages[i]];
+  }
+  return shuffledMessages;
+};

--- a/src/test/perf/utils.ts
+++ b/src/test/perf/utils.ts
@@ -1,29 +1,11 @@
 import { JSONRPCError } from 'jayson/promise';
-import { Result } from 'neverthrow';
+import { err, ok, Result } from 'neverthrow';
 import { RPCClient } from '~/network/rpc';
 import { IdRegistryEvent, Message } from '~/types';
 import { isIdRegistryEvent, isMessage } from '~/types/typeguards';
 import { logger } from '~/utils/logger';
 
-const getCounts = (results: Result<any, any>[]): SubmitCounts => {
-  const counts = results
-    .map((r) => [Number(r.isOk()), Number(r.isErr())])
-    .reduce((results, result) => {
-      results[0] += result[0];
-      results[1] += result[1];
-      return results;
-    });
-  return {
-    success: counts[0],
-    fail: counts[1],
-  };
-};
-
-export type SubmitCounts = {
-  success: number;
-  fail: number;
-};
-
+/** Submits a list of messages to the given RPC client */
 export const submitInBatches = async (rpcClient: RPCClient, messages: Message[] | IdRegistryEvent[]) => {
   // limits what we try to do in parallel. If this number is too large, we'll run out of sockets to use for tcp
   const BATCH_SIZE = 100;
@@ -53,12 +35,47 @@ export const post = (msg: string, start: number, stop: number) => {
   return delta;
 };
 
+/** Randomly shuffles a list of messages */
 export const shuffleMessages = (messages: Message[]) => {
   const shuffledMessages = [...messages];
   for (let i = shuffledMessages.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
+    // safe to disable because inputs are controlled and known
     // eslint-disable-next-line security/detect-object-injection
     [shuffledMessages[i], shuffledMessages[j]] = [shuffledMessages[j], shuffledMessages[i]];
   }
   return shuffledMessages;
+};
+
+/** Compares two sets and returns the items that the left set has and the right set doesn't */
+export const ComputeSetDifference = (
+  left: Result<Set<number | Message>, JSONRPCError>,
+  right: Result<Set<number | Message>, JSONRPCError>
+) => {
+  if (left.isErr() || right.isErr()) return err('Failed to compare messages');
+
+  // JSON encode set values
+  const l = new Set([...left.value].map((i) => JSON.stringify(i)));
+  const r = new Set([...right.value].map((i) => JSON.stringify(i)));
+  const difference = new Set([...l].filter((item) => !r.has(item)));
+  return ok(difference);
+};
+
+const getCounts = (results: Result<any, any>[]): SubmitCounts => {
+  const counts = results
+    .map((r) => [Number(r.isOk()), Number(r.isErr())])
+    .reduce((results, result) => {
+      results[0] += result[0];
+      results[1] += result[1];
+      return results;
+    });
+  return {
+    success: counts[0],
+    fail: counts[1],
+  };
+};
+
+export type SubmitCounts = {
+  success: number;
+  fail: number;
 };

--- a/src/test/perf/verify.ts
+++ b/src/test/perf/verify.ts
@@ -1,9 +1,7 @@
-import { JSONRPCError } from 'jayson/promise';
-import { Result } from 'neverthrow';
 import { RPCClient } from '~/network/rpc';
-import { Message } from '~/types';
 import { sleep } from '~/utils/crypto';
 import { logger } from '~/utils/logger';
+import { ComputeSetDifference } from '~/test/perf/utils';
 
 // A 5 minute network sync timer
 let syncTimer: NodeJS.Timer;
@@ -31,28 +29,19 @@ export const waitForSync = async (rpcClients: RPCClient[]) => {
   clearInterval(syncTimer);
 };
 
-const compareMessages = (
-  left: Result<Set<number | Message>, JSONRPCError>,
-  right: Result<Set<number | Message>, JSONRPCError>
-) => {
-  // This is hacky and not going to work for very long (FlatBuffs?)
-  // TODO Consider pulling in lodash for dev deps
-  if (left.isErr() || right.isErr()) return false;
-  return JSON.stringify(left.value) === JSON.stringify(right.value);
-};
-
 /** Caches information from 1 RPC Client (Hub) and compares it to a list of other RPC Clients (Hubs)  */
 const cacheCompareClients = async (sourceRpcClient: RPCClient, networkRpcClients: RPCClient[]) => {
   // Check that the hubs have synchronized
   const userIds = await sourceRpcClient.getUsers();
   if (userIds.isErr()) {
-    logger.error(userIds.error, `Unable to get users from ${sourceRpcClient.getServerMultiaddr()}`);
+    logger.error(userIds.error, `Unable to get users from ${sourceRpcClient.serverMultiaddr}`);
     return false;
   }
   for (const client of networkRpcClients) {
     const clientSet = await client.getUsers();
-    if (!compareMessages(clientSet, userIds)) {
-      logger.error(`${client.getServerMultiaddr()} fids are not in sync`);
+    const difference = ComputeSetDifference(userIds, clientSet);
+    if (difference.isErr() || (difference.isOk() && difference.value.size > 0)) {
+      logger.error(difference, `${client.serverMultiaddr} fids are not in sync`);
       return false;
     }
   }
@@ -60,32 +49,37 @@ const cacheCompareClients = async (sourceRpcClient: RPCClient, networkRpcClients
     const casts = await sourceRpcClient.getAllCastsByUser(user);
     for (const client of networkRpcClients) {
       const clientSet = await client.getAllCastsByUser(user);
-      if (!compareMessages(clientSet, casts)) {
-        logger.error(`${client.getServerMultiaddr()} casts are not in sync for user ${user}`);
+      const difference = ComputeSetDifference(casts, clientSet);
+      if (difference.isErr() || (difference.isOk() && difference.value.size > 0)) {
+        logger.error(difference, `${client.serverMultiaddr} casts are not in sync for user ${user}`);
         return false;
       }
     }
     const follows = await sourceRpcClient.getAllFollowsByUser(user);
     for (const client of networkRpcClients) {
       const clientSet = await client.getAllFollowsByUser(user);
-      if (!compareMessages(clientSet, follows)) {
-        logger.error(`${client.getServerMultiaddr()} follows are not in sync for user ${user}`);
+      const difference = ComputeSetDifference(follows, clientSet);
+      if (difference.isErr() || (difference.isOk() && difference.value.size > 0)) {
+        logger.error(difference, `${client.serverMultiaddr} follows are not in sync for user ${user}`);
+
         return false;
       }
     }
     const reactions = await sourceRpcClient.getAllReactionsByUser(user);
     for (const client of networkRpcClients) {
       const clientSet = await client.getAllReactionsByUser(user);
-      if (!compareMessages(clientSet, reactions)) {
-        logger.error(`${client.getServerMultiaddr()} reactions are not in sync for user ${user}`);
+      const difference = ComputeSetDifference(reactions, clientSet);
+      if (difference.isErr() || (difference.isOk() && difference.value.size > 0)) {
+        logger.error(difference, `${client.serverMultiaddr} reactions are not in sync for user ${user}`);
         return false;
       }
     }
     const verifications = await sourceRpcClient.getAllVerificationsByUser(user);
     for (const client of networkRpcClients) {
       const clientSet = await client.getAllVerificationsByUser(user);
-      if (!compareMessages(clientSet, verifications)) {
-        logger.error(`${client.getServerMultiaddr()} verifications are not in sync for user ${user}`);
+      const difference = ComputeSetDifference(verifications, clientSet);
+      if (difference.isErr() || (difference.isOk() && difference.value.size > 0)) {
+        logger.error(difference, `${client.serverMultiaddr} verifications are not in sync for user ${user}`);
         return false;
       }
     }

--- a/src/test/perf/verify.ts
+++ b/src/test/perf/verify.ts
@@ -1,0 +1,95 @@
+import { JSONRPCError } from 'jayson/promise';
+import { Result } from 'neverthrow';
+import { RPCClient } from '~/network/rpc';
+import { Message } from '~/types';
+import { sleep } from '~/utils/crypto';
+import { logger } from '~/utils/logger';
+
+// A 5 minute network sync timer
+let syncTimer: NodeJS.Timer;
+
+/** Waits until a network of Hubs synchronizes completely */
+export const waitForSync = async (rpcClients: RPCClient[]) => {
+  if (!syncTimer) {
+    syncTimer = setInterval(async () => {
+      throw Error('Sync failure');
+    }, 5 * 60 * 1000);
+  }
+
+  if (rpcClients.length <= 1) return;
+  logger.info('Waiting for network to synchronize');
+
+  const lastClient = [...rpcClients].shift();
+  if (!lastClient) throw Error('No RPC Clients');
+  const result = await cacheCompareClients(lastClient, rpcClients.slice(1));
+  if (!result) {
+    logger.error(`Network is not in sync yet`);
+    await sleep(10 * 1000);
+    await waitForSync(rpcClients);
+  }
+  logger.info('Network is synchronized');
+  clearInterval(syncTimer);
+};
+
+const compareMessages = (
+  left: Result<Set<number | Message>, JSONRPCError>,
+  right: Result<Set<number | Message>, JSONRPCError>
+) => {
+  // This is hacky and not going to work for very long (FlatBuffs?)
+  // TODO Consider pulling in lodash for dev deps
+  if (left.isErr() || right.isErr()) return false;
+  return JSON.stringify(left.value) === JSON.stringify(right.value);
+};
+
+/** Caches information from 1 RPC Client (Hub) and compares it to a list of other RPC Clients (Hubs)  */
+const cacheCompareClients = async (sourceRpcClient: RPCClient, networkRpcClients: RPCClient[]) => {
+  // Check that the hubs have synchronized
+  const userIds = await sourceRpcClient.getUsers();
+  if (userIds.isErr()) {
+    logger.error(userIds.error, `Unable to get users from ${sourceRpcClient.getServerMultiaddr()}`);
+    return false;
+  }
+  for (const client of networkRpcClients) {
+    const clientSet = await client.getUsers();
+    if (!compareMessages(clientSet, userIds)) {
+      logger.error(`${client.getServerMultiaddr()} fids are not in sync`);
+      return false;
+    }
+  }
+  for (const user of userIds.value) {
+    const casts = await sourceRpcClient.getAllCastsByUser(user);
+    for (const client of networkRpcClients) {
+      const clientSet = await client.getAllCastsByUser(user);
+      if (!compareMessages(clientSet, casts)) {
+        logger.error(`${client.getServerMultiaddr()} casts are not in sync for user ${user}`);
+        return false;
+      }
+    }
+    const follows = await sourceRpcClient.getAllFollowsByUser(user);
+    for (const client of networkRpcClients) {
+      const clientSet = await client.getAllFollowsByUser(user);
+      if (!compareMessages(clientSet, follows)) {
+        logger.error(`${client.getServerMultiaddr()} follows are not in sync for user ${user}`);
+        return false;
+      }
+    }
+    const reactions = await sourceRpcClient.getAllReactionsByUser(user);
+    for (const client of networkRpcClients) {
+      const clientSet = await client.getAllReactionsByUser(user);
+      if (!compareMessages(clientSet, reactions)) {
+        logger.error(`${client.getServerMultiaddr()} reactions are not in sync for user ${user}`);
+        return false;
+      }
+    }
+    const verifications = await sourceRpcClient.getAllVerificationsByUser(user);
+    for (const client of networkRpcClients) {
+      const clientSet = await client.getAllVerificationsByUser(user);
+      if (!compareMessages(clientSet, verifications)) {
+        logger.error(`${client.getServerMultiaddr()} verifications are not in sync for user ${user}`);
+        return false;
+      }
+    }
+  }
+  return true;
+  // Is there RPC to compare the merkle tries ?
+};

--- a/src/utils/p2p.test.ts
+++ b/src/utils/p2p.test.ts
@@ -36,15 +36,7 @@ describe('p2p utils tests', () => {
     expect(result.isOk()).toBeTruthy();
     const info = result._unsafeUnwrap();
     expect(info.address).toEqual('127.0.0.1');
-    expect(info.family).toEqual('ip4');
-  });
-
-  test('addressInfo from valid IPv4:port formatted inputs', async () => {
-    const result = addressInfoFromParts('127.0.0.1:8080', 0);
-    expect(result.isOk()).toBeTruthy();
-    const info = result._unsafeUnwrap();
-    expect(info.address).toEqual('127.0.0.1');
-    expect(info.family).toEqual('ip4');
+    expect(info.family).toEqual('IPv4');
   });
 
   test('addressInfo from valid IPv6 inputs', async () => {
@@ -52,7 +44,7 @@ describe('p2p utils tests', () => {
     expect(result.isOk()).toBeTruthy();
     const info = result._unsafeUnwrap();
     expect(info.address).toEqual('2600:1700:6cf0:990:2052:a166:fb35:830a');
-    expect(info.family).toEqual('ip6');
+    expect(info.family).toEqual('IPv6');
   });
 
   test('addressInfo fails on invalid inputs', async () => {

--- a/src/utils/p2p.test.ts
+++ b/src/utils/p2p.test.ts
@@ -1,5 +1,5 @@
 import { multiaddr } from '@multiformats/multiaddr';
-import { parseAddress, checkNodeAddrs, getAddressInfo, ipMultiAddrStrFromAddressInfo } from '~/utils/p2p';
+import { parseAddress, checkNodeAddrs, addressInfoFromParts, ipMultiAddrStrFromAddressInfo } from '~/utils/p2p';
 
 describe('p2p utils tests', () => {
   test('parse a valid multiaddr', async () => {
@@ -31,29 +31,37 @@ describe('p2p utils tests', () => {
     );
   });
 
-  test('AddressInfo from valid IPv4 inputs', async () => {
-    const result = getAddressInfo('127.0.0.1', 0);
+  test('addressInfo from valid IPv4 inputs', async () => {
+    const result = addressInfoFromParts('127.0.0.1', 0);
     expect(result.isOk()).toBeTruthy();
     const info = result._unsafeUnwrap();
     expect(info.address).toEqual('127.0.0.1');
     expect(info.family).toEqual('ip4');
   });
 
-  test('AddressInfo from valid IPv6 inputs', async () => {
-    const result = getAddressInfo('2600:1700:6cf0:990:2052:a166:fb35:830a', 12345);
+  test('addressInfo from valid IPv4:port formatted inputs', async () => {
+    const result = addressInfoFromParts('127.0.0.1:8080', 0);
+    expect(result.isOk()).toBeTruthy();
+    const info = result._unsafeUnwrap();
+    expect(info.address).toEqual('127.0.0.1');
+    expect(info.family).toEqual('ip4');
+  });
+
+  test('addressInfo from valid IPv6 inputs', async () => {
+    const result = addressInfoFromParts('2600:1700:6cf0:990:2052:a166:fb35:830a', 12345);
     expect(result.isOk()).toBeTruthy();
     const info = result._unsafeUnwrap();
     expect(info.address).toEqual('2600:1700:6cf0:990:2052:a166:fb35:830a');
     expect(info.family).toEqual('ip6');
   });
 
-  test('AddressInfo fails on invalid inputs', async () => {
-    const result = getAddressInfo('clearlyNotAnIP', 12345);
+  test('addressInfo fails on invalid inputs', async () => {
+    const result = addressInfoFromParts('clearlyNotAnIP', 12345);
     expect(result.isErr()).toBeTruthy();
   });
 
   test('valid multiaddr from addressInfo', async () => {
-    const addressInfo = getAddressInfo('127.0.0.1', 0);
+    const addressInfo = addressInfoFromParts('127.0.0.1', 0);
     expect(addressInfo.isOk()).toBeTruthy();
 
     const multiAddrStr = ipMultiAddrStrFromAddressInfo(addressInfo._unsafeUnwrap());

--- a/src/utils/p2p.test.ts
+++ b/src/utils/p2p.test.ts
@@ -1,5 +1,11 @@
-import { multiaddr } from '@multiformats/multiaddr';
-import { parseAddress, checkNodeAddrs, addressInfoFromParts, ipMultiAddrStrFromAddressInfo } from '~/utils/p2p';
+import { multiaddr, NodeAddress } from '@multiformats/multiaddr';
+import {
+  parseAddress,
+  checkNodeAddrs,
+  addressInfoFromParts,
+  ipMultiAddrStrFromAddressInfo,
+  addressInfoFromNodeAddress,
+} from '~/utils/p2p';
 
 describe('p2p utils tests', () => {
   test('parse a valid multiaddr', async () => {
@@ -61,5 +67,41 @@ describe('p2p utils tests', () => {
 
     const multiAddr = multiaddr(multiAddrStr);
     expect(multiAddr).toBeDefined();
+  });
+
+  test('throws when making multiaddr from invalid addressInfo', () => {
+    const addressInfo = addressInfoFromParts('127.0.0.1', 0);
+    expect(addressInfo.isOk()).toBeTruthy();
+
+    addressInfo._unsafeUnwrap().family = 'ip12';
+    expect(() => {
+      ipMultiAddrStrFromAddressInfo(addressInfo._unsafeUnwrap());
+    }).toThrow();
+  });
+
+  test('converts a valid nodeAddress to an addressInfo', () => {
+    const nodeAddr: NodeAddress = {
+      family: 4,
+      address: '127.0.0.1',
+      port: 0,
+    };
+
+    const addressInfo = addressInfoFromNodeAddress(nodeAddr);
+    expect(addressInfo).toBeTruthy();
+    expect(addressInfo.address).toEqual(nodeAddr.address);
+    expect(addressInfo.port).toEqual(nodeAddr.port);
+    expect(addressInfo.family).toEqual('IPv4');
+  });
+
+  test('throws when converting an invalid nodeAddress to an addressInfo', () => {
+    const nodeAddr: NodeAddress = {
+      family: 21 as 4,
+      address: '127.0.0.1',
+      port: 0,
+    };
+
+    expect(() => {
+      addressInfoFromNodeAddress(nodeAddr);
+    }).toThrow();
   });
 });

--- a/src/utils/p2p.ts
+++ b/src/utils/p2p.ts
@@ -55,6 +55,9 @@ export const checkNodeAddrs = (listenIPAddr: string, listenCombinedAddr: string)
 
 /** Get an AddressInfo object from a given NodeAddress object */
 export const addressInfoFromNodeAddress = (nodeAddress: NodeAddress): AddressInfo => {
+  if (nodeAddress.family != 4 && nodeAddress.family != 6)
+    throw Error(`${nodeAddress.family}: Invalid NodeAddress Family`);
+
   return {
     address: nodeAddress.address,
     port: nodeAddress.port,
@@ -83,7 +86,7 @@ export const addressInfoFromParts = (address: string, port: number) => {
  */
 export const ipMultiAddrStrFromAddressInfo = (addressInfo: AddressInfo) => {
   if (addressInfo.family != 'IPv6' && addressInfo.family != 'IPv4')
-    throw Error(`${addressInfo.family}: Invalid AdddressInfo`);
+    throw Error(`${addressInfo.family}: Invalid AdddressInfo Family`);
   const family = addressInfo.family === 'IPv6' ? 'ip6' : 'ip4';
   const multiaddrStr = `/${family}/${addressInfo.address}`;
   return multiaddrStr;

--- a/src/utils/p2p.ts
+++ b/src/utils/p2p.ts
@@ -1,4 +1,4 @@
-import { Multiaddr, multiaddr } from '@multiformats/multiaddr';
+import { Multiaddr, multiaddr, NodeAddress } from '@multiformats/multiaddr';
 import { AddressInfo, isIP } from 'net';
 import { err, ok, Result } from 'neverthrow';
 import { FarcasterError, ServerError } from '~/utils/errors';
@@ -53,15 +53,24 @@ export const checkNodeAddrs = (listenIPAddr: string, listenCombinedAddr: string)
   return result;
 };
 
-/** Get an AddressInfo object for a given IP and port  */
-export const getAddressInfo = (address: string, port: number) => {
+/** Get an AddressInfo object from a given NodeAddress object */
+export const addressInfoFromNodeAddress = (nodeAddress: NodeAddress): AddressInfo => {
+  return {
+    address: nodeAddress.address,
+    port: nodeAddress.port,
+    family: nodeAddress.family == 4 ? 'IPv4' : 'IPv6',
+  };
+};
+
+/** Get an AddressInfo object for a given IP and port */
+export const addressInfoFromParts = (address: string, port: number) => {
   const family = isIP(address);
   if (!family) return err(new ServerError('Not an IP address'));
 
   const addrInfo: AddressInfo = {
     address,
     port,
-    family: family == 4 ? 'ip4' : 'ip6',
+    family: family == 4 ? 'IPv4' : 'IPv6',
   };
   return ok(addrInfo);
 };
@@ -73,6 +82,9 @@ export const getAddressInfo = (address: string, port: number) => {
  * Does not preserve port or transport information
  */
 export const ipMultiAddrStrFromAddressInfo = (addressInfo: AddressInfo) => {
-  const multiaddrStr = `/${addressInfo.family}/${addressInfo.address}`;
+  if (addressInfo.family != 'IPv6' && addressInfo.family != 'IPv4')
+    throw Error(`${addressInfo.family}: Invalid AdddressInfo`);
+  const family = addressInfo.family === 'IPv6' ? 'ip6' : 'ip4';
+  const multiaddrStr = `/${family}/${addressInfo.address}`;
   return multiaddrStr;
 };


### PR DESCRIPTION
This is what it looks like now.. 

```
$ yarn bench -l "/ip6/::/tcp/57949" "/ip6/::/tcp/57952"

{"level":30,"time":1666371935295,"pid":27736,"hostname":"MacBook-Pro","msg":"Generating IdRegistry events for 10 users."}
{"level":30,"time":1666371935887,"pid":27736,"hostname":"MacBook-Pro","time":"0.591","msg":"Generated 10 users. UserInfo has 10 items"}
{"level":30,"time":1666371935941,"pid":27736,"hostname":"MacBook-Pro","time":"0.054","msg":"IdRegistry Events submitted"}
{"level":30,"time":1666371935941,"pid":27736,"hostname":"MacBook-Pro","msg":"10 events submitted successfully. 0 events failed."}
{"level":30,"time":1666371935941,"pid":27736,"hostname":"MacBook-Pro","msg":"_Waiting a few seconds for the network to synchronize_"}
{"level":30,"time":1666371946125,"pid":27736,"hostname":"MacBook-Pro","time":"0.181","msg":"Signers submitted"}
{"level":30,"time":1666371946125,"pid":27736,"hostname":"MacBook-Pro","msg":"10 signers submitted successfully. 0 signers failed."}
{"level":30,"time":1666371946125,"pid":27736,"hostname":"MacBook-Pro","msg":"_Waiting a few seconds for the network to synchronize_"}
{"level":30,"time":1666371956134,"pid":27736,"hostname":"MacBook-Pro","msg":"Generating Casts for 10 users"}
{"level":30,"time":1666371956351,"pid":27736,"hostname":"MacBook-Pro","msg":"Generating Follows for 10 users"}
{"level":30,"time":1666371956487,"pid":27736,"hostname":"MacBook-Pro","msg":"Generating Reactions for 10 users"}
{"level":30,"time":1666371956610,"pid":27736,"hostname":"MacBook-Pro","msg":"Generating Verifications for 10 users"}
{"level":30,"time":1666371958524,"pid":27736,"hostname":"MacBook-Pro","msg":"Created 640 messages for Basic scenario"}
{"level":30,"time":1666371958524,"pid":27736,"hostname":"MacBook-Pro","msg":"Using RPC server: /ip6/::/tcp/57949 for playback"}
{"level":30,"time":1666371961531,"pid":27736,"hostname":"MacBook-Pro","playback":{"success":460,"fail":180},"msg":"Playback completed"}
{"level":30,"time":1666371961532,"pid":27736,"hostname":"MacBook-Pro","time":"3.006","msg":"Submitted 640 messages to /ip6/::/tcp/57949"}
{"level":30,"time":1666371961532,"pid":27736,"hostname":"MacBook-Pro","msg":"Waiting for network to synchronize"}
{"level":30,"time":1666371963832,"pid":27736,"hostname":"MacBook-Pro","msg":"Network is synchronized"}
```

## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

- Perf test now verifies that the network of Hubs has synchronized. 
- Test can send data in a random order


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
