### PR TITLE
feat: add flatbuffer followset

### DIFF
--- a/src/storage/flatbuffers/model.ts
+++ b/src/storage/flatbuffers/model.ts
@@ -126,6 +126,10 @@ export default class MessageModel {
       return UserPrefix.CastMessage;
     }
 
+    if (this.type() === MessageType.FollowAdd || this.type() === MessageType.FollowRemove) {
+      return UserPrefix.FollowMessage;
+    }
+
     // TODO: add all message types
 
     throw new Error('invalid type');

--- a/src/storage/flatbuffers/typeguards.ts
+++ b/src/storage/flatbuffers/typeguards.ts
@@ -1,5 +1,5 @@
 import MessageModel from '~/storage/flatbuffers/model';
-import { CastAddModel, CastRemoveModel } from '~/storage/flatbuffers/types';
+import { CastAddModel, CastRemoveModel, FollowAddModel, FollowRemoveModel } from '~/storage/flatbuffers/types';
 import { MessageBody, MessageType } from '~/utils/generated/message_generated';
 
 export const isCastRemove = (message: MessageModel): message is CastRemoveModel => {
@@ -8,4 +8,12 @@ export const isCastRemove = (message: MessageModel): message is CastRemoveModel 
 
 export const isCastAdd = (message: MessageModel): message is CastAddModel => {
   return message.type() === MessageType.CastAdd && message.data.bodyType() === MessageBody.CastAddBody;
+};
+
+export const isFollowRemove = (message: MessageModel): message is FollowRemoveModel => {
+  return message.type() === MessageType.FollowRemove && message.data.bodyType() === MessageBody.FollowBody;
+};
+
+export const isFollowAdd = (message: MessageModel): message is FollowAddModel => {
+  return message.type() === MessageType.FollowAdd && message.data.bodyType() === MessageBody.FollowBody;
 };

--- a/src/storage/flatbuffers/types.ts
+++ b/src/storage/flatbuffers/types.ts
@@ -1,10 +1,11 @@
 import MessageModel from '~/storage/flatbuffers/model';
-import { CastAddBody, CastRemoveBody } from '~/utils/generated/message_generated';
+import { CastAddBody, CastRemoveBody, FollowBody } from '~/utils/generated/message_generated';
 
 export enum RootPrefix {
   User = 1,
   CastsByParent = 2,
   CastsByMention = 3,
+  FollowsByUser = 4,
 }
 
 export enum UserPrefix {
@@ -12,9 +13,12 @@ export enum UserPrefix {
   CastAdds = 2,
   CastRemoves = 3,
   BySigner = 4,
+  FollowMessage = 5,
+  FollowAdds = 6,
+  FollowRemoves = 7,
 }
 
-export type UserMessagePrefix = UserPrefix.CastMessage;
+export type UserMessagePrefix = UserPrefix.CastMessage | UserPrefix.FollowMessage;
 
 export interface CastRemoveModel extends MessageModel {
   body(): CastRemoveBody;
@@ -22,4 +26,12 @@ export interface CastRemoveModel extends MessageModel {
 
 export interface CastAddModel extends MessageModel {
   body(): CastAddBody;
+}
+
+export interface FollowAddModel extends MessageModel {
+  body(): FollowBody;
+}
+
+export interface FollowRemoveModel extends MessageModel {
+  body(): FollowBody;
 }

--- a/src/storage/sets/flatbuffers/castSet.ts
+++ b/src/storage/sets/flatbuffers/castSet.ts
@@ -31,6 +31,7 @@ class CastSet {
     ]);
   }
 
+  // TODO: make parentFid and parentHash fixed size
   /** RocksDB key of the form <castsByParent prefix byte, parent fid, parent cast hash, fid, cast hash> */
   static castsByParentKey(parentFid: Uint8Array, parentHash: Uint8Array, fid?: Uint8Array, hash?: Uint8Array): Buffer {
     const bytes = new Uint8Array(1 + FID_BYTES + parentHash.length + (fid ? FID_BYTES : 0) + (hash ? hash.length : 0));
@@ -46,6 +47,7 @@ class CastSet {
     return Buffer.from(bytes);
   }
 
+  // TODO: make parentFid and parentHash fixed size
   /** RocksDB key of the form <castsByMention prefix byte, mention fid, fid, cast hash> */
   static caststByMentionKey(mentionFid: Uint8Array, fid?: Uint8Array, hash?: Uint8Array): Buffer {
     const bytes = new Uint8Array(1 + FID_BYTES + (fid ? FID_BYTES : 0) + (hash ? hash.length : 0));

--- a/src/storage/sets/flatbuffers/followSet.test.ts
+++ b/src/storage/sets/flatbuffers/followSet.test.ts
@@ -1,0 +1,265 @@
+import Factories from '~/test/factories/flatbuffer';
+import { jestBinaryRocksDB } from '~/storage/db/jestUtils';
+import MessageModel from '~/storage/flatbuffers/model';
+import { BadRequestError, NotFoundError } from '~/utils/errors';
+import { FollowAddModel, FollowRemoveModel, UserPrefix } from '~/storage/flatbuffers/types';
+import FollowSet from '~/storage/sets/flatbuffers/followSet';
+
+const db = jestBinaryRocksDB('flatbuffers.followSet.test');
+const set = new FollowSet(db);
+const fid = Factories.FID.build();
+
+const userId = Factories.FID.build();
+let followAdd: FollowAddModel;
+let followRemove: FollowRemoveModel;
+
+beforeAll(async () => {
+  const followBody = Factories.FollowBody.build({ user: Factories.UserID.build({ fid: Array.from(userId) }) });
+
+  const followAddData = await Factories.FollowAddData.create({ fid: Array.from(fid), body: followBody });
+  const followAddMessage = await Factories.Message.create({ data: Array.from(followAddData.bb?.bytes() ?? []) });
+  followAdd = new MessageModel(followAddMessage) as FollowAddModel;
+
+  const followRemoveData = await Factories.FollowRemoveData.create({
+    fid: Array.from(fid),
+    body: followBody,
+    timestamp: followAddData.timestamp() + 1,
+  });
+  const followRemoveMessage = await Factories.Message.create({ data: Array.from(followRemoveData.bb?.bytes() ?? []) });
+  followRemove = new MessageModel(followRemoveMessage) as FollowRemoveModel;
+});
+
+describe('getFollowAdd', () => {
+  test('fails if missing', async () => {
+    await expect(set.getFollowAdd(fid, userId)).rejects.toThrow(NotFoundError);
+  });
+
+  test('returns message', async () => {
+    await set.merge(followAdd);
+    await expect(set.getFollowAdd(fid, userId)).resolves.toEqual(followAdd);
+  });
+});
+
+describe('getFollowRemove', () => {
+  test('fails if missing', async () => {
+    await expect(set.getFollowRemove(fid, userId)).rejects.toThrow(NotFoundError);
+  });
+
+  test('returns message', async () => {
+    await set.merge(followRemove);
+    await expect(set.getFollowRemove(fid, userId)).resolves.toEqual(followRemove);
+  });
+});
+
+describe('getFollowAddsByUser', () => {
+  test('returns follow adds for an fid', async () => {
+    await set.merge(followAdd);
+    await expect(set.getFollowAddsByUser(fid)).resolves.toEqual([followAdd]);
+  });
+
+  test('returns empty array without messages', async () => {
+    await expect(set.getFollowAddsByUser(fid)).resolves.toEqual([]);
+  });
+});
+
+describe('getFollowRemovesByUser', () => {
+  test('returns follow removes for an fid', async () => {
+    await set.merge(followRemove);
+    await expect(set.getFollowRemovesByUser(fid)).resolves.toEqual([followRemove]);
+  });
+
+  test('returns empty array without messages', async () => {
+    await expect(set.getFollowRemovesByUser(fid)).resolves.toEqual([]);
+  });
+});
+
+describe('getFollowsByUser', () => {
+  test('returns follows for a user', async () => {
+    const sameUserData = await Factories.FollowAddData.create({
+      body: followAdd.body().unpack() || null,
+    });
+    const sameUserMessage = await Factories.Message.create({
+      data: Array.from(sameUserData.bb?.bytes() ?? []),
+    });
+    const sameUser = new MessageModel(sameUserMessage) as FollowAddModel;
+
+    await set.merge(followAdd);
+    await set.merge(sameUser);
+
+    const byUser = await set.getFollowsByUser(userId);
+    expect(new Set(byUser)).toEqual(new Set([followAdd, sameUser]));
+  });
+});
+
+describe('merge', () => {
+  test('fails with invalid message type', async () => {
+    const invalidData = await Factories.ReactionAddData.create({ fid: Array.from(fid) });
+    const message = await Factories.Message.create({ data: Array.from(invalidData.bb?.bytes() ?? []) });
+    await expect(set.merge(new MessageModel(message))).rejects.toThrow(BadRequestError);
+  });
+
+  describe('FollowRemove', () => {
+    describe('succeeds', () => {
+      beforeEach(async () => {
+        await set.merge(followAdd);
+        await expect(set.merge(followRemove)).resolves.toEqual(undefined);
+      });
+
+      test('saves message', async () => {
+        await expect(
+          MessageModel.get(db, fid, UserPrefix.FollowMessage, followRemove.timestampHash())
+        ).resolves.toEqual(followRemove);
+      });
+
+      test('saves followRemoves index', async () => {
+        await expect(set.getFollowRemove(fid, userId)).resolves.toEqual(followRemove);
+      });
+
+      test('deletes FollowAdd message', async () => {
+        await expect(MessageModel.get(db, fid, UserPrefix.FollowMessage, followAdd.timestampHash())).rejects.toThrow(
+          NotFoundError
+        );
+      });
+
+      test('deletes followAdds index', async () => {
+        await expect(set.getFollowAdd(fid, userId)).rejects.toThrow(NotFoundError);
+      });
+
+      test('deletes followsByUser index', async () => {
+        await expect(set.getFollowsByUser(userId)).resolves.toEqual([]);
+      });
+
+      test('overwrites earlier FollowRemove', async () => {
+        const followRemoveData = await Factories.FollowRemoveData.create({
+          ...followRemove.data.unpack(),
+          timestamp: followRemove.timestamp() + 1,
+        });
+        const followRemoveMessage = await Factories.Message.create({
+          data: Array.from(followRemoveData.bb?.bytes() ?? []),
+        });
+        const followRemoveLater = new MessageModel(followRemoveMessage) as FollowRemoveModel;
+
+        await expect(set.merge(followRemoveLater)).resolves.toEqual(undefined);
+        await expect(set.getFollowRemove(fid, userId)).resolves.toEqual(followRemoveLater);
+        await expect(MessageModel.get(db, fid, UserPrefix.FollowMessage, followRemove.timestampHash())).rejects.toThrow(
+          NotFoundError
+        );
+      });
+
+      test('no-ops when later FollowRemove exists', async () => {
+        const followRemoveData = await Factories.FollowRemoveData.create({
+          ...followRemove.data.unpack(),
+          timestamp: followRemove.timestamp() - 1,
+        });
+        const followRemoveMessage = await Factories.Message.create({
+          data: Array.from(followRemoveData.bb?.bytes() ?? []),
+        });
+        const followRemoveEarlier = new MessageModel(followRemoveMessage) as FollowRemoveModel;
+        await expect(set.merge(followRemoveEarlier)).resolves.toEqual(undefined);
+        await expect(set.getFollowRemove(fid, userId)).resolves.toEqual(followRemove);
+      });
+
+      test('no-ops when merged twice', async () => {
+        await expect(set.merge(followRemove)).resolves.toEqual(undefined);
+        await expect(set.getFollowRemove(fid, userId)).resolves.toEqual(followRemove);
+      });
+    });
+
+    test('succeeds when FollowAdd does not exist', async () => {
+      await expect(set.merge(followRemove)).resolves.toEqual(undefined);
+      await expect(set.getFollowRemove(fid, userId)).resolves.toEqual(followRemove);
+      await expect(set.getFollowAdd(fid, userId)).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe('FollowAdd', () => {
+    describe('succeeds', () => {
+      beforeEach(async () => {
+        await expect(set.merge(followAdd)).resolves.toEqual(undefined);
+      });
+
+      test('saves message', async () => {
+        await expect(MessageModel.get(db, fid, UserPrefix.FollowMessage, followAdd.timestampHash())).resolves.toEqual(
+          followAdd
+        );
+      });
+
+      test('saves followAdds index', async () => {
+        await expect(set.getFollowAdd(fid, userId)).resolves.toEqual(followAdd);
+      });
+
+      test('saves followsByUser index', async () => {
+        await expect(set.getFollowsByUser(userId)).resolves.toEqual([followAdd]);
+      });
+
+      test('no-ops when merged twice', async () => {
+        await expect(set.merge(followAdd)).resolves.toEqual(undefined);
+        await expect(set.getFollowAdd(fid, userId)).resolves.toEqual(followAdd);
+      });
+    });
+
+    describe('with conflicting FollowAdd', () => {
+      let followAddLater: FollowAddModel;
+
+      beforeAll(async () => {
+        const followAddData = await Factories.FollowAddData.create({
+          ...followAdd.data.unpack(),
+          timestamp: followAdd.timestamp() + 1,
+        });
+        const followAddMessage = await Factories.Message.create({
+          data: Array.from(followAddData.bb?.bytes() ?? []),
+        });
+        followAddLater = new MessageModel(followAddMessage) as FollowAddModel;
+      });
+
+      test('succeeds with a later timestamp', async () => {
+        await set.merge(followAdd);
+        await expect(set.merge(followAddLater)).resolves.toEqual(undefined);
+        await expect(set.getFollowAdd(fid, userId)).resolves.toEqual(followAddLater);
+        await expect(MessageModel.get(db, fid, UserPrefix.FollowMessage, followAdd.timestampHash())).rejects.toThrow(
+          NotFoundError
+        );
+      });
+
+      test('no-ops with an earlier timestamp', async () => {
+        await set.merge(followAddLater);
+        await expect(set.merge(followAdd)).resolves.toEqual(undefined);
+        await expect(set.getFollowAdd(fid, userId)).resolves.toEqual(followAddLater);
+        await expect(MessageModel.get(db, fid, UserPrefix.FollowMessage, followAdd.timestampHash())).rejects.toThrow(
+          NotFoundError
+        );
+      });
+    });
+
+    describe('with conflicting FollowRemove', () => {
+      test('succeeds with a later timestamp', async () => {
+        const followRemoveData = await Factories.FollowRemoveData.create({
+          ...followRemove.data.unpack(),
+          timestamp: followAdd.timestamp() - 1,
+        });
+        const followRemoveMessage = await Factories.Message.create({
+          data: Array.from(followRemoveData.bb?.bytes() ?? []),
+        });
+        const followRemoveEarlier = new MessageModel(followRemoveMessage) as FollowRemoveModel;
+
+        await set.merge(followRemoveEarlier);
+        await expect(set.merge(followAdd)).resolves.toEqual(undefined);
+        await expect(set.getFollowAdd(fid, userId)).resolves.toEqual(followAdd);
+        await expect(set.getFollowRemove(fid, userId)).rejects.toThrow(NotFoundError);
+        await expect(
+          MessageModel.get(db, fid, UserPrefix.FollowMessage, followRemoveEarlier.timestampHash())
+        ).rejects.toThrow(NotFoundError);
+      });
+
+      test('no-ops with an earlier timestamp', async () => {
+        await set.merge(followRemove);
+        await expect(set.merge(followAdd)).resolves.toEqual(undefined);
+        await expect(set.getFollowRemove(fid, userId)).resolves.toEqual(followRemove);
+        await expect(set.getFollowAdd(fid, userId)).rejects.toThrow(NotFoundError);
+        await expect(MessageModel.get(db, fid, UserPrefix.FollowMessage, followAdd.timestampHash())).rejects.toThrow(
+          NotFoundError
+        );
+      });
+    });
+  });
+});

--- a/src/storage/sets/flatbuffers/followSet.ts
+++ b/src/storage/sets/flatbuffers/followSet.ts
@@ -1,0 +1,292 @@
+import RocksDB, { Transaction } from '~/storage/db/binaryrocksdb';
+import { BadRequestError } from '~/utils/errors';
+import MessageModel, { FID_BYTES, TRUE_VALUE } from '~/storage/flatbuffers/model';
+import { ResultAsync } from 'neverthrow';
+import { FollowAddModel, FollowRemoveModel, RootPrefix, UserPrefix } from '~/storage/flatbuffers/types';
+import { isFollowAdd, isFollowRemove } from '~/storage/flatbuffers/typeguards';
+import { bytesCompare } from '~/storage/flatbuffers/utils';
+import { MessageType } from '~/utils/generated/message_generated';
+
+class FollowSet {
+  private _db: RocksDB;
+
+  constructor(db: RocksDB) {
+    this._db = db;
+  }
+
+  /** RocksDB key of the form <user prefix (1 byte), fid (32 bytes), follow removes key (1 byte), user id (variable bytes)> */
+  static followRemovesKey(fid: Uint8Array, user?: Uint8Array): Buffer {
+    return Buffer.concat([
+      MessageModel.userKey(fid),
+      Buffer.from([UserPrefix.FollowRemoves]),
+      user ? Buffer.from(user) : new Uint8Array(),
+    ]);
+  }
+
+  /** RocksDB key of the form <user prefix (1 byte), fid (32 bytes), follow adds key (1 byte), user id (variable bytes)> */
+  static followAddsKey(fid: Uint8Array, user?: Uint8Array): Buffer {
+    return Buffer.concat([
+      MessageModel.userKey(fid),
+      Buffer.from([UserPrefix.FollowAdds]),
+      user ? Buffer.from(user) : new Uint8Array(),
+    ]);
+  }
+
+  /** RocksDB key of the form <followByUser prefix (1 byte), user id (32 bytes), fid (32 bytes), message timestamp hash (8 bytes)> */
+  static followsByUserKey(user: Uint8Array, fid?: Uint8Array, hash?: Uint8Array): Buffer {
+    const bytes = new Uint8Array(1 + FID_BYTES + (fid ? FID_BYTES : 0) + (hash ? hash.length : 0));
+    bytes.set([RootPrefix.FollowsByUser], 0);
+    bytes.set(user, 1 + FID_BYTES - user.length); // pad for alignment
+    if (fid) {
+      bytes.set(fid, 1 + FID_BYTES + FID_BYTES - fid.length); // pad fid for alignment
+    }
+    if (hash) {
+      bytes.set(hash, 1 + FID_BYTES + FID_BYTES);
+    }
+    return Buffer.from(bytes);
+  }
+
+  /** Look up FollowAdd message by user */
+  async getFollowAdd(fid: Uint8Array, user: Uint8Array): Promise<FollowAddModel> {
+    const messageTimestampHash = await this._db.get(FollowSet.followAddsKey(fid, user));
+    return MessageModel.get<FollowAddModel>(this._db, fid, UserPrefix.FollowMessage, messageTimestampHash);
+  }
+
+  /** Look up FollowRemove message by user */
+  async getFollowRemove(fid: Uint8Array, user: Uint8Array): Promise<FollowRemoveModel> {
+    const messageTimestampHash = await this._db.get(FollowSet.followRemovesKey(fid, user));
+    return MessageModel.get<FollowRemoveModel>(this._db, fid, UserPrefix.FollowMessage, messageTimestampHash);
+  }
+
+  /** Get all FollowAdd messages for an fid */
+  async getFollowAddsByUser(fid: Uint8Array): Promise<FollowAddModel[]> {
+    const addsPrefix = FollowSet.followAddsKey(fid);
+    const messageKeys: Buffer[] = [];
+    for await (const [, value] of this._db.iteratorByPrefix(addsPrefix, { keys: false, valueAsBuffer: true })) {
+      messageKeys.push(value);
+    }
+    return MessageModel.getManyByUser<FollowAddModel>(this._db, fid, UserPrefix.FollowMessage, messageKeys);
+  }
+
+  /** Get all FollowRemove messages for an fid */
+  async getFollowRemovesByUser(fid: Uint8Array): Promise<FollowRemoveModel[]> {
+    const removesPrefix = FollowSet.followRemovesKey(fid);
+    const messageKeys: Buffer[] = [];
+    for await (const [, value] of this._db.iteratorByPrefix(removesPrefix, { keys: false, valueAsBuffer: true })) {
+      messageKeys.push(value);
+    }
+    return MessageModel.getManyByUser<FollowRemoveModel>(this._db, fid, UserPrefix.FollowMessage, messageKeys);
+  }
+
+  /** Get all FollowAdd messages for a user */
+  async getFollowsByUser(user: Uint8Array): Promise<FollowAddModel[]> {
+    const byUserPrefix = FollowSet.followsByUserKey(user);
+    const messageKeys: Buffer[] = [];
+    for await (const [key] of this._db.iteratorByPrefix(byUserPrefix, { keyAsBuffer: true, values: false })) {
+      const fid = Uint8Array.from(key).subarray(byUserPrefix.length, byUserPrefix.length + FID_BYTES);
+      const timestampHash = Uint8Array.from(key).subarray(byUserPrefix.length + FID_BYTES);
+      messageKeys.push(MessageModel.primaryKey(fid, UserPrefix.FollowMessage, timestampHash));
+    }
+    return MessageModel.getMany(this._db, messageKeys);
+  }
+
+  /** Merge a FollowAdd or FollowRemove message into the set */
+  async merge(message: MessageModel): Promise<void> {
+    if (isFollowRemove(message)) {
+      return this.mergeRemove(message);
+    }
+
+    if (isFollowAdd(message)) {
+      return this.mergeAdd(message);
+    }
+
+    throw new BadRequestError('invalid message type');
+  }
+
+  /* -------------------------------------------------------------------------- */
+  /*                               Private Methods                              */
+  /* -------------------------------------------------------------------------- */
+
+  private async mergeAdd(message: FollowAddModel): Promise<void> {
+    // Define follow id for lookups
+    const followId = message.body().user()?.fidArray() ?? new Uint8Array();
+
+    let tsx = await this.resolveMergeConflicts(this._db.transaction(), followId, message);
+
+    // No-op if resolveMergeConflicts did not return a transaction
+    if (!tsx) return undefined;
+
+    // Add putFollowAdd operations to the RocksDB transaction
+    tsx = this.putFollowAddTransaction(tsx, message);
+
+    // Commit the RocksDB transaction
+    return this._db.commit(tsx);
+  }
+
+  private async mergeRemove(message: FollowRemoveModel): Promise<void> {
+    // Define follow id for lookups
+    const followId = message.body().user()?.fidArray() ?? new Uint8Array();
+
+    let tsx = await this.resolveMergeConflicts(this._db.transaction(), followId, message);
+
+    // No-op if resolveMergeConflicts did not return a transaction
+    if (!tsx) return undefined;
+
+    // Add putFollowRemove operations to the RocksDB transaction
+    tsx = this.putFollowRemoveTransaction(tsx, message);
+
+    // Commit the RocksDB transaction
+    return this._db.commit(tsx);
+  }
+
+  private followMessageCompare(
+    aType: MessageType,
+    aTimestampHash: Uint8Array,
+    bType: MessageType,
+    bTimestampHash: Uint8Array
+  ): number {
+    const timestampHashOrder = bytesCompare(aTimestampHash, bTimestampHash);
+    if (timestampHashOrder !== 0) {
+      return timestampHashOrder;
+    }
+
+    if (aType === MessageType.FollowRemove && bType === MessageType.FollowAdd) {
+      return 1;
+    } else if (aType === MessageType.FollowAdd && bType === MessageType.FollowRemove) {
+      return -1;
+    }
+
+    return 0;
+  }
+
+  private async resolveMergeConflicts(
+    tsx: Transaction,
+    followId: Uint8Array,
+    message: FollowAddModel | FollowRemoveModel
+  ): Promise<Transaction | undefined> {
+    // Look up the remove timestampHash for this follow
+    const followRemoveTimestampHash = await ResultAsync.fromPromise(
+      this._db.get(FollowSet.followRemovesKey(message.fid(), followId)),
+      () => undefined
+    );
+
+    if (followRemoveTimestampHash.isOk()) {
+      if (
+        this.followMessageCompare(
+          MessageType.FollowRemove,
+          followRemoveTimestampHash.value,
+          message.type(),
+          message.timestampHash()
+        ) >= 0
+      ) {
+        // If the existing remove has the same or higher order than the new message, no-op
+        return undefined;
+      } else {
+        // If the existing remove has a lower order than the new message, retrieve the full
+        // FollowRemove message and delete it as part of the RocksDB transaction
+        const existingRemove = await MessageModel.get<FollowRemoveModel>(
+          this._db,
+          message.fid(),
+          UserPrefix.FollowMessage,
+          followRemoveTimestampHash.value
+        );
+        tsx = this.deleteFollowRemoveTransaction(tsx, existingRemove);
+      }
+    }
+
+    // Look up the add timestampHash for this follow
+    const followAddTimestampHash = await ResultAsync.fromPromise(
+      this._db.get(FollowSet.followAddsKey(message.fid(), followId)),
+      () => undefined
+    );
+
+    if (followAddTimestampHash.isOk()) {
+      if (
+        this.followMessageCompare(
+          MessageType.FollowAdd,
+          followAddTimestampHash.value,
+          message.type(),
+          message.timestampHash()
+        ) >= 0
+      ) {
+        // If the existing add has the same or higher order than the new message, no-op
+        return undefined;
+      } else {
+        // If the existing add has a lower order than the new message, retrieve the full
+        // FollowAdd message and delete it as part of the RocksDB transaction
+        const existingAdd = await MessageModel.get<FollowAddModel>(
+          this._db,
+          message.fid(),
+          UserPrefix.FollowMessage,
+          followAddTimestampHash.value
+        );
+        tsx = this.deleteFollowAddTransaction(tsx, existingAdd);
+      }
+    }
+
+    return tsx;
+  }
+
+  private putFollowAddTransaction(tsx: Transaction, message: FollowAddModel): Transaction {
+    // Put message and index by signer
+    tsx = MessageModel.putTransaction(tsx, message);
+
+    // Put followAdds index
+    tsx = tsx.put(
+      FollowSet.followAddsKey(message.fid(), message.body().user()?.fidArray() ?? new Uint8Array()),
+      Buffer.from(message.timestampHash())
+    );
+
+    // Index by user
+    tsx = tsx.put(
+      FollowSet.followsByUserKey(
+        message.body().user()?.fidArray() ?? new Uint8Array(),
+        message.fid(),
+        message.timestampHash()
+      ),
+      TRUE_VALUE
+    );
+
+    return tsx;
+  }
+
+  private deleteFollowAddTransaction(tsx: Transaction, message: FollowAddModel): Transaction {
+    // Delete from user index
+    tsx = tsx.del(
+      FollowSet.followsByUserKey(
+        message.body().user()?.fidArray() ?? new Uint8Array(),
+        message.fid(),
+        message.timestampHash()
+      )
+    );
+
+    // Delete from followAdds
+    tsx = tsx.del(FollowSet.followAddsKey(message.fid(), message.body().user()?.fidArray() ?? new Uint8Array()));
+
+    // Delete message
+    return MessageModel.deleteTransaction(tsx, message);
+  }
+
+  private putFollowRemoveTransaction(tsx: Transaction, message: FollowRemoveModel): Transaction {
+    // Add to db
+    tsx = MessageModel.putTransaction(tsx, message);
+
+    // Add to followRemoves
+    tsx = tsx.put(
+      FollowSet.followRemovesKey(message.fid(), message.body().user()?.fidArray() ?? new Uint8Array()),
+      Buffer.from(message.timestampHash())
+    );
+
+    return tsx;
+  }
+
+  private deleteFollowRemoveTransaction(tsx: Transaction, message: FollowRemoveModel): Transaction {
+    // Delete from followRemoves
+    tsx = tsx.del(FollowSet.followRemovesKey(message.fid(), message.body().user()?.fidArray() ?? new Uint8Array()));
+
+    // Delete message
+    return MessageModel.deleteTransaction(tsx, message);
+  }
+}
+
+export default FollowSet;

--- a/src/test/factories/flatbuffer.ts
+++ b/src/test/factories/flatbuffer.ts
@@ -9,6 +9,8 @@ import {
   CastRemoveBody,
   CastRemoveBodyT,
   FarcasterNetwork,
+  FollowBody,
+  FollowBodyT,
   HashScheme,
   Message,
   MessageBody,
@@ -127,6 +129,40 @@ const CastRemoveDataFactory = Factory.define<MessageDataT, any, MessageData>(({ 
   });
 });
 
+const FollowBodyFactory = Factory.define<FollowBodyT, any, FollowBody>(({ onCreate }) => {
+  onCreate((params) => {
+    const builder = new Builder();
+    builder.finish(params.pack(builder));
+    return FollowBody.getRootAsFollowBody(new ByteBuffer(builder.asUint8Array()));
+  });
+
+  return new FollowBodyT(UserIDFactory.build());
+});
+
+const FollowAddDataFactory = Factory.define<MessageDataT, any, MessageData>(({ onCreate }) => {
+  onCreate((params) => {
+    return MessageDataFactory.create(params);
+  });
+
+  return MessageDataFactory.build({
+    bodyType: MessageBody.FollowBody,
+    body: FollowBodyFactory.build(),
+    type: MessageType.FollowAdd,
+  });
+});
+
+const FollowRemoveDataFactory = Factory.define<MessageDataT, any, MessageData>(({ onCreate }) => {
+  onCreate((params) => {
+    return MessageDataFactory.create(params);
+  });
+
+  return MessageDataFactory.build({
+    bodyType: MessageBody.FollowBody,
+    body: FollowBodyFactory.build(),
+    type: MessageType.FollowRemove,
+  });
+});
+
 const ReactionBodyFactory = Factory.define<ReactionBodyT, any, ReactionBody>(({ onCreate }) => {
   onCreate((params) => {
     const builder = new Builder();
@@ -196,6 +232,9 @@ const Factories = {
   MessageData: MessageDataFactory,
   CastAddData: CastAddDataFactory,
   CastRemoveData: CastRemoveDataFactory,
+  FollowBody: FollowBodyFactory,
+  FollowAddData: FollowAddDataFactory,
+  FollowRemoveData: FollowRemoveDataFactory,
   Message: MessageFactory,
 };
 


### PR DESCRIPTION
## Motivation

Continuing to migrate sets over to flatbuffers. Original flatbuffers PR here: https://github.com/farcasterxyz/hub/pull/181

## Change Summary

* Add FollowSet version that uses flatbuffers
* Add FollowAddModel and FollowRemoveModel wrappers
* Index follows by user ID
* Add follow-related types to flatbuffers factories

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged
