### PR TITLE
refactor: rename timestampHash to tsHash

### DIFF
--- a/src/storage/flatbuffers/messageModel.test.ts
+++ b/src/storage/flatbuffers/messageModel.test.ts
@@ -21,18 +21,16 @@ describe('static methods', () => {
   describe('get', () => {
     test('succeeds when message exists', async () => {
       await model.put(db);
-      await expect(MessageModel.get(db, model.fid(), model.setPrefix(), model.timestampHash())).resolves.toEqual(model);
+      await expect(MessageModel.get(db, model.fid(), model.setPrefix(), model.tsHash())).resolves.toEqual(model);
     });
 
     test('fails when message not found', async () => {
-      await expect(MessageModel.get(db, model.fid(), model.setPrefix(), model.timestampHash())).rejects.toThrow(
-        NotFoundError
-      );
+      await expect(MessageModel.get(db, model.fid(), model.setPrefix(), model.tsHash())).rejects.toThrow(NotFoundError);
     });
 
     test('fails with wrong key', async () => {
       await model.put(db);
-      const badKey = new Uint8Array([...model.timestampHash(), 1]);
+      const badKey = new Uint8Array([...model.tsHash(), 1]);
       await expect(MessageModel.get(db, model.fid(), model.setPrefix(), badKey)).rejects.toThrow(NotFoundError);
     });
   });
@@ -40,7 +38,7 @@ describe('static methods', () => {
   describe('getManyByUser', () => {
     test('succeeds', async () => {
       await model.put(db);
-      const getMany = MessageModel.getManyByUser(db, model.fid(), model.setPrefix(), [model.timestampHash()]);
+      const getMany = MessageModel.getManyByUser(db, model.fid(), model.setPrefix(), [model.tsHash()]);
       await expect(getMany).resolves.toEqual([model]);
     });
   });
@@ -168,7 +166,7 @@ describe('instance methods', () => {
       await expect(model.put(db)).resolves.toEqual(undefined);
     });
     test('stores binary message', async () => {
-      const get = MessageModel.get(db, model.fid(), model.setPrefix(), model.timestampHash());
+      const get = MessageModel.get(db, model.fid(), model.setPrefix(), model.tsHash());
       await expect(get).resolves.toEqual(model);
     });
 
@@ -177,7 +175,7 @@ describe('instance methods', () => {
     });
   });
 
-  describe('timestampHash', () => {
+  describe('tsHash', () => {
     test('orders messages by timestamp and hash', async () => {
       const aData = await Factories.MessageData.create({ timestamp: 1 });
       const a = new MessageModel(
@@ -196,10 +194,10 @@ describe('instance methods', () => {
 
       const tsx = db
         .transaction()
-        .put(Buffer.from(model.timestampHash()), Buffer.from('m'))
-        .put(Buffer.from(a.timestampHash()), Buffer.from('a'))
-        .put(Buffer.from(b.timestampHash()), Buffer.from('b'))
-        .put(Buffer.from(c.timestampHash()), Buffer.from('c'));
+        .put(Buffer.from(model.tsHash()), Buffer.from('m'))
+        .put(Buffer.from(a.tsHash()), Buffer.from('a'))
+        .put(Buffer.from(b.tsHash()), Buffer.from('b'))
+        .put(Buffer.from(c.tsHash()), Buffer.from('c'));
 
       await db.commit(tsx);
 

--- a/src/storage/flatbuffers/messageModel.ts
+++ b/src/storage/flatbuffers/messageModel.ts
@@ -158,11 +158,11 @@ export default class MessageModel {
   }
 
   primaryKey(): Buffer {
-    return MessageModel.primaryKey(this.fid(), this.setPrefix(), this.timestampHash());
+    return MessageModel.primaryKey(this.fid(), this.setPrefix(), this.tsHash());
   }
 
   bySignerKey(): Buffer {
-    return MessageModel.bySignerKey(this.fid(), this.signer(), this.type(), this.timestampHash());
+    return MessageModel.bySignerKey(this.fid(), this.signer(), this.type(), this.tsHash());
   }
 
   toBuffer(): Buffer {
@@ -173,7 +173,7 @@ export default class MessageModel {
     return this.message.bb?.bytes() || new Uint8Array();
   }
 
-  timestampHash(): Uint8Array {
+  tsHash(): Uint8Array {
     const hash = this.hash();
     const buffer = new ArrayBuffer(4 + hash.length);
     const view = new DataView(buffer);

--- a/src/storage/sets/flatbuffers/castSet.ts
+++ b/src/storage/sets/flatbuffers/castSet.ts
@@ -49,7 +49,7 @@ class CastSet {
 
   // TODO: make parentFid and parentHash fixed size
   /** RocksDB key of the form <castsByMention prefix byte, mention fid, fid, cast hash> */
-  static caststByMentionKey(mentionFid: Uint8Array, fid?: Uint8Array, hash?: Uint8Array): Buffer {
+  static castsByMentionKey(mentionFid: Uint8Array, fid?: Uint8Array, hash?: Uint8Array): Buffer {
     const bytes = new Uint8Array(1 + FID_BYTES + (fid ? FID_BYTES : 0) + (hash ? hash.length : 0));
     bytes.set([RootPrefix.CastsByMention], 0);
     bytes.set(mentionFid, 1 + FID_BYTES - mentionFid.length); // pad fid for alignment
@@ -108,7 +108,7 @@ class CastSet {
 
   /** Get all CastAdd messages for a mention (fid) */
   async getCastsByMention(fid: Uint8Array): Promise<CastAddModel[]> {
-    const byMentionPrefix = CastSet.caststByMentionKey(fid);
+    const byMentionPrefix = CastSet.castsByMentionKey(fid);
     const messageKeys: Buffer[] = [];
     for await (const [key] of this._db.iteratorByPrefix(byMentionPrefix, { keyAsBuffer: true, values: false })) {
       const fid = Uint8Array.from(key).subarray(byMentionPrefix.length, byMentionPrefix.length + FID_BYTES);
@@ -250,7 +250,7 @@ class CastSet {
       for (let i = 0; i < message.body().mentionsLength(); i++) {
         const mention = message.body().mentions(i);
         tsx = tsx.put(
-          CastSet.caststByMentionKey(mention?.fidArray() ?? new Uint8Array(), message.fid(), message.tsHash()),
+          CastSet.castsByMentionKey(mention?.fidArray() ?? new Uint8Array(), message.fid(), message.tsHash()),
           TRUE_VALUE
         );
       }
@@ -265,7 +265,7 @@ class CastSet {
       for (let i = 0; i < message.body().mentionsLength(); i++) {
         const mention = message.body().mentions(i);
         tsx = tsx.del(
-          CastSet.caststByMentionKey(mention?.fidArray() ?? new Uint8Array(), message.fid(), message.tsHash())
+          CastSet.castsByMentionKey(mention?.fidArray() ?? new Uint8Array(), message.fid(), message.tsHash())
         );
       }
     }

--- a/src/storage/sets/flatbuffers/followSet.test.ts
+++ b/src/storage/sets/flatbuffers/followSet.test.ts
@@ -106,9 +106,9 @@ describe('merge', () => {
       });
 
       test('saves message', async () => {
-        await expect(
-          MessageModel.get(db, fid, UserPostfix.FollowMessage, followRemove.timestampHash())
-        ).resolves.toEqual(followRemove);
+        await expect(MessageModel.get(db, fid, UserPostfix.FollowMessage, followRemove.tsHash())).resolves.toEqual(
+          followRemove
+        );
       });
 
       test('saves followRemoves index', async () => {
@@ -116,7 +116,7 @@ describe('merge', () => {
       });
 
       test('deletes FollowAdd message', async () => {
-        await expect(MessageModel.get(db, fid, UserPostfix.FollowMessage, followAdd.timestampHash())).rejects.toThrow(
+        await expect(MessageModel.get(db, fid, UserPostfix.FollowMessage, followAdd.tsHash())).rejects.toThrow(
           NotFoundError
         );
       });
@@ -141,9 +141,9 @@ describe('merge', () => {
 
         await expect(set.merge(followRemoveLater)).resolves.toEqual(undefined);
         await expect(set.getFollowRemove(fid, userId)).resolves.toEqual(followRemoveLater);
-        await expect(
-          MessageModel.get(db, fid, UserPostfix.FollowMessage, followRemove.timestampHash())
-        ).rejects.toThrow(NotFoundError);
+        await expect(MessageModel.get(db, fid, UserPostfix.FollowMessage, followRemove.tsHash())).rejects.toThrow(
+          NotFoundError
+        );
       });
 
       test('no-ops when later FollowRemove exists', async () => {
@@ -179,7 +179,7 @@ describe('merge', () => {
       });
 
       test('saves message', async () => {
-        await expect(MessageModel.get(db, fid, UserPostfix.FollowMessage, followAdd.timestampHash())).resolves.toEqual(
+        await expect(MessageModel.get(db, fid, UserPostfix.FollowMessage, followAdd.tsHash())).resolves.toEqual(
           followAdd
         );
       });
@@ -216,7 +216,7 @@ describe('merge', () => {
         await set.merge(followAdd);
         await expect(set.merge(followAddLater)).resolves.toEqual(undefined);
         await expect(set.getFollowAdd(fid, userId)).resolves.toEqual(followAddLater);
-        await expect(MessageModel.get(db, fid, UserPostfix.FollowMessage, followAdd.timestampHash())).rejects.toThrow(
+        await expect(MessageModel.get(db, fid, UserPostfix.FollowMessage, followAdd.tsHash())).rejects.toThrow(
           NotFoundError
         );
       });
@@ -225,7 +225,7 @@ describe('merge', () => {
         await set.merge(followAddLater);
         await expect(set.merge(followAdd)).resolves.toEqual(undefined);
         await expect(set.getFollowAdd(fid, userId)).resolves.toEqual(followAddLater);
-        await expect(MessageModel.get(db, fid, UserPostfix.FollowMessage, followAdd.timestampHash())).rejects.toThrow(
+        await expect(MessageModel.get(db, fid, UserPostfix.FollowMessage, followAdd.tsHash())).rejects.toThrow(
           NotFoundError
         );
       });
@@ -247,7 +247,7 @@ describe('merge', () => {
         await expect(set.getFollowAdd(fid, userId)).resolves.toEqual(followAdd);
         await expect(set.getFollowRemove(fid, userId)).rejects.toThrow(NotFoundError);
         await expect(
-          MessageModel.get(db, fid, UserPostfix.FollowMessage, followRemoveEarlier.timestampHash())
+          MessageModel.get(db, fid, UserPostfix.FollowMessage, followRemoveEarlier.tsHash())
         ).rejects.toThrow(NotFoundError);
       });
 
@@ -256,7 +256,7 @@ describe('merge', () => {
         await expect(set.merge(followAdd)).resolves.toEqual(undefined);
         await expect(set.getFollowRemove(fid, userId)).resolves.toEqual(followRemove);
         await expect(set.getFollowAdd(fid, userId)).rejects.toThrow(NotFoundError);
-        await expect(MessageModel.get(db, fid, UserPostfix.FollowMessage, followAdd.timestampHash())).rejects.toThrow(
+        await expect(MessageModel.get(db, fid, UserPostfix.FollowMessage, followAdd.tsHash())).rejects.toThrow(
           NotFoundError
         );
       });

--- a/src/storage/sets/flatbuffers/followSet.ts
+++ b/src/storage/sets/flatbuffers/followSet.ts
@@ -33,15 +33,15 @@ class FollowSet {
   }
 
   /** RocksDB key of the form <followByUser prefix (1 byte), user id (32 bytes), fid (32 bytes), message timestamp hash (8 bytes)> */
-  static followsByUserKey(user: Uint8Array, fid?: Uint8Array, hash?: Uint8Array): Buffer {
-    const bytes = new Uint8Array(1 + FID_BYTES + (fid ? FID_BYTES : 0) + (hash ? hash.length : 0));
+  static followsByUserKey(user: Uint8Array, fid?: Uint8Array, tsHash?: Uint8Array): Buffer {
+    const bytes = new Uint8Array(1 + FID_BYTES + (fid ? FID_BYTES : 0) + (tsHash ? tsHash.length : 0));
     bytes.set([RootPrefix.FollowsByUser], 0);
     bytes.set(user, 1 + FID_BYTES - user.length); // pad for alignment
     if (fid) {
       bytes.set(fid, 1 + FID_BYTES + FID_BYTES - fid.length); // pad fid for alignment
     }
-    if (hash) {
-      bytes.set(hash, 1 + FID_BYTES + FID_BYTES);
+    if (tsHash) {
+      bytes.set(tsHash, 1 + FID_BYTES + FID_BYTES);
     }
     return Buffer.from(bytes);
   }

--- a/src/storage/sets/flatbuffers/reactionSet.test.ts
+++ b/src/storage/sets/flatbuffers/reactionSet.test.ts
@@ -231,13 +231,11 @@ describe('getReactionsByTarget', () => {
 
 describe('merge', () => {
   const assertReactionExists = async (message: ReactionAddModel | ReactionRemoveModel) => {
-    await expect(MessageModel.get(db, fid, UserPostfix.ReactionMessage, message.timestampHash())).resolves.toEqual(
-      message
-    );
+    await expect(MessageModel.get(db, fid, UserPostfix.ReactionMessage, message.tsHash())).resolves.toEqual(message);
   };
 
   const assertReactionDoesNotExist = async (message: ReactionAddModel | ReactionRemoveModel) => {
-    await expect(MessageModel.get(db, fid, UserPostfix.ReactionMessage, message.timestampHash())).rejects.toThrow(
+    await expect(MessageModel.get(db, fid, UserPostfix.ReactionMessage, message.tsHash())).rejects.toThrow(
       NotFoundError
     );
   };

--- a/src/storage/sets/flatbuffers/reactionSet.ts
+++ b/src/storage/sets/flatbuffers/reactionSet.ts
@@ -18,15 +18,15 @@ import { bytesCompare } from '~/storage/flatbuffers/utils';
  * 2. Highest lexicographic hash wins
  * 3. Remove wins over Adds
  *
- * ReactionMessages are stored ordinally in RocksDB indexed by a unique key `fid:timestampHash`,
+ * ReactionMessages are stored ordinally in RocksDB indexed by a unique key `fid:tsHash`,
  * which makes truncating a user's earliest messages easy. Indices are also build for each phase
  * set (adds, removes) to make lookups easy when checking if a collision exists. An index is also
  * build for the target to make it easy to fetch all reactions for a target. The key-value entries
  * created by the reaction set are:
  *
- * fid:timestampHash -> message
- * fidPrefix:setPrefix:targetCastTimestampHash:reactionType -> fid:timestampHash (Set Index)
- * reactionTargetPrefix:targetCastTimestampHash:reactionType -> fid:timestampHash (Target Index)
+ * fid:tsHash -> message
+ * fidPrefix:setPrefix:targetCastTimestampHash:reactionType -> fid:tsHash (Set Index)
+ * reactionTargetPrefix:targetCastTimestampHash:reactionType -> fid:tsHash (Target Index)
  */
 class ReactionSet {
   private _db: RocksDB;
@@ -181,15 +181,15 @@ class ReactionSet {
   async getReactionsByTarget(castId: CastID, type?: ReactionType): Promise<ReactionAddModel[]> {
     const prefix = ReactionSet.reactionsByTargetKey(this.targetKeyForCastId(castId), type);
 
-    // Calculates the positions in the key where the fid and timestampHash begin
+    // Calculates the positions in the key where the fid and tsHash begin
     const fidOffset = type ? prefix.length : prefix.length + 1; // prefix is 1 byte longer if type was provided
     const tsHashOffset = fidOffset + FID_BYTES;
 
     const messageKeys: Buffer[] = [];
     for await (const [key] of this._db.iteratorByPrefix(prefix, { keyAsBuffer: true, values: false })) {
       const fid = Uint8Array.from(key).subarray(fidOffset, tsHashOffset);
-      const timestampHash = Uint8Array.from(key).subarray(tsHashOffset);
-      messageKeys.push(MessageModel.primaryKey(fid, UserPostfix.ReactionMessage, timestampHash));
+      const tsHash = Uint8Array.from(key).subarray(tsHashOffset);
+      messageKeys.push(MessageModel.primaryKey(fid, UserPostfix.ReactionMessage, tsHash));
     }
     return MessageModel.getMany(this._db, messageKeys);
   }
@@ -253,9 +253,9 @@ class ReactionSet {
     bType: MessageType,
     bTimestampHash: Uint8Array
   ): number {
-    const timestampHashOrder = bytesCompare(aTimestampHash, bTimestampHash);
-    if (timestampHashOrder !== 0) {
-      return timestampHashOrder;
+    const tsHashOrder = bytesCompare(aTimestampHash, bTimestampHash);
+    if (tsHashOrder !== 0) {
+      return tsHashOrder;
     }
 
     // TODO: Changing these types to FollowRemove and FollowAdd did not break tests
@@ -290,7 +290,7 @@ class ReactionSet {
           MessageType.ReactionRemove,
           reactionRemoveTimestampHash.value,
           message.type(),
-          message.timestampHash()
+          message.tsHash()
         ) >= 0
       ) {
         // If the existing remove has the same or higher order than the new message, no-op
@@ -321,7 +321,7 @@ class ReactionSet {
           MessageType.ReactionAdd,
           reactionAddTimestampHash.value,
           message.type(),
-          message.timestampHash()
+          message.tsHash()
         ) >= 0
       ) {
         // If the existing add has the same or higher order than the new message, no-op
@@ -352,12 +352,12 @@ class ReactionSet {
     // Puts the message into the ReactionAdds Set index
     txn = txn.put(
       ReactionSet.reactionAddsKey(message.fid(), message.body().type(), targetKey),
-      Buffer.from(message.timestampHash())
+      Buffer.from(message.tsHash())
     );
 
     // Puts message key into the byTarget index
     txn = txn.put(
-      ReactionSet.reactionsByTargetKey(targetKey, message.body().type(), message.fid(), message.timestampHash()),
+      ReactionSet.reactionsByTargetKey(targetKey, message.body().type(), message.fid(), message.tsHash()),
       TRUE_VALUE
     );
 
@@ -369,9 +369,7 @@ class ReactionSet {
     const targetKey = this.targetKeyForMessage(message);
 
     // Delete the message key from byTarget index
-    txn = txn.del(
-      ReactionSet.reactionsByTargetKey(targetKey, message.body().type(), message.fid(), message.timestampHash())
-    );
+    txn = txn.del(ReactionSet.reactionsByTargetKey(targetKey, message.body().type(), message.fid(), message.tsHash()));
 
     // Delete the message key from ReactionAdds Set index
     txn = txn.del(ReactionSet.reactionAddsKey(message.fid(), message.body().type(), targetKey));
@@ -390,7 +388,7 @@ class ReactionSet {
     // Puts message key into the ReactionRemoves Set index
     txn = txn.put(
       ReactionSet.reactionRemovesKey(message.fid(), message.body().type(), targetKey),
-      Buffer.from(message.timestampHash())
+      Buffer.from(message.tsHash())
     );
 
     return txn;

--- a/src/storage/sets/flatbuffers/signerSet.test.ts
+++ b/src/storage/sets/flatbuffers/signerSet.test.ts
@@ -305,9 +305,9 @@ describe('merge', () => {
       });
 
       test('saves message', async () => {
-        await expect(
-          MessageModel.get(db, fid, UserPostfix.SignerMessage, signerRemove.timestampHash())
-        ).resolves.toEqual(signerRemove);
+        await expect(MessageModel.get(db, fid, UserPostfix.SignerMessage, signerRemove.tsHash())).resolves.toEqual(
+          signerRemove
+        );
       });
 
       test('saves signerRemoves index', async () => {
@@ -315,7 +315,7 @@ describe('merge', () => {
       });
 
       test('deletes SignerAdd message', async () => {
-        await expect(MessageModel.get(db, fid, UserPostfix.SignerMessage, signerAdd.timestampHash())).rejects.toThrow(
+        await expect(MessageModel.get(db, fid, UserPostfix.SignerMessage, signerAdd.tsHash())).rejects.toThrow(
           NotFoundError
         );
       });
@@ -346,18 +346,18 @@ describe('merge', () => {
         await set.merge(signerRemove);
         await expect(set.merge(signerRemoveLater)).resolves.toEqual(undefined);
         await expect(set.getSignerRemove(fid, signer, custody1Address)).resolves.toEqual(signerRemoveLater);
-        await expect(
-          MessageModel.get(db, fid, UserPostfix.VerificationMessage, signerRemove.timestampHash())
-        ).rejects.toThrow(NotFoundError);
+        await expect(MessageModel.get(db, fid, UserPostfix.VerificationMessage, signerRemove.tsHash())).rejects.toThrow(
+          NotFoundError
+        );
       });
 
       test('no-ops with an earlier timestamp', async () => {
         await set.merge(signerRemoveLater);
         await expect(set.merge(signerRemove)).resolves.toEqual(undefined);
         await expect(set.getSignerRemove(fid, signer, custody1Address)).resolves.toEqual(signerRemoveLater);
-        await expect(
-          MessageModel.get(db, fid, UserPostfix.VerificationMessage, signerRemove.timestampHash())
-        ).rejects.toThrow(NotFoundError);
+        await expect(MessageModel.get(db, fid, UserPostfix.VerificationMessage, signerRemove.tsHash())).rejects.toThrow(
+          NotFoundError
+        );
       });
 
       // TODO: same signer, different custody address
@@ -385,9 +385,9 @@ describe('merge', () => {
         await expect(set.merge(signerRemove)).resolves.toEqual(undefined);
         await expect(set.getSignerAdd(fid, signer, custody1Address)).resolves.toEqual(signerAddLater);
         await expect(set.getSignerRemove(fid, signer, custody1Address)).rejects.toThrow(NotFoundError);
-        await expect(
-          MessageModel.get(db, fid, UserPostfix.SignerMessage, signerRemove.timestampHash())
-        ).rejects.toThrow(NotFoundError);
+        await expect(MessageModel.get(db, fid, UserPostfix.SignerMessage, signerRemove.tsHash())).rejects.toThrow(
+          NotFoundError
+        );
       });
 
       test('succeeds with a later timestamp', async () => {
@@ -395,7 +395,7 @@ describe('merge', () => {
         await expect(set.merge(signerRemove)).resolves.toEqual(undefined);
         await expect(set.getSignerRemove(fid, signer, custody1Address)).resolves.toEqual(signerRemove);
         await expect(set.getSignerAdd(fid, signer, custody1Address)).rejects.toThrow(NotFoundError);
-        await expect(MessageModel.get(db, fid, UserPostfix.SignerMessage, signerAdd.timestampHash())).rejects.toThrow(
+        await expect(MessageModel.get(db, fid, UserPostfix.SignerMessage, signerAdd.tsHash())).rejects.toThrow(
           NotFoundError
         );
       });
@@ -415,7 +415,7 @@ describe('merge', () => {
       });
 
       test('saves message', async () => {
-        await expect(MessageModel.get(db, fid, UserPostfix.SignerMessage, signerAdd.timestampHash())).resolves.toEqual(
+        await expect(MessageModel.get(db, fid, UserPostfix.SignerMessage, signerAdd.tsHash())).resolves.toEqual(
           signerAdd
         );
       });
@@ -451,7 +451,7 @@ describe('merge', () => {
         await set.merge(signerAdd);
         await expect(set.merge(signerAddLater)).resolves.toEqual(undefined);
         await expect(set.getSignerAdd(fid, signer, custody1Address)).resolves.toEqual(signerAddLater);
-        await expect(MessageModel.get(db, fid, UserPostfix.SignerMessage, signerAdd.timestampHash())).rejects.toThrow(
+        await expect(MessageModel.get(db, fid, UserPostfix.SignerMessage, signerAdd.tsHash())).rejects.toThrow(
           NotFoundError
         );
       });
@@ -460,7 +460,7 @@ describe('merge', () => {
         await set.merge(signerAddLater);
         await expect(set.merge(signerAdd)).resolves.toEqual(undefined);
         await expect(set.getSignerAdd(fid, signer, custody1Address)).resolves.toEqual(signerAddLater);
-        await expect(MessageModel.get(db, fid, UserPostfix.SignerMessage, signerAdd.timestampHash())).rejects.toThrow(
+        await expect(MessageModel.get(db, fid, UserPostfix.SignerMessage, signerAdd.tsHash())).rejects.toThrow(
           NotFoundError
         );
       });
@@ -489,7 +489,7 @@ describe('merge', () => {
         await expect(set.getSignerAdd(fid, signer, custody1Address)).resolves.toEqual(signerAdd);
         await expect(set.getSignerRemove(fid, signer, custody1Address)).rejects.toThrow(NotFoundError);
         await expect(
-          MessageModel.get(db, fid, UserPostfix.SignerMessage, signerRemoveEarlier.timestampHash())
+          MessageModel.get(db, fid, UserPostfix.SignerMessage, signerRemoveEarlier.tsHash())
         ).rejects.toThrow(NotFoundError);
       });
 
@@ -498,7 +498,7 @@ describe('merge', () => {
         await expect(set.merge(signerAdd)).resolves.toEqual(undefined);
         await expect(set.getSignerRemove(fid, signer, custody1Address)).resolves.toEqual(signerRemove);
         await expect(set.getSignerAdd(fid, signer, custody1Address)).rejects.toThrow(NotFoundError);
-        await expect(MessageModel.get(db, fid, UserPostfix.SignerMessage, signerAdd.timestampHash())).rejects.toThrow(
+        await expect(MessageModel.get(db, fid, UserPostfix.SignerMessage, signerAdd.tsHash())).rejects.toThrow(
           NotFoundError
         );
       });

--- a/src/storage/sets/flatbuffers/signerSet.ts
+++ b/src/storage/sets/flatbuffers/signerSet.ts
@@ -171,9 +171,9 @@ class SignerSet {
     bType: MessageType,
     bTimestampHash: Uint8Array
   ): number {
-    const timestampHashOrder = bytesCompare(aTimestampHash, bTimestampHash);
-    if (timestampHashOrder !== 0) {
-      return timestampHashOrder;
+    const tsHashOrder = bytesCompare(aTimestampHash, bTimestampHash);
+    if (tsHashOrder !== 0) {
+      return tsHashOrder;
     }
 
     if (aType === MessageType.SignerRemove && bType === MessageType.SignerAdd) {
@@ -194,7 +194,7 @@ class SignerSet {
       throw new BadRequestError('signer is required');
     }
 
-    // Look up the remove timestampHash for this custody adddress and signer
+    // Look up the remove tsHash for this custody adddress and signer
     const removeTimestampHash = await ResultAsync.fromPromise(
       this._db.get(SignerSet.signerRemovesKey(message.fid(), message.signer(), signer)),
       () => undefined
@@ -206,7 +206,7 @@ class SignerSet {
           MessageType.SignerRemove,
           removeTimestampHash.value,
           message.type(),
-          message.timestampHash()
+          message.tsHash()
         ) >= 0
       ) {
         // If the existing remove has the same or higher order than the new message, no-op
@@ -224,7 +224,7 @@ class SignerSet {
       }
     }
 
-    // Look up the add timestampHash for this custody address and signer
+    // Look up the add tsHash for this custody address and signer
     const addTimestampHash = await ResultAsync.fromPromise(
       this._db.get(SignerSet.signerAddsKey(message.fid(), message.signer(), signer)),
       () => undefined
@@ -232,12 +232,7 @@ class SignerSet {
 
     if (addTimestampHash.isOk()) {
       if (
-        this.SignerMessageCompare(
-          MessageType.SignerAdd,
-          addTimestampHash.value,
-          message.type(),
-          message.timestampHash()
-        ) >= 0
+        this.SignerMessageCompare(MessageType.SignerAdd, addTimestampHash.value, message.type(), message.tsHash()) >= 0
       ) {
         // If the existing add has the same or higher order than the new message, no-op
         return undefined;
@@ -264,7 +259,7 @@ class SignerSet {
     // Put signerAdds index
     txn = txn.put(
       SignerSet.signerAddsKey(message.fid(), message.signer(), message.body().signerArray() ?? new Uint8Array()),
-      Buffer.from(message.timestampHash())
+      Buffer.from(message.tsHash())
     );
 
     return txn;
@@ -287,7 +282,7 @@ class SignerSet {
     // Put signerRemoves index
     txn = txn.put(
       SignerSet.signerRemovesKey(message.fid(), message.signer(), message.body().signerArray() ?? new Uint8Array()),
-      Buffer.from(message.timestampHash())
+      Buffer.from(message.tsHash())
     );
 
     return txn;

--- a/src/storage/sets/flatbuffers/signerSet.ts
+++ b/src/storage/sets/flatbuffers/signerSet.ts
@@ -50,8 +50,8 @@ class SignerSet {
       // Will throw NotFoundError if custody address is missing
       custodyAddress = await this.getCustodyAddress(fid);
     }
-    const messageTimestampHash = await this._db.get(SignerSet.signerAddsKey(fid, custodyAddress, signer));
-    return MessageModel.get<SignerAddModel>(this._db, fid, UserPostfix.SignerMessage, messageTimestampHash);
+    const messageTsHash = await this._db.get(SignerSet.signerAddsKey(fid, custodyAddress, signer));
+    return MessageModel.get<SignerAddModel>(this._db, fid, UserPostfix.SignerMessage, messageTsHash);
   }
 
   /** Look up SignerRemove message by fid, custody address, and signer */
@@ -60,8 +60,8 @@ class SignerSet {
       // Will throw NotFoundError if custody address is missing
       custodyAddress = await this.getCustodyAddress(fid);
     }
-    const messageTimestampHash = await this._db.get(SignerSet.signerRemovesKey(fid, custodyAddress, signer));
-    return MessageModel.get<SignerRemoveModel>(this._db, fid, UserPostfix.SignerMessage, messageTimestampHash);
+    const messageTsHash = await this._db.get(SignerSet.signerRemovesKey(fid, custodyAddress, signer));
+    return MessageModel.get<SignerRemoveModel>(this._db, fid, UserPostfix.SignerMessage, messageTsHash);
   }
 
   /** Get all SignerAdd messages for an fid and custody address */
@@ -167,11 +167,11 @@ class SignerSet {
 
   private SignerMessageCompare(
     aType: MessageType,
-    aTimestampHash: Uint8Array,
+    aTsHash: Uint8Array,
     bType: MessageType,
-    bTimestampHash: Uint8Array
+    bTsHash: Uint8Array
   ): number {
-    const tsHashOrder = bytesCompare(aTimestampHash, bTimestampHash);
+    const tsHashOrder = bytesCompare(aTsHash, bTsHash);
     if (tsHashOrder !== 0) {
       return tsHashOrder;
     }
@@ -195,19 +195,14 @@ class SignerSet {
     }
 
     // Look up the remove tsHash for this custody adddress and signer
-    const removeTimestampHash = await ResultAsync.fromPromise(
+    const removeTsHash = await ResultAsync.fromPromise(
       this._db.get(SignerSet.signerRemovesKey(message.fid(), message.signer(), signer)),
       () => undefined
     );
 
-    if (removeTimestampHash.isOk()) {
+    if (removeTsHash.isOk()) {
       if (
-        this.SignerMessageCompare(
-          MessageType.SignerRemove,
-          removeTimestampHash.value,
-          message.type(),
-          message.tsHash()
-        ) >= 0
+        this.SignerMessageCompare(MessageType.SignerRemove, removeTsHash.value, message.type(), message.tsHash()) >= 0
       ) {
         // If the existing remove has the same or higher order than the new message, no-op
         return undefined;
@@ -218,22 +213,20 @@ class SignerSet {
           this._db,
           message.fid(),
           UserPostfix.SignerMessage,
-          removeTimestampHash.value
+          removeTsHash.value
         );
         txn = this.deleteSignerRemoveTransaction(txn, existingRemove);
       }
     }
 
     // Look up the add tsHash for this custody address and signer
-    const addTimestampHash = await ResultAsync.fromPromise(
+    const addTsHash = await ResultAsync.fromPromise(
       this._db.get(SignerSet.signerAddsKey(message.fid(), message.signer(), signer)),
       () => undefined
     );
 
-    if (addTimestampHash.isOk()) {
-      if (
-        this.SignerMessageCompare(MessageType.SignerAdd, addTimestampHash.value, message.type(), message.tsHash()) >= 0
-      ) {
+    if (addTsHash.isOk()) {
+      if (this.SignerMessageCompare(MessageType.SignerAdd, addTsHash.value, message.type(), message.tsHash()) >= 0) {
         // If the existing add has the same or higher order than the new message, no-op
         return undefined;
       } else {
@@ -243,7 +236,7 @@ class SignerSet {
           this._db,
           message.fid(),
           UserPostfix.SignerMessage,
-          addTimestampHash.value
+          addTsHash.value
         );
         txn = this.deleteSignerAddTransaction(txn, existingAdd);
       }

--- a/src/storage/sets/flatbuffers/verificationSet.test.ts
+++ b/src/storage/sets/flatbuffers/verificationSet.test.ts
@@ -102,7 +102,7 @@ describe('merge', () => {
 
       test('saves message', async () => {
         await expect(
-          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationRemove.timestampHash())
+          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationRemove.tsHash())
         ).resolves.toEqual(verificationRemove);
       });
 
@@ -112,7 +112,7 @@ describe('merge', () => {
 
       test('deletes VerificationAdd* message', async () => {
         await expect(
-          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationAdd.timestampHash())
+          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationAdd.tsHash())
         ).rejects.toThrow(NotFoundError);
       });
 
@@ -140,7 +140,7 @@ describe('merge', () => {
         await expect(set.merge(verificationRemoveLater)).resolves.toEqual(undefined);
         await expect(set.getVerificationRemove(fid, address)).resolves.toEqual(verificationRemoveLater);
         await expect(
-          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationRemove.timestampHash())
+          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationRemove.tsHash())
         ).rejects.toThrow(NotFoundError);
       });
 
@@ -149,7 +149,7 @@ describe('merge', () => {
         await expect(set.merge(verificationRemove)).resolves.toEqual(undefined);
         await expect(set.getVerificationRemove(fid, address)).resolves.toEqual(verificationRemoveLater);
         await expect(
-          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationRemove.timestampHash())
+          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationRemove.tsHash())
         ).rejects.toThrow(NotFoundError);
       });
     });
@@ -170,7 +170,7 @@ describe('merge', () => {
         await expect(set.getVerificationAdd(fid, address)).resolves.toEqual(verificationAddLater);
         await expect(set.getVerificationRemove(fid, address)).rejects.toThrow(NotFoundError);
         await expect(
-          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationRemove.timestampHash())
+          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationRemove.tsHash())
         ).rejects.toThrow(NotFoundError);
       });
 
@@ -180,7 +180,7 @@ describe('merge', () => {
         await expect(set.getVerificationRemove(fid, address)).resolves.toEqual(verificationRemove);
         await expect(set.getVerificationAdd(fid, address)).rejects.toThrow(NotFoundError);
         await expect(
-          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationAdd.timestampHash())
+          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationAdd.tsHash())
         ).rejects.toThrow(NotFoundError);
       });
     });
@@ -200,7 +200,7 @@ describe('merge', () => {
 
       test('saves message', async () => {
         await expect(
-          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationAdd.timestampHash())
+          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationAdd.tsHash())
         ).resolves.toEqual(verificationAdd);
       });
 
@@ -233,7 +233,7 @@ describe('merge', () => {
         await expect(set.merge(verificationAddLater)).resolves.toEqual(undefined);
         await expect(set.getVerificationAdd(fid, address)).resolves.toEqual(verificationAddLater);
         await expect(
-          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationAdd.timestampHash())
+          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationAdd.tsHash())
         ).rejects.toThrow(NotFoundError);
       });
 
@@ -242,7 +242,7 @@ describe('merge', () => {
         await expect(set.merge(verificationAdd)).resolves.toEqual(undefined);
         await expect(set.getVerificationAdd(fid, address)).resolves.toEqual(verificationAddLater);
         await expect(
-          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationAdd.timestampHash())
+          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationAdd.tsHash())
         ).rejects.toThrow(NotFoundError);
       });
     });
@@ -263,7 +263,7 @@ describe('merge', () => {
         await expect(set.getVerificationAdd(fid, address)).resolves.toEqual(verificationAdd);
         await expect(set.getVerificationRemove(fid, address)).rejects.toThrow(NotFoundError);
         await expect(
-          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationRemoveEarlier.timestampHash())
+          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationRemoveEarlier.tsHash())
         ).rejects.toThrow(NotFoundError);
       });
 
@@ -273,7 +273,7 @@ describe('merge', () => {
         await expect(set.getVerificationRemove(fid, address)).resolves.toEqual(verificationRemove);
         await expect(set.getVerificationAdd(fid, address)).rejects.toThrow(NotFoundError);
         await expect(
-          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationAdd.timestampHash())
+          MessageModel.get(db, fid, UserPostfix.VerificationMessage, verificationAdd.tsHash())
         ).rejects.toThrow(NotFoundError);
       });
     });

--- a/src/storage/sets/flatbuffers/verificationSet.ts
+++ b/src/storage/sets/flatbuffers/verificationSet.ts
@@ -145,9 +145,9 @@ class VerificationSet {
     bType: MessageType,
     bTimestampHash: Uint8Array
   ): number {
-    const timestampHashOrder = bytesCompare(aTimestampHash, bTimestampHash);
-    if (timestampHashOrder !== 0) {
-      return timestampHashOrder;
+    const tsHashOrder = bytesCompare(aTimestampHash, bTimestampHash);
+    if (tsHashOrder !== 0) {
+      return tsHashOrder;
     }
 
     if (aType === MessageType.VerificationRemove && bType === MessageType.VerificationAddEthAddress) {
@@ -164,7 +164,7 @@ class VerificationSet {
     address: Uint8Array,
     message: VerificationAddEthAddressModel | VerificationRemoveModel
   ): Promise<Transaction | undefined> {
-    // Look up the remove timestampHash for this address
+    // Look up the remove tsHash for this address
     const removeTimestampHash = await ResultAsync.fromPromise(
       this._db.get(VerificationSet.verificationRemovesKey(message.fid(), address)),
       () => undefined
@@ -176,7 +176,7 @@ class VerificationSet {
           MessageType.VerificationRemove,
           removeTimestampHash.value,
           message.type(),
-          message.timestampHash()
+          message.tsHash()
         ) >= 0
       ) {
         // If the existing remove has the same or higher order than the new message, no-op
@@ -194,7 +194,7 @@ class VerificationSet {
       }
     }
 
-    // Look up the add timestampHash for this address
+    // Look up the add tsHash for this address
     const addTimestampHash = await ResultAsync.fromPromise(
       this._db.get(VerificationSet.verificationAddsKey(message.fid(), address)),
       () => undefined
@@ -206,7 +206,7 @@ class VerificationSet {
           MessageType.VerificationAddEthAddress,
           addTimestampHash.value,
           message.type(),
-          message.timestampHash()
+          message.tsHash()
         ) >= 0
       ) {
         // If the existing add has the same or higher order than the new message, no-op
@@ -234,7 +234,7 @@ class VerificationSet {
     // Put verificationAdds index
     tsx = tsx.put(
       VerificationSet.verificationAddsKey(message.fid(), message.body().addressArray() ?? new Uint8Array()),
-      Buffer.from(message.timestampHash())
+      Buffer.from(message.tsHash())
     );
 
     return tsx;
@@ -257,7 +257,7 @@ class VerificationSet {
     // Add to verificationRemoves
     tsx = tsx.put(
       VerificationSet.verificationRemovesKey(message.fid(), message.body().addressArray() ?? new Uint8Array()),
-      Buffer.from(message.timestampHash())
+      Buffer.from(message.tsHash())
     );
 
     return tsx;

--- a/src/test/factories/flatbuffer.ts
+++ b/src/test/factories/flatbuffer.ts
@@ -47,7 +47,7 @@ const FIDFactory = Factory.define<Uint8Array>(() => {
   return new Uint8Array([faker.datatype.number(255)]);
 });
 
-const TimestampHashFactory = Factory.define<Uint8Array>(() => {
+const TsHashFactory = Factory.define<Uint8Array>(() => {
   const builder = new Builder();
   builder.addInt32(faker.date.recent().getTime());
   const hash = arrayify(faker.datatype.hexadecimal({ length: 4 }).toLowerCase());
@@ -71,7 +71,7 @@ const CastIDFactory = Factory.define<CastIDT, any, CastID>(({ onCreate }) => {
     return CastID.getRootAsCastID(new ByteBuffer(builder.asUint8Array()));
   });
 
-  return new CastIDT(Array.from(FIDFactory.build()), Array.from(TimestampHashFactory.build()));
+  return new CastIDT(Array.from(FIDFactory.build()), Array.from(TsHashFactory.build()));
 });
 
 const MessageDataFactory = Factory.define<MessageDataT, any, MessageData>(({ onCreate }) => {
@@ -125,7 +125,7 @@ const CastRemoveBodyFactory = Factory.define<CastRemoveBodyT, any, CastRemoveBod
     return CastRemoveBody.getRootAsCastRemoveBody(new ByteBuffer(builder.asUint8Array()));
   });
 
-  return new CastRemoveBodyT(Array.from(TimestampHashFactory.build()));
+  return new CastRemoveBodyT(Array.from(TsHashFactory.build()));
 });
 
 const CastRemoveDataFactory = Factory.define<MessageDataT, any, MessageData>(({ onCreate }) => {
@@ -366,7 +366,7 @@ const IDRegistryEventFactory = Factory.define<ContractEventT, any, ContractEvent
 
 const Factories = {
   FID: FIDFactory,
-  TimestampHash: TimestampHashFactory,
+  TsHash: TsHashFactory,
   UserID: UserIDFactory,
   CastID: CastIDFactory,
   ReactionBody: ReactionBodyFactory,


### PR DESCRIPTION
## Motivation

Variables names for certain constructs (e.g. `reactionRemoveTimestampHash`) were becoming verbose and using `TsHash` instead of `TimestampHash` avoids a lot of unnecessary density. 

## Change Summary

All instances of timestampHash were changed to tsHash, and some incorrectly named instances of hash were renamed to tsHash

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
