### PR TITLE
chore: replace faker with faker-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage"
   },
   "devDependencies": {
+    "@faker-js/faker": "^7.6.0",
     "@libp2p/interface-mocks": "^7.0.1",
-    "@types/faker": "5.5.9",
     "@types/jest": "^29.0.2",
     "@types/node": "^18.7.6",
     "@types/pino": "^7.0.5",
@@ -71,7 +71,6 @@
     "commander": "^9.4.1",
     "ethereum-cryptography": "^1.1.2",
     "ethers": "^5.6.1",
-    "faker": "5.5.3",
     "flatbuffers": "^2.0.7",
     "jayson": "^4.0.0",
     "libp2p": "^0.39.5",

--- a/src/network/rpc/rpc.test.ts
+++ b/src/network/rpc/rpc.test.ts
@@ -23,13 +23,13 @@ import { Factories } from '~/test/factories';
 import { generateEd25519Signer, generateEthereumSigner } from '~/utils/crypto';
 import { RPCServer, RPCClient, RPCHandler } from '~/network/rpc';
 import Engine from '~/storage/engine';
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import { FarcasterError } from '~/utils/errors';
 import { Result } from 'neverthrow';
 import { multiaddr } from '@multiformats/multiaddr';
 
-const aliceFid = Faker.datatype.number();
+const aliceFid = faker.datatype.number();
 const testDb = jestRocksDB('rpc.test');
 const engine = new Engine(testDb);
 

--- a/src/network/sync/syncEngine.test.ts
+++ b/src/network/sync/syncEngine.test.ts
@@ -3,7 +3,7 @@ import Engine from '~/storage/engine';
 import { SyncEngine } from '~/network/sync/syncEngine';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import { mockFid } from '~/storage/engine/mock';
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { SyncId } from '~/network/sync/syncId';
 
 const testDb = jestRocksDB(`engine.syncEngine.test`);
@@ -18,7 +18,7 @@ describe('SyncEngine', () => {
   });
 
   test('trie is updated on successful merge', async () => {
-    const fid = Faker.datatype.number();
+    const fid = faker.datatype.number();
     const userInfo = await mockFid(engine, fid);
     const cast = await Factories.CastShort.create(
       { data: { fid: fid } },

--- a/src/storage/db/binaryrocksdb.test.ts
+++ b/src/storage/db/binaryrocksdb.test.ts
@@ -1,10 +1,10 @@
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { NotFoundError, RocksDBError } from '~/utils/errors';
 import RocksDB from '~/storage/db/binaryrocksdb';
 import { jestBinaryRocksDB } from './jestUtils';
 import { existsSync, mkdirSync, rmdirSync } from 'fs';
 
-const randomDbName = () => `rocksdb.test.${Faker.name.lastName().toLowerCase()}.${Faker.random.alphaNumeric(8)}`;
+const randomDbName = () => `rocksdb.test.${faker.name.lastName().toLowerCase()}.${faker.random.alphaNumeric(8)}`;
 
 describe('open', () => {
   describe('opens db and changes status', () => {

--- a/src/storage/db/cast.test.ts
+++ b/src/storage/db/cast.test.ts
@@ -1,4 +1,4 @@
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import CastDB from '~/storage/db/cast';
 import { Factories } from '~/test/factories';
 import { CastRecast, CastRemove, CastShort } from '~/types';
@@ -9,8 +9,8 @@ const rocks = jestRocksDB('db.cast.test');
 const db = new CastDB(rocks);
 
 /** Test data */
-const fid = Faker.datatype.number();
-const target = Faker.internet.url();
+const fid = faker.datatype.number();
+const target = faker.internet.url();
 
 let cast1: CastShort;
 let recast1: CastRecast;
@@ -18,7 +18,7 @@ let remove1: CastRemove;
 
 beforeAll(async () => {
   cast1 = await Factories.CastShort.create({
-    data: { fid, body: { parent: target, mentions: [Faker.datatype.number(), Faker.datatype.number()] } },
+    data: { fid, body: { parent: target, mentions: [faker.datatype.number(), faker.datatype.number()] } },
   });
   recast1 = await Factories.CastRecast.create({ data: { fid, body: { targetCastUri: target } } });
   remove1 = await Factories.CastRemove.create({ data: { fid, body: { targetHash: cast1.hash } } });

--- a/src/storage/db/message.test.ts
+++ b/src/storage/db/message.test.ts
@@ -1,4 +1,4 @@
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { Factories } from '~/test/factories';
 import { CastShort, Ed25519Signer, FollowAdd, MessageType } from '~/types';
 import { generateEd25519Signer } from '~/utils/crypto';
@@ -8,7 +8,7 @@ import { jestRocksDB } from '~/storage/db/jestUtils';
 const rocks = jestRocksDB('db.message.test');
 const db = new MessageDB(rocks);
 
-const fid = Faker.datatype.number();
+const fid = faker.datatype.number();
 
 /** Create sample data */
 let signer: Ed25519Signer;

--- a/src/storage/db/rocksdb.test.ts
+++ b/src/storage/db/rocksdb.test.ts
@@ -1,10 +1,10 @@
 import { existsSync, rmdirSync, mkdirSync } from 'fs';
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { NotFoundError, RocksDBError } from '~/utils/errors';
 import RocksDB from '~/storage/db/rocksdb';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 
-const randomDbName = () => `rocksdb.test.${Faker.name.lastName().toLowerCase()}`;
+const randomDbName = () => `rocksdb.test.${faker.name.lastName().toLowerCase()}`;
 
 describe('open', () => {
   describe('opens db and changes status', () => {

--- a/src/storage/engine/engine.cast.test.ts
+++ b/src/storage/engine/engine.cast.test.ts
@@ -1,4 +1,4 @@
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import Engine from '~/storage/engine';
 import { Factories } from '~/test/factories';
 import { Cast, CastShort, EthereumSigner, IdRegistryEvent, MessageSigner, SignerAdd, SignerRemove } from '~/types';
@@ -11,7 +11,7 @@ const rocksDb = jestRocksDB('engine.cast.test');
 const castDb = new CastDB(rocksDb);
 const engine = new Engine(rocksDb);
 
-const aliceFid = Faker.datatype.number();
+const aliceFid = faker.datatype.number();
 const aliceAdds = async () => new Set(await castDb.getCastAddsByUser(aliceFid));
 
 describe('mergeCast', () => {
@@ -44,7 +44,11 @@ describe('mergeCast', () => {
 
     removeDelegateSigner = await Factories.SignerRemove.create(
       {
-        data: { fid: aliceFid, body: { delegate: aliceDelegateSigner.signerKey } },
+        data: {
+          fid: aliceFid,
+          body: { delegate: aliceDelegateSigner.signerKey },
+          signedAt: addDelegateSigner.data.signedAt + 1,
+        },
       },
       { transient: { signer: aliceCustodySigner } }
     );
@@ -257,7 +261,7 @@ describe('mergeCast', () => {
 
       test('fails if meta is greater than 256 chars', async () => {
         const invalidCast = await Factories.CastShort.create(
-          { data: { fid: aliceFid, body: { meta: Faker.random.alphaNumeric(257) } } },
+          { data: { fid: aliceFid, body: { meta: faker.random.alphaNumeric(257) } } },
           { transient: { signer: aliceDelegateSigner } }
         );
         const result = await engine.mergeMessage(invalidCast);

--- a/src/storage/engine/engine.follow.test.ts
+++ b/src/storage/engine/engine.follow.test.ts
@@ -1,5 +1,5 @@
 import Engine from '~/storage/engine';
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { Factories } from '~/test/factories';
 import {
   Ed25519Signer,
@@ -19,7 +19,7 @@ import { BadRequestError } from '~/utils/errors';
 const testDb = jestRocksDB(`engine.follow.test`);
 const followDb = new FollowDB(testDb);
 const engine = new Engine(testDb);
-const aliceFid = Faker.datatype.number();
+const aliceFid = faker.datatype.number();
 
 describe('mergeFollow', () => {
   let aliceCustody: EthereumSigner;
@@ -49,7 +49,7 @@ describe('mergeFollow', () => {
     transientParams = { transient: { signer: aliceSigner } };
     follow = await Factories.FollowAdd.create({ data: { fid: aliceFid } }, transientParams);
     unfollow = await Factories.FollowRemove.create(
-      { data: { fid: aliceFid, body: { targetUri: follow.data.body.targetUri } } },
+      { data: { fid: aliceFid, body: { targetUri: follow.data.body.targetUri }, signedAt: follow.data.signedAt + 1 } },
       transientParams
     );
   });
@@ -104,7 +104,7 @@ describe('mergeFollow', () => {
       });
 
       test('fails if the signature is invalid', async () => {
-        const followInvalidSignature: Follow = { ...follow, signature: Faker.datatype.hexaDecimal(128) };
+        const followInvalidSignature: Follow = { ...follow, signature: faker.datatype.hexadecimal({ length: 128 }) };
         const res = await engine.mergeMessage(followInvalidSignature);
         expect(res.isOk()).toBe(false);
         expect(res._unsafeUnwrapErr()).toMatchObject(new BadRequestError('validateMessage: invalid signature'));

--- a/src/storage/engine/engine.mock.test.ts
+++ b/src/storage/engine/engine.mock.test.ts
@@ -1,5 +1,5 @@
 import Engine from '~/storage/engine';
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import { mockEvents, MockFCEvent, mockFid, populateEngine } from '~/storage/engine/mock';
 
@@ -17,7 +17,7 @@ describe('mock engine events', () => {
   test(
     'generates a pair of mock events of each type',
     async () => {
-      const fid = Faker.datatype.number();
+      const fid = faker.datatype.number();
       const user = await mockFid(engine, fid);
       const users = await engine.getUsers();
       expect(users.size).toEqual(1);

--- a/src/storage/engine/engine.reaction.test.ts
+++ b/src/storage/engine/engine.reaction.test.ts
@@ -1,4 +1,4 @@
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import ReactionDB from '~/storage/db/reaction';
 import Engine from '~/storage/engine';
@@ -17,7 +17,7 @@ import { generateEd25519Signer, generateEthereumSigner } from '~/utils/crypto';
 
 const testDb = jestRocksDB(`engine.reaction.test`);
 const engine = new Engine(testDb);
-const aliceFid = Faker.datatype.number();
+const aliceFid = faker.datatype.number();
 
 const reactionDb = new ReactionDB(testDb);
 const aliceAdds = async () => {

--- a/src/storage/engine/engine.revoke.test.ts
+++ b/src/storage/engine/engine.revoke.test.ts
@@ -1,4 +1,4 @@
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import CastDB from '~/storage/db/cast';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import SignerDB from '~/storage/db/signer';
@@ -20,7 +20,7 @@ import { generateEd25519Signer, generateEthereumSigner } from '~/utils/crypto';
 const testDb = jestRocksDB(`engine.revoke.test`);
 const engine = new Engine(testDb);
 
-const aliceFid = Faker.datatype.number();
+const aliceFid = faker.datatype.number();
 
 const signerDb = new SignerDB(testDb);
 const aliceCustodyAddress = async (): Promise<string> => {

--- a/src/storage/engine/engine.signer.test.ts
+++ b/src/storage/engine/engine.signer.test.ts
@@ -1,4 +1,4 @@
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { ResultAsync } from 'neverthrow';
 
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -11,7 +11,7 @@ import { generateEd25519Signer, generateEthereumSigner, hashFCObject } from '~/u
 
 const testDb = jestRocksDB(`engine.signer.test`);
 const engine = new Engine(testDb);
-const aliceFid = Faker.datatype.number();
+const aliceFid = faker.datatype.number();
 
 const signerDb = new SignerDB(testDb);
 const aliceCustodyAddress = async (): Promise<string> => {
@@ -44,7 +44,13 @@ describe('mergeSignerMessage', () => {
       { transient: { signer: aliceCustodySigner, delegateSigner: aliceDelegateSigner } }
     );
     aliceSignerRemoveDelegate = await Factories.SignerRemove.create(
-      { data: { fid: aliceFid, body: { delegate: aliceDelegateSigner.signerKey } } },
+      {
+        data: {
+          fid: aliceFid,
+          body: { delegate: aliceDelegateSigner.signerKey },
+          signedAt: aliceSignerAddDelegate.data.signedAt + 1,
+        },
+      },
       { transient: { signer: aliceCustodySigner } }
     );
   });
@@ -77,7 +83,7 @@ describe('mergeSignerMessage', () => {
     });
 
     test('fails when delegate is another custody address', async () => {
-      const ethAddress = Faker.datatype.hexaDecimal(32);
+      const ethAddress = faker.datatype.hexadecimal({ length: 32 });
       const addEthSigner = await Factories.SignerAdd.create(
         { data: { fid: aliceFid, body: { delegate: ethAddress } } },
         { transient: { signer: aliceCustodySigner } }

--- a/src/storage/engine/engine.verification.test.ts
+++ b/src/storage/engine/engine.verification.test.ts
@@ -13,7 +13,7 @@ import {
   CastShort,
   CastRecast,
 } from '~/types';
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { Wallet } from 'ethers';
 import { hashFCObject, generateEd25519Signer, generateEthereumSigner } from '~/utils/crypto';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -25,7 +25,7 @@ import SignerDB from '~/storage/db/signer';
 const testDb = jestRocksDB(`engine.verification.test`);
 const engine = new Engine(testDb);
 
-const aliceFid = Faker.datatype.number();
+const aliceFid = faker.datatype.number();
 
 const verificationDb = new VerificationDB(testDb);
 const aliceAdds = () => engine.getVerificationsByUser(aliceFid);
@@ -68,7 +68,7 @@ describe('mergeVerification', () => {
     );
     aliceEthWallet = Wallet.createRandom();
     transientParams = { transient: { signer: aliceSigner, ethWallet: aliceEthWallet } };
-    aliceBlockHash = Faker.datatype.hexaDecimal(64).toLowerCase();
+    aliceBlockHash = faker.datatype.hexadecimal({ length: 64 }).toLowerCase();
 
     const verificationClaim: VerificationEthereumAddressClaim = {
       fid: aliceFid,
@@ -286,7 +286,7 @@ describe('mergeVerification', () => {
           fid: aliceFid,
           body: {
             claimHash: aliceClaimHash,
-            blockHash: Faker.datatype.hexaDecimal(64).toLowerCase(),
+            blockHash: faker.datatype.hexadecimal({ length: 64 }).toLowerCase(),
             externalSignature: aliceExternalSignature,
           },
         },

--- a/src/storage/engine/mock.ts
+++ b/src/storage/engine/mock.ts
@@ -2,7 +2,7 @@ import { Ed25519Signer, EthereumSigner } from '~/types';
 import { Factories } from '~/test/factories';
 import { generateEd25519Signer, generateEthereumSigner } from '~/utils/crypto';
 import Engine from '~/storage/engine';
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 
 export type UserInfo = {
   fid: number;
@@ -35,7 +35,7 @@ export const populateEngine = async (
   }
 ) => {
   // create a list of users' credentials
-  const startFid = Faker.datatype.number();
+  const startFid = faker.datatype.number();
   const userInfos: UserInfo[] = await Promise.all(
     [...Array(users)].map(async (_value, index) => {
       return mockFid(engine, startFid + index);

--- a/src/storage/sets/castSet.test.ts
+++ b/src/storage/sets/castSet.test.ts
@@ -1,4 +1,4 @@
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { Factories } from '~/test/factories';
 import CastSet from '~/storage/sets/castSet';
 import { CastRecast, CastRemove, CastShort } from '~/types';
@@ -8,7 +8,7 @@ import CastDB from '~/storage/db/cast';
 const rocksDb = jestRocksDB('castSet.test');
 const testDb = new CastDB(rocksDb);
 
-const fid = Faker.datatype.number();
+const fid = faker.datatype.number();
 const set = new CastSet(rocksDb);
 
 const getCastAdds = async () => {
@@ -266,7 +266,7 @@ describe('merge', () => {
         const castRemove1Later = {
           ...castRemove1,
           data: { ...castRemove1.data, signedAt: castRemove1.data.signedAt + 1 },
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
         };
         await set.merge(castRemove1);
         await expect(set.merge(castRemove1Later)).resolves.toEqual(undefined);

--- a/src/storage/sets/followSet.test.ts
+++ b/src/storage/sets/followSet.test.ts
@@ -1,5 +1,5 @@
 import { Factories } from '~/test/factories';
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import FollowSet from '~/storage/sets/followSet';
 import { Ed25519Signer, Follow, FollowAdd, FollowRemove, URI } from '~/types';
 import { generateEd25519Signer } from '~/utils/crypto';
@@ -11,7 +11,7 @@ const testDb = jestRocksDB('followSet.test');
 const followDb = new FollowDB(testDb);
 const set = new FollowSet(testDb);
 
-const fid = Faker.datatype.number();
+const fid = faker.datatype.number();
 
 const follows = async (): Promise<Set<FollowAdd>> => {
   const followAdds = await followDb.getFollowAddsByUser(fid);
@@ -32,13 +32,13 @@ let unfollowB: Follow;
 
 beforeAll(async () => {
   signer = await generateEd25519Signer();
-  a = Faker.internet.url();
+  a = faker.internet.url();
   followA = await Factories.FollowAdd.create({ data: { fid, body: { targetUri: a } } }, { transient: { signer } });
   unfollowA = await Factories.FollowRemove.create(
     { data: { fid, body: { targetUri: a }, signedAt: followA.data.signedAt + 1 } },
     { transient: { signer } }
   );
-  b = Faker.internet.url();
+  b = faker.internet.url();
   followB = await Factories.FollowAdd.create({ data: { fid, body: { targetUri: b } } }, { transient: { signer } });
   unfollowB = await Factories.FollowRemove.create(
     { data: { fid, body: { targetUri: b }, signedAt: followB.data.signedAt + 1 } },
@@ -105,7 +105,7 @@ describe('merge', () => {
       test('succeeds with later timestamp', async () => {
         const followALater: FollowAdd = {
           ...followA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...followA.data, signedAt: followA.data.signedAt + 1 },
         };
         await expect(set.merge(followALater)).resolves.toEqual(undefined);
@@ -116,7 +116,7 @@ describe('merge', () => {
       test('succeeds (no-op) with earlier timestamp', async () => {
         const followAEarlier: FollowAdd = {
           ...followA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...followA.data, signedAt: followA.data.signedAt - 1 },
         };
         await expect(set.merge(followAEarlier)).resolves.toEqual(undefined);
@@ -149,7 +149,7 @@ describe('merge', () => {
       test('succeeds with later timestamp', async () => {
         const followALater: FollowAdd = {
           ...followA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...followA.data, signedAt: unfollowA.data.signedAt + 1 },
         };
         await expect(set.merge(followALater)).resolves.toEqual(undefined);
@@ -160,7 +160,7 @@ describe('merge', () => {
       test('succeeds (no-op) with earlier timestamp', async () => {
         const followAEarlier: FollowAdd = {
           ...followA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...followA.data, signedAt: unfollowA.data.signedAt - 1 },
         };
         await expect(set.merge(followAEarlier)).resolves.toEqual(undefined);
@@ -171,7 +171,7 @@ describe('merge', () => {
       test('succeeds (no-op) with same timestamp', async () => {
         const followASameTimestamp: FollowAdd = {
           ...followA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...followA.data, signedAt: unfollowA.data.signedAt },
         };
         await expect(set.merge(followASameTimestamp)).resolves.toEqual(undefined);
@@ -216,7 +216,7 @@ describe('merge', () => {
       test('succeeds (no-op) with earlier timestamp', async () => {
         const unfollowAEarlier: FollowRemove = {
           ...unfollowA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...unfollowA.data, signedAt: followA.data.signedAt - 1 },
         };
         await expect(set.merge(unfollowAEarlier)).resolves.toEqual(undefined);
@@ -227,7 +227,7 @@ describe('merge', () => {
       test('succeeds with same timestamp', async () => {
         const unfollowASameTimestamp: FollowRemove = {
           ...unfollowA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...unfollowA.data, signedAt: followA.data.signedAt },
         };
         await expect(set.merge(unfollowASameTimestamp)).resolves.toEqual(undefined);
@@ -244,7 +244,7 @@ describe('merge', () => {
       test('succeeds with later timestamp', async () => {
         const unfollowALater: FollowRemove = {
           ...unfollowA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...unfollowA.data, signedAt: unfollowA.data.signedAt + 1 },
         };
         await expect(set.merge(unfollowALater)).resolves.toEqual(undefined);
@@ -255,7 +255,7 @@ describe('merge', () => {
       test('succeeds (no-op) with earlier timestamp', async () => {
         const unfollowAEarlier: FollowRemove = {
           ...unfollowA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...unfollowA.data, signedAt: unfollowA.data.signedAt - 1 },
         };
         await expect(set.merge(unfollowAEarlier)).resolves.toEqual(undefined);

--- a/src/storage/sets/reactionSet.test.ts
+++ b/src/storage/sets/reactionSet.test.ts
@@ -1,4 +1,4 @@
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import ReactionDB from '~/storage/db/reaction';
 import { BadRequestError, NotFoundError } from '~/utils/errors';
@@ -10,7 +10,7 @@ const testDb = jestRocksDB('reactionSet.test');
 const reactionDb = new ReactionDB(testDb);
 const set = new ReactionSet(testDb);
 
-const fid = Faker.datatype.number();
+const fid = faker.datatype.number();
 
 const reactionAdds = async (): Promise<Set<ReactionAdd>> => {
   const adds = await reactionDb.getReactionAddsByUser(fid);
@@ -28,12 +28,12 @@ let b: URI;
 let addB: ReactionAdd;
 
 beforeAll(async () => {
-  a = Faker.internet.url();
+  a = faker.internet.url();
   addA = await Factories.ReactionAdd.create({ data: { fid, body: { targetUri: a } } });
   remA = await Factories.ReactionRemove.create({
     data: { fid, body: { targetUri: a }, signedAt: addA.data.signedAt + 1 },
   });
-  b = Faker.internet.url();
+  b = faker.internet.url();
   addB = await Factories.ReactionAdd.create({ data: { fid, body: { targetUri: b } } });
 });
 
@@ -95,7 +95,7 @@ describe('merge', () => {
       test('succeeds with a later timestamp', async () => {
         const addALater: ReactionAdd = {
           ...addA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...addA.data, signedAt: addA.data.signedAt + 1 },
         };
         await expect(set.merge(addALater)).resolves.toEqual(undefined);
@@ -106,7 +106,7 @@ describe('merge', () => {
       test('succeeds (no-ops) with an earlier timestamp', async () => {
         const addAEarlier: ReactionAdd = {
           ...addA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...addA.data, signedAt: addA.data.signedAt - 1 },
         };
         await expect(set.merge(addAEarlier)).resolves.toEqual(undefined);
@@ -139,7 +139,7 @@ describe('merge', () => {
       test('succeeds with a later timestamp', async () => {
         const addALater: ReactionAdd = {
           ...addA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...addA.data, signedAt: remA.data.signedAt + 1 },
         };
         await expect(set.merge(addALater)).resolves.toEqual(undefined);
@@ -156,7 +156,7 @@ describe('merge', () => {
       test('succeeds (no-ops) with the same timestamp', async () => {
         const addASameTimestamp: ReactionAdd = {
           ...addA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...addA.data, signedAt: remA.data.signedAt },
         };
         await expect(set.merge(addASameTimestamp)).resolves.toEqual(undefined);
@@ -195,7 +195,7 @@ describe('merge', () => {
       test('succeeds with a later timestamp', async () => {
         const remALater: ReactionRemove = {
           ...remA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...remA.data, signedAt: remA.data.signedAt + 1 },
         };
         await expect(set.merge(remALater)).resolves.toEqual(undefined);
@@ -206,7 +206,7 @@ describe('merge', () => {
       test('succeeds (no-ops) with an earlier timestamp', async () => {
         const remAEarlier: ReactionRemove = {
           ...remA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...remA.data, signedAt: remA.data.signedAt - 1 },
         };
         await expect(set.merge(remAEarlier)).resolves.toEqual(undefined);
@@ -245,7 +245,7 @@ describe('merge', () => {
       test('succeeds (no-ops) with an earlier timestamp', async () => {
         const remAEarlier: ReactionRemove = {
           ...remA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...remA.data, signedAt: addA.data.signedAt - 1 },
         };
         await expect(set.merge(remAEarlier)).resolves.toEqual(undefined);
@@ -256,7 +256,7 @@ describe('merge', () => {
       test('succeeds with the same timestamp', async () => {
         const remASameTimestamp: ReactionRemove = {
           ...remA,
-          hash: Faker.datatype.hexaDecimal(128),
+          hash: faker.datatype.hexadecimal({ length: 128 }),
           data: { ...remA.data, signedAt: addA.data.signedAt },
         };
         await expect(set.merge(remASameTimestamp)).resolves.toEqual(undefined);

--- a/src/storage/sets/signerSet.test.ts
+++ b/src/storage/sets/signerSet.test.ts
@@ -1,4 +1,4 @@
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { SignerAdd, SignerRemove, EthereumSigner, Ed25519Signer, IdRegistryEvent } from '~/types';
 import SignerSet, { SignerSetEvents } from '~/storage/sets/signerSet';
 import { Factories } from '~/test/factories';
@@ -10,7 +10,7 @@ import SignerDB from '~/storage/db/signer';
 const rocksDb = jestRocksDB('signerSet.test');
 const testDb = new SignerDB(rocksDb);
 
-const fid = Faker.datatype.number();
+const fid = faker.datatype.number();
 const set = new SignerSet(rocksDb);
 
 const custodyAddress = () => set.getCustodyAddress(fid);
@@ -60,12 +60,12 @@ beforeAll(async () => {
   a = await generateEd25519Signer();
   addATo1 = await Factories.SignerAdd.create({ data: { fid } }, { transient: { signer: custody1, delegateSigner: a } });
   remAFrom1 = await Factories.SignerRemove.create(
-    { data: { fid, body: { delegate: a.signerKey } } },
+    { data: { fid, body: { delegate: a.signerKey }, signedAt: addATo1.data.signedAt + 1 } },
     { transient: { signer: custody1 } }
   );
   addATo2 = await Factories.SignerAdd.create({ data: { fid } }, { transient: { signer: custody2, delegateSigner: a } });
   remAFrom2 = await Factories.SignerRemove.create(
-    { data: { fid, body: { delegate: a.signerKey } } },
+    { data: { fid, body: { delegate: a.signerKey }, signedAt: addATo2.data.signedAt + 1 } },
     { transient: { signer: custody2 } }
   );
   b = await generateEd25519Signer();
@@ -213,7 +213,7 @@ describe('mergeIdRegistryEvent', () => {
     });
 
     test('succeeds if a custody is registered to another fid', async () => {
-      const fid2 = Faker.datatype.number();
+      const fid2 = faker.datatype.number();
       const custody2Register = await Factories.IdRegistryEvent.create(
         { args: { to: custody2.signerKey, id: fid2 } },
         {}
@@ -584,7 +584,7 @@ describe('merge', () => {
         test('succeeds with later timestamp', async () => {
           const addALater: SignerAdd = {
             ...addATo1,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...addATo1.data, signedAt: addATo1.data.signedAt + 1 },
           };
           await expect(set.merge(addALater)).resolves.toEqual(undefined);
@@ -603,7 +603,7 @@ describe('merge', () => {
         test('succeeds (no-ops) with earlier timestamp', async () => {
           const addAEarlier: SignerAdd = {
             ...addATo1,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...addATo1.data, signedAt: addATo1.data.signedAt - 1 },
           };
           await expect(set.merge(addAEarlier)).resolves.toEqual(undefined);
@@ -659,7 +659,7 @@ describe('merge', () => {
         test('succeeds and emits addSigner if SignerAdd is later than remove', async () => {
           const addATo2Later: SignerAdd = {
             ...addATo2,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...addATo2.data, signedAt: remAFrom1.data.signedAt + 1 },
           };
 
@@ -683,7 +683,7 @@ describe('merge', () => {
         test('succeeds and emits addSigner if SingerAdd is earlier than remove', async () => {
           const addATo2Earlier: SignerAdd = {
             ...addATo2,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...addATo2.data, signedAt: remAFrom1.data.signedAt - 1 },
           };
 
@@ -714,7 +714,7 @@ describe('merge', () => {
         test('succeeds if the signerAdd is earlier (but does not emit addSigner)', async () => {
           const addATo1Earlier: SignerAdd = {
             ...addATo1,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...addATo1.data, signedAt: remAFrom2.data.signedAt + 1 },
           };
 
@@ -738,7 +738,7 @@ describe('merge', () => {
         test('succeeds if the SignerAdd is later (but does not emit addSigner)', async () => {
           const addATo1Later: SignerAdd = {
             ...addATo1,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...addATo1.data, signedAt: remAFrom2.data.signedAt + 1 },
           };
 
@@ -768,7 +768,7 @@ describe('merge', () => {
         test('succeeds with later timestamp', async () => {
           const addALater: SignerAdd = {
             ...addATo1,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...addATo1.data, signedAt: remAFrom1.data.signedAt + 1 },
           };
           await expect(set.merge(addALater)).resolves.toEqual(undefined);
@@ -787,7 +787,7 @@ describe('merge', () => {
         test('succeeds (no-ops) with earlier timestamp', async () => {
           const addAEarlier: SignerAdd = {
             ...addATo1,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...addATo1.data, signedAt: remAFrom1.data.signedAt - 1 },
           };
           await expect(set.merge(addAEarlier)).resolves.toEqual(undefined);
@@ -805,7 +805,7 @@ describe('merge', () => {
         test('succeeds (no-ops) with the same timestamp', async () => {
           const addASameTimestamp: SignerAdd = {
             ...addATo1,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...addATo1.data, signedAt: remAFrom1.data.signedAt },
           };
           await expect(set.merge(addASameTimestamp)).resolves.toEqual(undefined);
@@ -938,7 +938,7 @@ describe('merge', () => {
         test('succeeds if the SignerRemove is later', async () => {
           const remAFrom2Later: SignerRemove = {
             ...remAFrom2,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...remAFrom2.data, signedAt: addATo1.data.signedAt + 1 },
           };
 
@@ -962,7 +962,7 @@ describe('merge', () => {
         test('succeeds if the SignerRemove is earlier', async () => {
           const remAFrom2Earlier: SignerRemove = {
             ...remAFrom2,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...remAFrom2.data, signedAt: addATo1.data.signedAt - 1 },
           };
 
@@ -993,7 +993,7 @@ describe('merge', () => {
         test('succeeds but does not emit removeSigner event if the SignerRemove is earlier', async () => {
           const remAFrom2Earlier: SignerRemove = {
             ...remAFrom1,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...remAFrom1.data, signedAt: addATo2.data.signedAt - 1 },
           };
 
@@ -1017,7 +1017,7 @@ describe('merge', () => {
         test('succeeds but does not emit removeSigner event if the SignerRemove is later', async () => {
           const remAFrom2Later: SignerRemove = {
             ...remAFrom1,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...remAFrom1.data, signedAt: addATo2.data.signedAt + 1 },
           };
 
@@ -1061,7 +1061,7 @@ describe('merge', () => {
         test('succeeds (no-ops) with earlier timestamp', async () => {
           const remAEarlier: SignerRemove = {
             ...remAFrom1,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...remAFrom1.data, signedAt: addATo1.data.signedAt - 1 },
           };
           await expect(set.merge(remAEarlier)).resolves.toEqual(undefined);
@@ -1079,7 +1079,7 @@ describe('merge', () => {
         test('succeeds with the same timestamp', async () => {
           const remASameTimestamp: SignerRemove = {
             ...remAFrom1,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...remAFrom1.data, signedAt: addATo1.data.signedAt },
           };
           await expect(set.merge(remASameTimestamp)).resolves.toEqual(undefined);
@@ -1148,7 +1148,7 @@ describe('merge', () => {
         test('succeeds with later timestamp', async () => {
           const remALater: SignerRemove = {
             ...remAFrom1,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...remAFrom1.data, signedAt: remAFrom1.data.signedAt + 1 },
           };
           await expect(set.merge(remALater)).resolves.toEqual(undefined);
@@ -1167,7 +1167,7 @@ describe('merge', () => {
         test('succeeds (no-ops) with earlier timestamp', async () => {
           const remAEarlier: SignerRemove = {
             ...remAFrom1,
-            hash: Faker.datatype.hexaDecimal(128),
+            hash: faker.datatype.hexadecimal({ length: 128 }),
             data: { ...remAFrom1.data, signedAt: remAFrom1.data.signedAt - 1 },
           };
           await expect(set.merge(remAEarlier)).resolves.toEqual(undefined);

--- a/src/storage/sets/verificationSet.test.ts
+++ b/src/storage/sets/verificationSet.test.ts
@@ -1,5 +1,5 @@
 import { Factories } from '~/test/factories';
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import VerificationSet from '~/storage/sets/verificationSet';
 import {
   Ed25519Signer,
@@ -18,7 +18,7 @@ const testDb = jestRocksDB('verificationSet.test');
 const verificationDb = new VerificationDB(testDb);
 const set = new VerificationSet(testDb);
 
-const fid = Faker.datatype.number();
+const fid = faker.datatype.number();
 
 const adds = async (): Promise<Set<VerificationEthereumAddress>> => {
   const verificationAdds = await verificationDb.getVerificationAddsByUser(fid);

--- a/src/test/e2e/hub.test.ts
+++ b/src/test/e2e/hub.test.ts
@@ -1,4 +1,4 @@
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { AddressInfo } from 'net';
 import { generateUserInfo, getIdRegistryEvent, getSignerAdd, mockFid, populateEngine } from '~/storage/engine/mock';
 import { Factories } from '~/test/factories';
@@ -61,7 +61,7 @@ describe('Hub running tests', () => {
     const rpcClient = new RPCClient(hub.rpcAddress as AddressInfo);
 
     // simulate custody events for alice
-    const aliceFid = Faker.datatype.number();
+    const aliceFid = faker.datatype.number();
     const aliceInfo = await mockFid(hub.engine, aliceFid);
     const cast = await Factories.CastShort.create(
       { data: { fid: aliceFid } },
@@ -121,7 +121,7 @@ describe('Hub running tests', () => {
   };
 
   test('hub handles various valid gossip messages', async () => {
-    const aliceFid = Faker.datatype.number();
+    const aliceFid = faker.datatype.number();
     const aliceInfo = await generateUserInfo(aliceFid);
     const IdRegistryEvent: GossipMessage<Content> = {
       content: {

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -1,5 +1,5 @@
 import { Factory } from 'fishery';
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { ethers } from 'ethers';
 import {
   CastShort,
@@ -82,15 +82,15 @@ const UserURLFactory = Factory.define<UserURL, { fid: number }, UserURL>(({ tran
 
 const EthereumAddressURLFactory = Factory.define<ChainAccountURL, EthAddressUrlFactoryTransientParams, ChainAccountURL>(
   ({ transientParams }) => {
-    const address = transientParams.address || Faker.datatype.hexaDecimal(32).toLowerCase();
+    const address = transientParams.address || faker.datatype.hexadecimal({ length: 32 }).toLowerCase();
     return new ChainAccountURL(new AccountId(`eip155:1:${address}`));
   }
 );
 
 const CastURLFactory = Factory.define<CastURL, { cast: Cast }, CastURL>(({ transientParams }) => {
   const { cast } = transientParams;
-  const fid = cast ? cast.data.fid : Faker.datatype.number();
-  const hash = cast ? cast.hash : Faker.datatype.hexaDecimal(128).toLowerCase();
+  const fid = cast ? cast.data.fid : faker.datatype.number();
+  const hash = cast ? cast.hash : faker.datatype.hexadecimal({ length: 128 }).toLowerCase();
   return new CastURL(new CastId(`fid:${fid}/cast:${hash}`));
 });
 
@@ -111,12 +111,12 @@ export const Factories = {
     return {
       data: {
         body: {
-          embeds: [Faker.internet.url(), Faker.internet.url()],
-          text: Faker.lorem.sentence(2),
-          mentions: [Faker.datatype.number()],
+          embeds: [faker.internet.url(), faker.internet.url()],
+          text: faker.lorem.sentence(2),
+          mentions: [faker.datatype.number()],
         },
-        signedAt: Faker.time.recent(),
-        fid: Faker.datatype.number(),
+        signedAt: faker.date.recent().getTime(),
+        fid: faker.datatype.number(),
         type: MessageType.CastShort,
         network: FarcasterNetwork.Testnet,
       },
@@ -137,10 +137,10 @@ export const Factories = {
     return {
       data: {
         body: {
-          targetHash: Faker.datatype.hexaDecimal(128).toLowerCase(),
+          targetHash: faker.datatype.hexadecimal({ length: 128 }).toLowerCase(),
         },
-        signedAt: Faker.time.recent(),
-        fid: Faker.datatype.number(),
+        signedAt: faker.date.recent().getTime(),
+        fid: faker.datatype.number(),
         type: MessageType.CastRemove,
         network: FarcasterNetwork.Testnet,
       },
@@ -163,8 +163,8 @@ export const Factories = {
         body: {
           targetCastUri: CastURLFactory.build().toString(),
         },
-        signedAt: Faker.time.recent(),
-        fid: Faker.datatype.number(),
+        signedAt: faker.date.recent().getTime(),
+        fid: faker.datatype.number(),
         type: MessageType.CastRecast,
         network: FarcasterNetwork.Testnet,
       },
@@ -186,11 +186,11 @@ export const Factories = {
       return {
         data: {
           body: {
-            targetUri: Faker.internet.url(),
+            targetUri: faker.internet.url(),
             type: 'like',
           },
-          signedAt: Faker.time.recent(),
-          fid: Faker.datatype.number(),
+          signedAt: faker.date.recent().getTime(),
+          fid: faker.datatype.number(),
           type: MessageType.ReactionAdd,
           network: FarcasterNetwork.Testnet,
         },
@@ -213,11 +213,11 @@ export const Factories = {
       return {
         data: {
           body: {
-            targetUri: Faker.internet.url(),
+            targetUri: faker.internet.url(),
             type: 'like',
           },
-          signedAt: Faker.time.recent(),
-          fid: Faker.datatype.number(),
+          signedAt: faker.date.recent().getTime(),
+          fid: faker.datatype.number(),
           type: MessageType.ReactionRemove,
           network: FarcasterNetwork.Testnet,
         },
@@ -241,8 +241,8 @@ export const Factories = {
         body: {
           targetUri: UserURLFactory.build().toString(),
         },
-        signedAt: Faker.time.recent(),
-        fid: Faker.datatype.number(),
+        signedAt: faker.date.recent().getTime(),
+        fid: faker.datatype.number(),
         type: MessageType.FollowAdd,
         network: FarcasterNetwork.Testnet,
       },
@@ -266,8 +266,8 @@ export const Factories = {
           body: {
             targetUri: UserURLFactory.build().toString(),
           },
-          signedAt: Faker.time.recent(),
-          fid: Faker.datatype.number(),
+          signedAt: faker.date.recent().getTime(),
+          fid: faker.datatype.number(),
           type: MessageType.FollowRemove,
           network: FarcasterNetwork.Testnet,
         },
@@ -288,13 +288,13 @@ export const Factories = {
 
     return {
       args: {
-        to: Faker.datatype.hexaDecimal(32).toLowerCase(),
-        id: Faker.datatype.number(),
+        to: faker.datatype.hexadecimal({ length: 32 }).toLowerCase(),
+        id: faker.datatype.number(),
       },
-      blockNumber: Faker.datatype.number(10_000),
-      blockHash: Faker.datatype.hexaDecimal(64).toLowerCase(),
-      transactionHash: Faker.datatype.hexaDecimal(64).toLowerCase(),
-      logIndex: Faker.datatype.number(),
+      blockNumber: faker.datatype.number(10_000),
+      blockHash: faker.datatype.hexadecimal({ length: 64 }).toLowerCase(),
+      transactionHash: faker.datatype.hexadecimal({ length: 64 }).toLowerCase(),
+      logIndex: faker.datatype.number(),
       name: 'Register',
     };
   }),
@@ -314,8 +314,8 @@ export const Factories = {
           body: {
             delegate: '',
           },
-          signedAt: Faker.time.recent(),
-          fid: Faker.datatype.number(),
+          signedAt: faker.date.recent().getTime(),
+          fid: faker.datatype.number(),
           type: MessageType.SignerAdd,
           network: FarcasterNetwork.Testnet,
         },
@@ -343,8 +343,8 @@ export const Factories = {
           body: {
             delegate: '',
           },
-          signedAt: Faker.time.recent(),
-          fid: Faker.datatype.number(),
+          signedAt: faker.date.recent().getTime(),
+          fid: faker.datatype.number(),
           type: MessageType.SignerRemove,
           network: FarcasterNetwork.Testnet,
         },
@@ -392,12 +392,12 @@ export const Factories = {
             transient: { address: ethWallet.address },
           }).toString(),
           claimHash: '',
-          blockHash: Faker.datatype.hexaDecimal(64).toLowerCase(),
+          blockHash: faker.datatype.hexadecimal({ length: 64 }).toLowerCase(),
           externalSignature: '',
           externalSignatureType: SignatureAlgorithm.EthereumPersonalSign,
         },
-        signedAt: Faker.time.recent(),
-        fid: Faker.datatype.number(),
+        signedAt: faker.date.recent().getTime(),
+        fid: faker.datatype.number(),
         type: MessageType.VerificationEthereumAddress,
         network: FarcasterNetwork.Testnet,
       },
@@ -419,10 +419,10 @@ export const Factories = {
       return {
         data: {
           body: {
-            claimHash: Faker.datatype.hexaDecimal(128).toLowerCase(),
+            claimHash: faker.datatype.hexadecimal({ length: 128 }).toLowerCase(),
           },
-          signedAt: Faker.time.recent(),
-          fid: Faker.datatype.number(),
+          signedAt: faker.date.recent().getTime(),
+          fid: faker.datatype.number(),
           type: MessageType.VerificationRemove,
           network: FarcasterNetwork.Testnet,
         },

--- a/src/test/factories/flatbuffer.ts
+++ b/src/test/factories/flatbuffer.ts
@@ -1,5 +1,5 @@
 import { Factory } from 'fishery';
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { KeyPair } from '~/types';
 import {
   CastAddBody,
@@ -33,13 +33,13 @@ import { arrayify } from 'ethers/lib/utils';
 
 const FIDFactory = Factory.define<Uint8Array>(() => {
   // TODO: generate larger random fid
-  return new Uint8Array([Faker.datatype.number(255)]);
+  return new Uint8Array([faker.datatype.number(255)]);
 });
 
 const TimestampHashFactory = Factory.define<Uint8Array>(() => {
   const builder = new Builder();
-  builder.addInt32(Faker.time.recent());
-  const hash = arrayify(Faker.datatype.hexaDecimal(4).toLowerCase());
+  builder.addInt32(faker.date.recent().getTime());
+  const hash = arrayify(faker.datatype.hexadecimal({ length: 4 }).toLowerCase());
   return new Uint8Array([...builder.asUint8Array(), ...hash]);
 });
 
@@ -74,7 +74,7 @@ const MessageDataFactory = Factory.define<MessageDataT, any, MessageData>(({ onC
     MessageBody.CastAddBody,
     CastAddBodyFactory.build(),
     MessageType.CastAdd,
-    Faker.time.recent(),
+    faker.date.recent().getTime(),
     Array.from(FIDFactory.build()),
     FarcasterNetwork.Testnet
   );
@@ -88,10 +88,10 @@ const CastAddBodyFactory = Factory.define<CastAddBodyT, any, CastAddBody>(({ onC
   });
 
   return new CastAddBodyT(
-    [Faker.internet.url(), Faker.internet.url()],
+    [faker.internet.url(), faker.internet.url()],
     [UserIDFactory.build(), UserIDFactory.build(), UserIDFactory.build()],
     CastIDFactory.build(),
-    Faker.lorem.sentence(4)
+    faker.lorem.sentence(4)
   );
 });
 

--- a/src/test/perf/setup.ts
+++ b/src/test/perf/setup.ts
@@ -1,6 +1,6 @@
 import { RPCClient } from '~/network/rpc';
 import { logger } from '~/utils/logger';
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import { IdRegistryEvent, SignerAdd } from '~/types';
 import { generateUserInfo, getSignerAdd, UserInfo, getIdRegistryEvent } from '~/storage/engine/mock';
 import { submitInBatches, post } from '~/test/perf/utils';
@@ -33,7 +33,7 @@ export const setupNetwork = async (rpcClients: RPCClient[], config: SetupConfig)
 
   // generate users
   logger.info(`Generating IdRegistry events for ${config.users} users.`);
-  const firstUser = Faker.datatype.number();
+  const firstUser = faker.datatype.number();
   const idRegistryEvents: IdRegistryEvent[] = [];
   const signerAddEvents: SignerAdd[] = [];
   let start = performance.now();

--- a/src/utils/crypto.test.ts
+++ b/src/utils/crypto.test.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers';
-import Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import * as ed from '@noble/ed25519';
 import { hashFCObject, hashCompare, generateEthereumSigner, generateEd25519Signer, convertToHex } from '~/utils/crypto';
 import { Ed25519Signer, EthereumSigner } from '~/types';
@@ -134,14 +134,14 @@ describe('generateEthereumSigner', () => {
   });
 
   test('text can be signed and verified', async () => {
-    const text = Faker.lorem.sentence(2);
+    const text = faker.lorem.sentence(2);
     const signature = await signer.wallet.signMessage(text);
     const recoveredAddress = await ethers.utils.verifyMessage(text, signature);
     expect(recoveredAddress.toLowerCase()).toEqual(signer.signerKey);
   });
 
   test('hex can be signed and verified', async () => {
-    const hex = Faker.datatype.hexaDecimal(40);
+    const hex = faker.datatype.hexadecimal({ length: 40 });
     const signature = await signer.wallet.signMessage(hex);
     const recoveredAddress = await ethers.utils.verifyMessage(hex, signature);
     expect(recoveredAddress.toLowerCase()).toEqual(signer.signerKey);
@@ -162,14 +162,14 @@ describe('generateEd25519Signer', () => {
   });
 
   test('text can be signed and verified', async () => {
-    const text = Faker.lorem.sentence(2);
+    const text = faker.lorem.sentence(2);
     const signature = await ed.sign(utf8ToBytes(text), signer.privateKey);
     const isValid = await ed.verify(signature, utf8ToBytes(text), hexToBytes(signer.signerKey));
     expect(isValid).toBe(true);
   });
 
   test('hex can be signed and verified', async () => {
-    const hex = Faker.datatype.hexaDecimal(40);
+    const hex = faker.datatype.hexadecimal({ length: 40 });
     const signature = await ed.sign(hexToBytes(hex), signer.privateKey);
     const isValid = await ed.verify(signature, hexToBytes(hex), hexToBytes(signer.signerKey));
     expect(isValid).toBe(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -781,6 +781,11 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@faker-js/faker@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.6.0.tgz#9ea331766084288634a9247fcd8b84f16ff4ba07"
+  integrity sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==
+
 "@humanwhocodes/config-array@^0.10.5":
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.5.tgz#bb679745224745fff1e9a41961c1d45a49f81c04"
@@ -1963,11 +1968,6 @@
   integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
   dependencies:
     "@types/node" "*"
-
-"@types/faker@5.5.9":
-  version "5.5.9"
-  resolved "https://registry.yarnpkg.com/@types/faker/-/faker-5.5.9.tgz#588ede92186dc557bff8341d294335d50d255f0c"
-  integrity sha512-uCx6mP3UY5SIO14XlspxsGjgaemrxpssJI0Ol+GfhxtcKpv9pgRZYsS4eeKeHVLje6Qtc8lGszuBI461+gVZBA==
 
 "@types/graceful-fs@^4.1.3":
   version "4.1.5"
@@ -3255,11 +3255,6 @@ eyes@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
   integrity sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==
-
-faker@5.5.3:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
-  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
 fast-copy@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Motivation

`faker` is a deprecated npm module that may be also responsible for other issues with deploys, so we're replacing with `faker-js` which is a more maintained implementation

## Change Summary

- `faker` was swapped in place for `faker-js` which mostly just worked with some API changes. 
- `signedAt` for some messages had to be explicitly set since `faker.date.recent().getTime()` works different from `faker.time.recent()`

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
