### PR TITLE
feat: Handle message deletion in diff sync

### DIFF
--- a/src/hub.ts
+++ b/src/hub.ts
@@ -294,7 +294,7 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
     return this.engine.getCustodyEventByUser(fid);
   }
   getSyncMetadataByPrefix(prefix: string): Promise<Result<NodeMetadata, FarcasterError>> {
-    const nodeMetadata = this.syncEngine.getNodeMetadata(prefix);
+    const nodeMetadata = this.syncEngine.getTrieNodeMetadata(prefix);
     if (nodeMetadata) {
       return Promise.resolve(ok(nodeMetadata));
     } else {

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -202,7 +202,7 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
       log.debug(`Already syncing, skipping sync`);
       return;
     }
-    if (!this.syncEngine.shouldSync(message.excludedHashes, message.count)) {
+    if (!this.syncEngine.shouldSync(message.excludedHashes)) {
       log.debug(`Upto date with peer, skipping sync`);
       this.emit('syncComplete', false);
       return;

--- a/src/network/rpc/rpc.test.ts
+++ b/src/network/rpc/rpc.test.ts
@@ -79,7 +79,7 @@ class mockRPCHandler implements RPCHandler {
     return engine.getCustodyEventByUser(fid);
   }
   getSyncMetadataByPrefix(prefix: string): Promise<Result<NodeMetadata, FarcasterError>> {
-    const nodeMetadata = syncEngine.getNodeMetadata(prefix);
+    const nodeMetadata = syncEngine.getTrieNodeMetadata(prefix);
     if (nodeMetadata) {
       return Promise.resolve(ok(nodeMetadata));
     } else {

--- a/src/network/rpc/rpc.test.ts
+++ b/src/network/rpc/rpc.test.ts
@@ -34,8 +34,8 @@ import { SyncId } from '~/network/sync/syncId';
 
 const aliceFid = faker.datatype.number();
 const testDb = jestRocksDB('rpc.test');
-const engine = new Engine(testDb);
 
+let engine: Engine;
 let aliceCustodySigner: EthereumSigner;
 let aliceCustodyRegister: IdRegistryEvent;
 let aliceDelegateSigner: MessageSigner;
@@ -158,7 +158,8 @@ describe('rpc', () => {
   });
 
   beforeEach(async () => {
-    engine._reset();
+    await testDb.clear();
+    engine = new Engine(testDb);
     syncEngine = new SyncEngine(engine);
     await engine.mergeIdRegistryEvent(aliceCustodyRegister);
     await engine.mergeMessage(addDelegateSigner);

--- a/src/network/sync/merkleTrie.test.ts
+++ b/src/network/sync/merkleTrie.test.ts
@@ -97,6 +97,22 @@ describe('MerkleTrie', () => {
       expect(trie.get(syncId)).toBeFalsy();
     });
 
+    test('deleting an item that does not exist does not change the trie', async () => {
+      const message = await Factories.CastShort.create();
+      const syncId = new SyncId(message);
+
+      const trie = new MerkleTrie();
+      trie.insert(syncId);
+
+      const rootHashBeforeDelete = trie.rootHash;
+      const message2 = await Factories.CastShort.create();
+      const syncId2 = new SyncId(message2);
+      trie.delete(syncId2);
+
+      expect(trie.rootHash).toEqual(rootHashBeforeDelete);
+      expect(trie.items).toEqual(1);
+    });
+
     test('delete is an exact inverse of insert', async () => {
       const message1 = await Factories.CastShort.create();
       const syncId1 = new SyncId(message1);

--- a/src/network/sync/merkleTrie.test.ts
+++ b/src/network/sync/merkleTrie.test.ts
@@ -167,7 +167,7 @@ describe('MerkleTrie', () => {
       const trie = new MerkleTrie();
       trie.insert(syncId);
 
-      expect(trie.getNodeMetadata('166518234')).toBeUndefined();
+      expect(trie.getTrieNodeMetadata('166518234')).toBeUndefined();
     });
 
     test('returns the root metadata if the prefix is empty', async () => {
@@ -175,7 +175,7 @@ describe('MerkleTrie', () => {
       const trie = new MerkleTrie();
       trie.insert(syncId);
 
-      const nodeMetadata = trie.getNodeMetadata('');
+      const nodeMetadata = trie.getTrieNodeMetadata('');
       expect(nodeMetadata).toBeDefined();
       expect(nodeMetadata?.numMessages).toEqual(1);
       expect(nodeMetadata?.prefix).toEqual('');
@@ -185,7 +185,7 @@ describe('MerkleTrie', () => {
 
     test('returns the correct metadata if prefix is present', async () => {
       const trie = await trieWithMessages([1665182332, 1665182343]);
-      const nodeMetadata = trie.getNodeMetadata('16651823');
+      const nodeMetadata = trie.getTrieNodeMetadata('16651823');
 
       expect(nodeMetadata).toBeDefined();
       expect(nodeMetadata?.numMessages).toEqual(2);
@@ -218,7 +218,7 @@ describe('MerkleTrie', () => {
     test('excluded hashes excludes the prefix char at every level', async () => {
       const trie = await trieWithMessages([1665182332, 1665182343, 1665182345, 1665182351]);
       let snapshot = trie.getSnapshot('1665182351');
-      let node = trie.getNodeMetadata('16651823');
+      let node = trie.getTrieNodeMetadata('16651823');
       // We expect the excluded hash to be the hash of the 3 and 4 child nodes, and excludes the 5 child node
       const expectedHash = createHash('sha256')
         .update(node?.children?.get('3')?.hash || '')
@@ -238,11 +238,11 @@ describe('MerkleTrie', () => {
       ]);
 
       snapshot = trie.getSnapshot('1665182343');
-      node = trie.getNodeMetadata('166518234');
+      node = trie.getTrieNodeMetadata('166518234');
       const expectedLastHash = createHash('sha256')
         .update(node?.children?.get('5')?.hash || '')
         .digest('hex');
-      node = trie.getNodeMetadata('16651823');
+      node = trie.getTrieNodeMetadata('16651823');
       const expectedPenultimateHash = createHash('sha256')
         .update(node?.children?.get('3')?.hash || '')
         .update(node?.children?.get('5')?.hash || '')

--- a/src/network/sync/merkleTrie.test.ts
+++ b/src/network/sync/merkleTrie.test.ts
@@ -89,10 +89,12 @@ describe('MerkleTrie', () => {
       trie.insert(syncId);
       expect(trie.items).toEqual(1);
       expect(trie.rootHash).toBeTruthy();
+      expect(trie.get(syncId)).toBeTruthy();
 
       trie.delete(syncId);
       expect(trie.items).toEqual(0);
       expect(trie.rootHash).toEqual(emptyHash);
+      expect(trie.get(syncId)).toBeFalsy();
     });
 
     test('delete is an exact inverse of insert', async () => {

--- a/src/network/sync/merkleTrie.ts
+++ b/src/network/sync/merkleTrie.ts
@@ -40,6 +40,10 @@ class MerkleTrie {
     this._root.insert(id.toString(), id.hashString);
   }
 
+  public delete(id: SyncId): void {
+    this._root.delete(id.toString());
+  }
+
   public get(id: SyncId): string | undefined {
     return this._root.get(id.toString());
   }

--- a/src/network/sync/merkleTrie.ts
+++ b/src/network/sync/merkleTrie.ts
@@ -66,7 +66,7 @@ class MerkleTrie {
     return prefix;
   }
 
-  public getNodeMetadata(prefix: string): NodeMetadata | undefined {
+  public getTrieNodeMetadata(prefix: string): NodeMetadata | undefined {
     const node = this._root.getNode(prefix);
     if (node === undefined) {
       return undefined;

--- a/src/network/sync/merkleTrie.ts
+++ b/src/network/sync/merkleTrie.ts
@@ -28,6 +28,10 @@ export type NodeMetadata = {
  *
  * Comparing the state of two tries (represented by the snapshot) for the same prefix allows us to determine
  * whether two hubs are in sync, and the earliest point of divergence if not.
+ *
+ * Note about concurrency: This class and TrieNode are not thread-safe. This is fine because there are no async
+ * methods, which means the operations won't be interrupted. DO NOT add async methods without considering
+ * impact on concurrency-safety.
  */
 class MerkleTrie {
   private readonly _root: TrieNode;

--- a/src/network/sync/syncEngine.test.ts
+++ b/src/network/sync/syncEngine.test.ts
@@ -10,13 +10,14 @@ import { RPCClient } from '~/network/rpc';
 import { ok } from 'neverthrow';
 
 const testDb = jestRocksDB(`engine.syncEngine.test`);
-const engine = new Engine(testDb);
 
 describe('SyncEngine', () => {
   let syncEngine: SyncEngine;
+  let engine: Engine;
 
   beforeEach(async () => {
-    await engine._reset();
+    await testDb.clear();
+    engine = new Engine(testDb);
     syncEngine = new SyncEngine(engine);
   });
 

--- a/src/network/sync/syncEngine.test.ts
+++ b/src/network/sync/syncEngine.test.ts
@@ -76,12 +76,13 @@ describe('SyncEngine', () => {
       { transient: { signer: user.delegateSigner } }
     );
     await engine.mergeMessage(reactionRemove);
-    expect(syncEngine.trie.get(new SyncId(reactionRemove))).toBeTruthy();
+    const id = new SyncId(reactionRemove);
+    expect(syncEngine.trie.get(id)).toEqual(id.hashString);
 
     // Merging the reaction add deletes the reaction remove in the db, and it should be reflected in the trie
     await engine.mergeMessage(reactionAdd);
     expect(await engine.getMessagesByHashes([reactionRemove.hash])).toEqual([]);
-    expect(syncEngine.trie.get(new SyncId(reactionRemove))).toBeFalsy();
+    expect(syncEngine.trie.get(id)).toBeFalsy();
   });
 
   test('snapshotTimestampPrefix trims the seconds', async () => {

--- a/src/network/sync/syncEngine.test.ts
+++ b/src/network/sync/syncEngine.test.ts
@@ -5,7 +5,7 @@ import { jestRocksDB } from '~/storage/db/jestUtils';
 import { mockFid, UserInfo } from '~/storage/engine/mock';
 import { faker } from '@faker-js/faker';
 import { SyncId } from '~/network/sync/syncId';
-import { mock, instance, when, anyString } from 'ts-mockito';
+import { anyString, instance, mock, when } from 'ts-mockito';
 import { RPCClient } from '~/network/rpc';
 import { ok } from 'neverthrow';
 
@@ -63,6 +63,26 @@ describe('SyncEngine', () => {
     expect(syncEngine.trie.get(new SyncId(message))).toBeFalsy();
   });
 
+  test('trie is updated when a message is removed', async () => {
+    const user = await mockFid(engine, faker.datatype.number());
+    const targetUri = faker.internet.url();
+    const reactionRemove = await Factories.ReactionRemove.create(
+      { data: { fid: user.fid, body: { targetUri: targetUri } } },
+      { transient: { signer: user.delegateSigner } }
+    );
+    const reactionAdd = await Factories.ReactionAdd.create(
+      { data: { fid: user.fid, body: { targetUri: targetUri }, signedAt: reactionRemove.data.signedAt + 1 } },
+      { transient: { signer: user.delegateSigner } }
+    );
+    await engine.mergeMessage(reactionRemove);
+    expect(syncEngine.trie.get(new SyncId(reactionRemove))).toBeTruthy();
+
+    // Merging the reaction add deletes the reaction remove in the db, and it should be reflected in the trie
+    await engine.mergeMessage(reactionAdd);
+    expect(await engine.getMessagesByHashes([reactionRemove.hash])).toEqual([]);
+    expect(syncEngine.trie.get(new SyncId(reactionRemove))).toBeFalsy();
+  });
+
   test('snapshotTimestampPrefix trims the seconds', async () => {
     const nowInSeconds = Date.now() / 1000;
     const snapshotTimestamp = syncEngine.snapshotTimestamp;
@@ -75,10 +95,9 @@ describe('SyncEngine', () => {
     const rpcClient = instance(mockRPCClient);
     let called = false;
     when(mockRPCClient.getSyncMetadataByPrefix(anyString())).thenCall(() => {
-      expect(syncEngine.shouldSync([], 0)).toBeFalsy();
-      // Return a high message count, so we don't try to fetch sync ids, and return an empty child map so sync
-      // will finish with a noop
+      expect(syncEngine.shouldSync([])).toBeFalsy();
       called = true;
+      // Return an empty child map so sync will finish with a noop
       return Promise.resolve(ok({ prefix: '', numMessages: 1000, hash: '', children: new Map() }));
     });
     await syncEngine.performSync(['some-divergence'], rpcClient);
@@ -88,22 +107,16 @@ describe('SyncEngine', () => {
   test('shouldSync returns false when excludedHashes match', async () => {
     const user = await mockFid(engine, faker.datatype.number());
     await addMessagesWithTimestamps(user, [1665182332, 1665182333, 1665182334]);
-    expect(syncEngine.shouldSync(syncEngine.snapshot.excludedHashes, 0)).toBeFalsy();
+    expect(syncEngine.shouldSync(syncEngine.snapshot.excludedHashes)).toBeFalsy();
   });
 
-  test('shouldSync return true or false based on number of messages when hashes dont match', async () => {
+  test('shouldSync returns true when hashes dont match', async () => {
     const user = await mockFid(engine, faker.datatype.number());
     await addMessagesWithTimestamps(user, [1665182332, 1665182333, 1665182334]);
     const oldSnapshot = syncEngine.snapshot;
     await addMessagesWithTimestamps(user, [1665182534]);
     expect(oldSnapshot.excludedHashes).not.toEqual(syncEngine.snapshot.excludedHashes);
-    // don't sync we have more messages
-    expect(syncEngine.shouldSync(oldSnapshot.excludedHashes, 1)).toBeFalsy();
-    // must sync if we have fewer messages
-    expect(syncEngine.shouldSync(oldSnapshot.excludedHashes, 1000)).toBeTruthy();
-    // must sync if we have same number of messages
-    const ourMessages = syncEngine.snapshot.numMessages;
-    expect(syncEngine.shouldSync(oldSnapshot.excludedHashes, ourMessages)).toBeTruthy();
+    expect(syncEngine.shouldSync(oldSnapshot.excludedHashes)).toBeTruthy();
   });
 
   test('should not sync if messages were added within the sync threshold', async () => {
@@ -114,10 +127,7 @@ describe('SyncEngine', () => {
     const snapshot = syncEngine.snapshot;
     // Add a message after the snapshot, within the sync threshold
     await addMessagesWithTimestamps(user, [snapshotTimestamp + 3]);
-    // Ensure messages counts match, run a few times to make sure we didn't accidentally the wrong answer
-    // due to randomness
-    const shouldSync = syncEngine.shouldSync(snapshot.excludedHashes, snapshot.numMessages + 1);
-    expect(shouldSync).toBeFalsy();
+    expect(syncEngine.shouldSync(snapshot.excludedHashes)).toBeFalsy();
   });
 
   test('initialize populates the trie with all existing messages', async () => {

--- a/src/network/sync/syncEngine.ts
+++ b/src/network/sync/syncEngine.ts
@@ -164,7 +164,8 @@ class SyncEngine {
         // TODO: Optimize by collecting all failures and retrying them in a batch
         for (const msg of msgs) {
           const result = await this.engine.mergeMessage(msg, 'SyncEngine');
-          if (result.isErr() && result.error.message.includes('unknown user')) {
+          // Unknown user error
+          if (result.isErr() && result.error.statusCode === 412) {
             log.warn({ fid: msg.data.fid }, 'Unknown user, fetching custody event');
             const result = await this.syncUserAndRetryMessage(msg, rpcClient);
             mergeResults.push(result);

--- a/src/network/sync/syncEngine.ts
+++ b/src/network/sync/syncEngine.ts
@@ -38,6 +38,7 @@ class SyncEngine {
       // Note: There's no guarantee that the message is actually deleted, because the transaction could fail.
       // This is fine, because we'll just end up syncing the message again. It's much worse to miss a removal and cause
       // the trie to diverge in a way that's not recoverable without reconstructing it from the db.
+      // Order of events does not matter. The trie will always converge to the same state.
       this.removeMessage(message);
     });
   }
@@ -74,16 +75,8 @@ class SyncEngine {
       ourSnapshot.excludedHashes.length === excludedHashes.length &&
       ourSnapshot.excludedHashes.every((value, index) => value === excludedHashes[index]);
 
-    if (excludedHashesMatch) {
-      // Excluded hashes match exactly, so we don't need to sync
-      log.debug('shouldSync: excluded hashes match');
-      return false;
-    } else {
-      log.debug('shouldSync: excluded hashes mismatch');
-      // Because of message removals, we cannot rely on number of messages to determine which hub is ahead,
-      // so always return true if the hashes don't match.
-      return true;
-    }
+    log.debug(`shouldSync: excluded hashes check: ${excludedHashes}`);
+    return !excludedHashesMatch;
   }
 
   async performSync(excludedHashes: string[], rpcClient: RPCClient) {

--- a/src/network/sync/syncEngine.ts
+++ b/src/network/sync/syncEngine.ts
@@ -34,6 +34,9 @@ class SyncEngine {
     this.engine.on('messageMerged', async (_fid, _type, message) => {
       this.addMessage(message);
     });
+    this.engine.onDBEvent('messageDeleted', async (message) => {
+      this.removeMessage(message);
+    });
   }
 
   public async initialize() {
@@ -51,6 +54,10 @@ class SyncEngine {
 
   public addMessage(message: Message): void {
     this._trie.insert(new SyncId(message));
+  }
+
+  public removeMessage(message: Message): void {
+    this._trie.delete(new SyncId(message));
   }
 
   public shouldSync(excludedHashes: string[], numMessages: number): boolean {

--- a/src/network/sync/syncEngine.ts
+++ b/src/network/sync/syncEngine.ts
@@ -107,7 +107,7 @@ class SyncEngine {
   }
 
   async fetchMissingHashesByPrefix(prefix: string, rpcClient: RPCClient): Promise<string[]> {
-    const ourNode = this._trie.getNodeMetadata(prefix);
+    const ourNode = this._trie.getTrieNodeMetadata(prefix);
     const theirNodeResult = await rpcClient.getSyncMetadataByPrefix(prefix);
 
     const missingHashes: string[] = [];
@@ -186,8 +186,8 @@ class SyncEngine {
     return result;
   }
 
-  public getNodeMetadata(prefix: string): NodeMetadata | undefined {
-    return this._trie.getNodeMetadata(prefix);
+  public getTrieNodeMetadata(prefix: string): NodeMetadata | undefined {
+    return this._trie.getTrieNodeMetadata(prefix);
   }
 
   public getIdsByPrefix(prefix: string): string[] {

--- a/src/network/sync/trieNode.ts
+++ b/src/network/sync/trieNode.ts
@@ -1,4 +1,4 @@
-import { ID_LENGTH } from '~/network/sync/syncId';
+// import { ID_LENGTH } from '~/network/sync/syncId';
 import { createHash } from 'crypto';
 
 /**
@@ -41,7 +41,7 @@ class TrieNode {
 
     // TODO: Optimize by using MPT extension nodes for leaves
     // We've reached the end of the key, add or update the value in a leaf node
-    if (current_index === ID_LENGTH - 1) {
+    if (current_index === key.length - 1) {
       // Key with the same value already exists, so no need to modify the tree
       if (this._children.has(char) && this._children.get(char)?.value === value) {
         return false;
@@ -60,6 +60,29 @@ class TrieNode {
     const success = this._children.get(char)?.insert(key, value, current_index + 1);
     if (success) {
       this._items += 1;
+      this._updateHash();
+      return true;
+    }
+
+    return false;
+  }
+
+  public delete(key: string, current_index = 0): boolean {
+    if (this.isLeaf) {
+      return true;
+    }
+
+    const char = key[current_index];
+    if (!this._children.has(char)) {
+      return false;
+    }
+
+    const success = this._children.get(char)?.delete(key, current_index + 1);
+    if (success) {
+      this._items -= 1;
+      if (this._children.get(char)?.items === 0) {
+        this._children.delete(char);
+      }
       this._updateHash();
       return true;
     }

--- a/src/network/sync/trieNode.ts
+++ b/src/network/sync/trieNode.ts
@@ -1,4 +1,3 @@
-// import { ID_LENGTH } from '~/network/sync/syncId';
 import { createHash } from 'crypto';
 
 /**
@@ -80,6 +79,8 @@ class TrieNode {
     const success = this._children.get(char)?.delete(key, current_index + 1);
     if (success) {
       this._items -= 1;
+      // Delete the child if it's empty. This is required to make sure the hash will be the same
+      // as another trie that doesn't have this node in the first place.
       if (this._children.get(char)?.items === 0) {
         this._children.delete(char);
       }

--- a/src/network/sync/trieNode.ts
+++ b/src/network/sync/trieNode.ts
@@ -35,6 +35,16 @@ class TrieNode {
     }
   }
 
+  /**
+   * Inserts a value into the trie. Returns true if the value was inserted, false if it already existed
+   * @param key - The key to insert
+   * @param value - The value to insert
+   * @param current_index - The index of the current character in the key (only used internally)
+   * @returns true if the value was inserted, false if it already existed
+   *
+   * Recursively traverses the trie by prefix and inserts the value at the end. Updates the hashes for
+   * every node that was traversed.
+   */
   public insert(key: string, value: string, current_index = 0): boolean {
     const char = key[current_index];
 
@@ -66,6 +76,14 @@ class TrieNode {
     return false;
   }
 
+  /**
+   * Deletes a value from the trie by key. Returns true if the value was deleted, false if it didn't exist
+   * @param key - The key to delete
+   * @param current_index - The index of the current character in the key (only used internally)
+   *
+   * Ensures that there are no empty nodes after deletion. This is important to make sure the hashes
+   * will match exactly with another trie that never had the value (e.g. in another hub).
+   */
   public delete(key: string, current_index = 0): boolean {
     if (this.isLeaf) {
       return true;

--- a/src/storage/db/message.test.ts
+++ b/src/storage/db/message.test.ts
@@ -67,6 +67,19 @@ describe('deleteMessage', () => {
     await expect(db.getMessage(cast1.hash)).rejects.toThrow();
     await expect(db.getMessagesBySigner(cast1.data.fid, cast1.signer)).resolves.toEqual([]);
   });
+
+  test('fires messageDeleted event', async () => {
+    await db.putMessage(cast1);
+    let called = false;
+    db.on('messageDeleted', (message) => {
+      expect(message).toEqual(cast1);
+      called = true;
+    });
+
+    await db.deleteMessage(cast1.hash);
+
+    expect(called).toBe(true);
+  });
 });
 
 describe('getMessagesBySigner', () => {

--- a/src/storage/engine/engine.cast.test.ts
+++ b/src/storage/engine/engine.cast.test.ts
@@ -5,7 +5,7 @@ import { Cast, CastShort, EthereumSigner, IdRegistryEvent, MessageSigner, Signer
 import { generateEd25519Signer, generateEthereumSigner } from '~/utils/crypto';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import CastDB from '~/storage/db/cast';
-import { BadRequestError } from '~/utils/errors';
+import { BadRequestError, UnknownUserError } from '~/utils/errors';
 
 const rocksDb = jestRocksDB('engine.cast.test');
 const castDb = new CastDB(rocksDb);
@@ -62,7 +62,7 @@ describe('mergeCast', () => {
     test('fails if there are no known signers', async () => {
       const result = await engine.mergeMessage(cast);
       expect(result.isOk()).toBe(false);
-      expect(result._unsafeUnwrapErr()).toMatchObject(new BadRequestError('validateMessage: unknown user'));
+      expect(result._unsafeUnwrapErr()).toMatchObject(new UnknownUserError('validateMessage: unknown user'));
       expect(await aliceAdds()).toEqual(new Set());
     });
 
@@ -117,7 +117,7 @@ describe('mergeCast', () => {
           );
           const result = await engine.mergeMessage(unknownUser);
           expect(result.isOk()).toBe(false);
-          expect(result._unsafeUnwrapErr()).toMatchObject(new BadRequestError('validateMessage: unknown user'));
+          expect(result._unsafeUnwrapErr()).toMatchObject(new UnknownUserError('validateMessage: unknown user'));
           expect(await aliceAdds()).toEqual(new Set());
         });
       });

--- a/src/storage/engine/engine.follow.test.ts
+++ b/src/storage/engine/engine.follow.test.ts
@@ -14,7 +14,7 @@ import {
 import { generateEd25519Signer, generateEthereumSigner } from '~/utils/crypto';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import FollowDB from '~/storage/db/follow';
-import { BadRequestError } from '~/utils/errors';
+import { BadRequestError, UnknownUserError } from '~/utils/errors';
 
 const testDb = jestRocksDB(`engine.follow.test`);
 const followDb = new FollowDB(testDb);
@@ -60,7 +60,7 @@ describe('mergeFollow', () => {
 
   test('fails if there are no known signers', async () => {
     const result = await engine.mergeMessage(follow);
-    expect(result._unsafeUnwrapErr()).toMatchObject(new BadRequestError('validateMessage: unknown user'));
+    expect(result._unsafeUnwrapErr()).toMatchObject(new UnknownUserError('validateMessage: unknown user'));
     await expect(aliceFollows()).resolves.toEqual(new Set());
   });
 
@@ -89,7 +89,7 @@ describe('mergeFollow', () => {
         const unknownUser = await Factories.FollowAdd.create({ data: { fid: aliceFid + 1 } }, transientParams);
         const res = await engine.mergeMessage(unknownUser);
         expect(res.isOk()).toBe(false);
-        expect(res._unsafeUnwrapErr()).toMatchObject(new BadRequestError('validateMessage: unknown user'));
+        expect(res._unsafeUnwrapErr()).toMatchObject(new UnknownUserError('validateMessage: unknown user'));
         await expect(aliceFollows()).resolves.toEqual(new Set());
       });
     });

--- a/src/storage/engine/engine.reaction.test.ts
+++ b/src/storage/engine/engine.reaction.test.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import ReactionDB from '~/storage/db/reaction';
 import Engine from '~/storage/engine';
-import { BadRequestError } from '~/utils/errors';
+import { BadRequestError, UnknownUserError } from '~/utils/errors';
 import { Factories } from '~/test/factories';
 import {
   Ed25519Signer,
@@ -61,7 +61,7 @@ describe('mergeReaction', () => {
 
   test('fails if there are no known signers', async () => {
     const result = await engine.mergeMessage(reaction);
-    expect(result._unsafeUnwrapErr()).toMatchObject(new BadRequestError('validateMessage: unknown user'));
+    expect(result._unsafeUnwrapErr()).toMatchObject(new UnknownUserError('validateMessage: unknown user'));
     await expect(aliceAdds()).resolves.toEqual(new Set([]));
   });
 
@@ -90,7 +90,7 @@ describe('mergeReaction', () => {
         const unknownUser = await Factories.ReactionAdd.create({ data: { fid: aliceFid + 1 } }, transient);
 
         expect((await engine.mergeMessage(unknownUser))._unsafeUnwrapErr()).toMatchObject(
-          new BadRequestError('validateMessage: unknown user')
+          new UnknownUserError('validateMessage: unknown user')
         );
         await expect(aliceAdds()).resolves.toEqual(new Set([]));
       });

--- a/src/storage/engine/engine.revoke.test.ts
+++ b/src/storage/engine/engine.revoke.test.ts
@@ -14,6 +14,7 @@ import {
   ReactionAdd,
   FollowAdd,
   CastRecast,
+  Message,
 } from '~/types';
 import { generateEd25519Signer, generateEthereumSigner } from '~/utils/crypto';
 
@@ -99,6 +100,19 @@ describe('revokeSigner', () => {
       await expect(aliceReactions()).resolves.toEqual(new Set());
       await expect(aliceVerifications()).resolves.toEqual(new Set());
       await expect(aliceFollows()).resolves.toEqual(new Set());
+    });
+
+    test('fires events for all the dropped messages', async () => {
+      const removedMessages: Message[] = [];
+      engine.onDBEvent('messageDeleted', (message) => removedMessages.push(message));
+
+      const res = await engine._revokeSigner(aliceFid, aliceSigner.signerKey);
+      expect(res.isOk()).toBeTruthy();
+
+      expect(removedMessages).toContainEqual(aliceCast);
+      expect(removedMessages).toContainEqual(aliceReaction);
+      expect(removedMessages).toContainEqual(aliceVerification);
+      expect(removedMessages).toContainEqual(aliceFollow);
     });
   });
 });

--- a/src/storage/engine/index.ts
+++ b/src/storage/engine/index.ts
@@ -42,7 +42,7 @@ import { Web2URL } from '~/urls/web2Url';
 import IdRegistryProvider from '~/storage/provider/idRegistryProvider';
 import { CastHash } from '~/urls/castUrl';
 import RocksDB from '~/storage/db/rocksdb';
-import { BadRequestError, FarcasterError, ServerError } from '~/utils/errors';
+import { BadRequestError, FarcasterError, ServerError, UnknownUserError } from '~/utils/errors';
 import { TypedEmitter } from 'tiny-typed-emitter';
 import MessageDB, { MessageDBEvents } from '~/storage/db/message';
 import { logger } from '~/utils/logger';
@@ -300,7 +300,7 @@ class Engine extends TypedEmitter<EngineEvents> {
       this._signerSet.getCustodyAddress(message.data.fid),
       () => undefined
     );
-    if (custodyEvent.isErr()) return err(new BadRequestError('validateMessage: unknown user'));
+    if (custodyEvent.isErr()) return err(new UnknownUserError('validateMessage: unknown user'));
 
     // 2. Check that the signer is valid if message is not a signer message
     if (!isSignerMessage(message)) {

--- a/src/storage/sets/castSet.ts
+++ b/src/storage/sets/castSet.ts
@@ -5,6 +5,7 @@ import CastDB from '~/storage/db/cast';
 import RocksDB from '~/storage/db/rocksdb';
 import { BadRequestError } from '~/utils/errors';
 import { hashCompare } from '~/utils/crypto';
+import { MessageDBEvents } from '~/storage/db/message';
 
 type CastAdd = CastShort | CastRecast;
 
@@ -63,6 +64,11 @@ class CastSet {
     }
 
     throw new BadRequestError('CastSet.merge: invalid message format');
+  }
+
+  /* Proxy db events */
+  onDBEvent<E extends keyof MessageDBEvents>(event: E, callback: MessageDBEvents[E]) {
+    this._db.on(event, callback);
   }
 
   /* -------------------------------------------------------------------------- */

--- a/src/storage/sets/followSet.ts
+++ b/src/storage/sets/followSet.ts
@@ -5,6 +5,7 @@ import { BadRequestError } from '~/utils/errors';
 import { Follow, FollowAdd, FollowRemove, URI } from '~/types';
 import { isFollowAdd, isFollowRemove } from '~/types/typeguards';
 import { hashCompare } from '~/utils/crypto';
+import { MessageDBEvents } from '~/storage/db/message';
 
 /**
  * FollowSet is a modified LWW set that stores and fetches follow actions. FollowAdd and FollowRemove messages
@@ -52,6 +53,10 @@ class FollowSet {
     }
 
     throw new BadRequestError('FollowSet.merge: invalid message format');
+  }
+
+  onDBEvent<E extends keyof MessageDBEvents>(event: E, callback: MessageDBEvents[E]) {
+    this._db.on(event, callback);
   }
 
   /* -------------------------------------------------------------------------- */

--- a/src/storage/sets/reactionSet.ts
+++ b/src/storage/sets/reactionSet.ts
@@ -5,6 +5,7 @@ import { BadRequestError } from '~/utils/errors';
 import { Reaction, ReactionAdd, ReactionRemove, URI } from '~/types';
 import { isReactionAdd, isReactionRemove } from '~/types/typeguards';
 import { hashCompare } from '~/utils/crypto';
+import { MessageDBEvents } from '~/storage/db/message';
 
 /**
  * ReactionSet is a modified LWW set that stores and fetches reactions. ReactionAdd and ReactionRemove messages are
@@ -54,6 +55,10 @@ class ReactionSet {
     }
 
     throw new BadRequestError('ReactionSet.merge: invalid message format');
+  }
+
+  onDBEvent<E extends keyof MessageDBEvents>(event: E, callback: MessageDBEvents[E]) {
+    this._db.on(event, callback);
   }
 
   /* -------------------------------------------------------------------------- */

--- a/src/storage/sets/signerSet.ts
+++ b/src/storage/sets/signerSet.ts
@@ -5,6 +5,7 @@ import { isSignerAdd, isSignerRemove } from '~/types/typeguards';
 import { hashCompare, sanitizeSigner } from '~/utils/crypto';
 import RocksDB from '~/storage/db/rocksdb';
 import SignerDB from '~/storage/db/signer';
+import { MessageDBEvents } from '~/storage/db/message';
 
 export type SignerSetEvents = {
   /** Emitted when a new Register or Transfer event is received from the Farcaster ID Registry */
@@ -154,6 +155,10 @@ class SignerSet extends TypedEmitter<SignerSetEvents> {
     // TODO: asynchronously run cleanup that deletes all entries that are not for the new custody address
 
     return undefined;
+  }
+
+  onDBEvent<E extends keyof MessageDBEvents>(event: E, callback: MessageDBEvents[E]) {
+    this._db.on(event, callback);
   }
 
   /* -------------------------------------------------------------------------- */

--- a/src/storage/sets/verificationSet.ts
+++ b/src/storage/sets/verificationSet.ts
@@ -5,6 +5,7 @@ import { BadRequestError } from '~/utils/errors';
 import { Verification, VerificationEthereumAddress, VerificationRemove } from '~/types';
 import { isVerificationEthereumAddress, isVerificationRemove } from '~/types/typeguards';
 import { hashCompare } from '~/utils/crypto';
+import { MessageDBEvents } from '~/storage/db/message';
 
 /**
  * VerificationSet is a modified LWW set that stores and fetches verifications. VerificationEthereumAddress and VerificationRemove
@@ -50,6 +51,10 @@ class VerificationSet {
     }
 
     throw new BadRequestError('VerificationSet.merge: invalid message format');
+  }
+
+  onDBEvent<E extends keyof MessageDBEvents>(event: E, callback: MessageDBEvents[E]) {
+    this._db.on(event, callback);
   }
 
   /* -------------------------------------------------------------------------- */

--- a/src/test/e2e/differentialSync.test.ts
+++ b/src/test/e2e/differentialSync.test.ts
@@ -12,11 +12,11 @@ import { Factories } from '~/test/factories';
 import { sleep } from '~/utils/crypto';
 
 const serverDb = jestRocksDB('rpcSync.test.server');
-const hubAStorageEngine = new Engine(serverDb);
+let hubAStorageEngine: Engine;
 let hubASyncEngine: SyncEngine;
 
 const clientDb = jestRocksDB('rpcSync.test.client');
-const hubBStorageEngine = new Engine(clientDb);
+let hubBStorageEngine: Engine;
 let hubBSyncEngine: SyncEngine;
 
 class mockRPCHandler implements RPCHandler {
@@ -70,8 +70,10 @@ describe('differentialSync', () => {
   let userInfos: UserInfo[];
 
   beforeEach(async () => {
-    await hubAStorageEngine._reset();
-    await hubBStorageEngine._reset();
+    await serverDb.clear();
+    await clientDb.clear();
+    hubAStorageEngine = new Engine(serverDb);
+    hubBStorageEngine = new Engine(clientDb);
     hubASyncEngine = new SyncEngine(hubAStorageEngine);
     hubBSyncEngine = new SyncEngine(hubBStorageEngine);
     // setup the rpc server and client

--- a/src/test/e2e/differentialSync.test.ts
+++ b/src/test/e2e/differentialSync.test.ts
@@ -42,7 +42,7 @@ class mockRPCHandler implements RPCHandler {
     return hubAStorageEngine.getCustodyEventByUser(fid);
   }
   getSyncMetadataByPrefix(prefix: string): Promise<Result<NodeMetadata, FarcasterError>> {
-    const nodeMetadata = hubASyncEngine.getNodeMetadata(prefix);
+    const nodeMetadata = hubASyncEngine.getTrieNodeMetadata(prefix);
     if (nodeMetadata) {
       return Promise.resolve(ok(nodeMetadata));
     } else {
@@ -167,7 +167,7 @@ describe('differentialSync', () => {
       );
       // The point of divergence should be some distance from the root, and must have fewer messages than the root
       expect(divergencePrefix.length).toBeGreaterThanOrEqual(3);
-      const serverDivergedNodeMetadata = hubASyncEngine.trie.getNodeMetadata(divergencePrefix);
+      const serverDivergedNodeMetadata = hubASyncEngine.trie.getTrieNodeMetadata(divergencePrefix);
       expect(serverDivergedNodeMetadata).toBeDefined();
       expect(serverDivergedNodeMetadata?.numMessages).toBeLessThanOrEqual(hubASyncEngine.trie.root.items);
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -10,6 +10,10 @@ export class NotFoundError extends FarcasterError {
   public override readonly statusCode = 404;
 }
 
+export class UnknownUserError extends FarcasterError {
+  public override readonly statusCode = 412; // Precondition Failed
+}
+
 export class BadRequestError extends FarcasterError {
   public override readonly statusCode = 400;
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -29,5 +29,11 @@ import { default as Pino } from 'pino';
  * More info on best practices:
  * https://betterstack.com/community/guides/logging/how-to-install-setup-and-use-pino-to-log-node-js-applications/
  */
+const defaultOptions: Pino.LoggerOptions = {};
 
-export const logger = Pino();
+// Disable logging in tests and CI to reduce noise
+if (process.env.NODE_ENV === 'test' || process.env.CI) {
+  defaultOptions.level = 'silent';
+}
+
+export const logger = Pino(defaultOptions);


### PR DESCRIPTION
## Motivation

Diff sync must be able to handle deleted messages (e.g. from a signer remove) and converge to the same state. 

## Change Summary

Sync engine listens for message deletions from the storage engine an deletes the item from the trie. Added tests to make sure hubs will converge to same state when they have deleted messages.

Also includes a other follow ups from review comments in https://github.com/farcasterxyz/hub/pull/179

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context


