### PR TITLE
debug: add second CMD to bust cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,3 +56,5 @@ COPY --chown=node:node --from=build /home/node/app/src ./src
 RUN yarn identity create
 
 CMD ["yarn", "tsx", "src/cli.ts", "start", "--rpc-port", "8080", "--gossip-port", "9090" ]
+
+CMD ["yarn", "tsx", "src/cli.ts", "start", "--rpc-port", "8080", "--gossip-port", "9090" ]


### PR DESCRIPTION
## Change Summary

Adding a duplicate CMD to bust an incorrect docker cache layer in our deploy pipeline. This should be reverted once the issue is resolved. 

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)