### PR TITLE
refactor(sets): rename flatbuffer sets to stores

### DIFF
--- a/src/storage/db/cast.ts
+++ b/src/storage/db/cast.ts
@@ -19,7 +19,7 @@ import MessageDB from '~/storage/db/message';
  * Note that the CastDB implements the constraint that a single cast hash can only exist in either castAdds
  * or castRemoves. Therefore, _putCastAdd also deletes the CastRemove for the same cast hash and _putCastRemove
  * also deletes the CastShort or CastRecast for the same target. The CastDB does not resolve conflicts between two cast
- * messages with the same cast hash. The CastSet should be used to handle conflicts and decide whether or not to
+ * messages with the same cast hash. The CastStore should be used to handle conflicts and decide whether or not to
  * perform a mutation.
  */
 class CastDB extends MessageDB {

--- a/src/storage/db/follow.ts
+++ b/src/storage/db/follow.ts
@@ -16,7 +16,7 @@ import MessageDB from '~/storage/db/message';
  * Note that the FollowDB implements the constraint that a single target can only exist in either followAdds
  * or followRemoves. Therefore, _putFollowAdd also deletes the FollowRemove for the same target and _putFollowRemove
  * also deletes the FollowAdd for the same target. The FollowDB does not resolve conflicts between two follow
- * messages with the same target. The FollowSet should be used to handle conflicts and decide whether or not to
+ * messages with the same target. The FollowStore should be used to handle conflicts and decide whether or not to
  * perform a mutation.
  */
 class FollowDB extends MessageDB {

--- a/src/storage/db/signer.ts
+++ b/src/storage/db/signer.ts
@@ -20,7 +20,7 @@ import MessageDB from '~/storage/db/message';
  * Note that the SignerDB implements the constraint that a single target can only exist in either signerAdds
  * or signerRemoves for a given custody address. Therefore, _putSignerAdd also deletes the SignerRemove for the same
  * delegate and _putSignerRemove also deletes the SignerAdd for the same delegate. The SignerDB does not resolve
- * conflicts between two signer messages with the same delegate. The SignerSet should be used to handle conflicts and
+ * conflicts between two signer messages with the same delegate. The SignerStore should be used to handle conflicts and
  * decide whether or not to perform a mutation.
  */
 class SignerDB extends MessageDB {

--- a/src/storage/db/verification.ts
+++ b/src/storage/db/verification.ts
@@ -15,7 +15,7 @@ import MessageDB from '~/storage/db/message';
  * Note that the VerificationDB implements the constraint that a single claimHash can only exist in either verificationAdds
  * or verificationRemoves. Therefore, _putVerificationAdd also deletes the VerificationRemove for the same target and
  * _putVerificationRemove also deletes the VerificationEthereumAddress for the same target. The VerificationDB does not resolve
- * conflicts between two verification messages with the same claimHash. The VerificationSet should be used to handle conflicts and
+ * conflicts between two verification messages with the same claimHash. The VerificationStore should be used to handle conflicts and
  * decide whether or not to perform a mutation.
  */
 class VerificationDB extends MessageDB {

--- a/src/storage/sets/flatbuffers/castStore.test.ts
+++ b/src/storage/sets/flatbuffers/castStore.test.ts
@@ -1,12 +1,12 @@
 import Factories from '~/test/factories/flatbuffer';
-import CastSet from '~/storage/sets/flatbuffers/castSet';
+import CastStore from '~/storage/sets/flatbuffers/castStore';
 import { jestBinaryRocksDB } from '~/storage/db/jestUtils';
 import MessageModel from '~/storage/flatbuffers/messageModel';
 import { BadRequestError, NotFoundError } from '~/utils/errors';
 import { CastAddModel, CastRemoveModel, UserPostfix } from '~/storage/flatbuffers/types';
 
 const db = jestBinaryRocksDB('flatbuffers.castSet.test');
-const set = new CastSet(db);
+const set = new CastStore(db);
 const fid = Factories.FID.build();
 
 let castAdd: CastAddModel;

--- a/src/storage/sets/flatbuffers/followStore.test.ts
+++ b/src/storage/sets/flatbuffers/followStore.test.ts
@@ -3,10 +3,10 @@ import { jestBinaryRocksDB } from '~/storage/db/jestUtils';
 import MessageModel from '~/storage/flatbuffers/messageModel';
 import { BadRequestError, NotFoundError } from '~/utils/errors';
 import { FollowAddModel, FollowRemoveModel, UserPostfix } from '~/storage/flatbuffers/types';
-import FollowSet from '~/storage/sets/flatbuffers/followSet';
+import FollowStore from '~/storage/sets/flatbuffers/followStore';
 
 const db = jestBinaryRocksDB('flatbuffers.followSet.test');
-const set = new FollowSet(db);
+const set = new FollowStore(db);
 const fid = Factories.FID.build();
 
 const userId = Factories.FID.build();

--- a/src/storage/sets/flatbuffers/signerStore.test.ts
+++ b/src/storage/sets/flatbuffers/signerStore.test.ts
@@ -5,13 +5,13 @@ import { BadRequestError, NotFoundError } from '~/utils/errors';
 import { EthereumSigner } from '~/types';
 import { generateEd25519KeyPair, generateEthereumSigner } from '~/utils/crypto';
 import { arrayify } from 'ethers/lib/utils';
-import SignerSet from '~/storage/sets/flatbuffers/signerSet';
+import SignerStore from '~/storage/sets/flatbuffers/signerStore';
 import ContractEventModel from '~/storage/flatbuffers/contractEventModel';
 import { SignerAddModel, SignerRemoveModel, UserPostfix } from '~/storage/flatbuffers/types';
 import MessageModel from '~/storage/flatbuffers/messageModel';
 
 const db = jestBinaryRocksDB('flatbuffers.signerSet.test');
-const set = new SignerSet(db);
+const set = new SignerStore(db);
 const fid = Factories.FID.build();
 
 let custody1: EthereumSigner;

--- a/src/storage/sets/flatbuffers/verificationStore.test.ts
+++ b/src/storage/sets/flatbuffers/verificationStore.test.ts
@@ -3,14 +3,14 @@ import { jestBinaryRocksDB } from '~/storage/db/jestUtils';
 import MessageModel from '~/storage/flatbuffers/messageModel';
 import { BadRequestError, NotFoundError } from '~/utils/errors';
 import { UserPostfix, VerificationAddEthAddressModel, VerificationRemoveModel } from '~/storage/flatbuffers/types';
-import VerificationSet from '~/storage/sets/flatbuffers/verificationSet';
+import VerificationStore from '~/storage/sets/flatbuffers/verificationStore';
 import { EthereumSigner } from '~/types';
 import { generateEthereumSigner } from '~/utils/crypto';
 import { FarcasterNetwork } from '~/utils/generated/message_generated';
 import { arrayify } from 'ethers/lib/utils';
 
 const db = jestBinaryRocksDB('flatbuffers.verificationSet.test');
-const set = new VerificationSet(db);
+const set = new VerificationStore(db);
 const fid = Factories.FID.build();
 
 let ethSigner: EthereumSigner;


### PR DESCRIPTION
## Motivation

See #199 

## Change Summary

Renaming all other sets to stores

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)