### PR TITLE
chore: disable noUnusedLocals in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,7 @@
     // TODO: fixing this is tracked here: https://github.com/farcasterxyz/hub/issues/151
     // "noPropertyAccessFromIndexSignature": true,
     // "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false, // causes hard failures when iterating in dev, enforce with eslint instead
     "noUnusedParameters": true
   },
 


### PR DESCRIPTION
## Motivation

`ts-jest` constantly fails when commenting out tests because it leaves unused locals, slowing down the pace of iteration when writing tests

## Change Summary

`noUnusedLocals` is not enforced in ts-config as a hard failure and is instead enforced as an eslint warning (no-unused-vars)

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)