### PR TITLE
feat: initialize sync trie with existing messages on hub boot

### DIFF
--- a/src/network/sync/syncEngine.test.ts
+++ b/src/network/sync/syncEngine.test.ts
@@ -119,4 +119,21 @@ describe('SyncEngine', () => {
     const shouldSync = syncEngine.shouldSync(snapshot.excludedHashes, snapshot.numMessages + 1);
     expect(shouldSync).toBeFalsy();
   });
+
+  test('initialize populates the trie with all existing messages', async () => {
+    const user = await mockFid(engine, faker.datatype.number());
+    const messages = await addMessagesWithTimestamps(user, [1665182332, 1665182333, 1665182334]);
+
+    const syncEngine = new SyncEngine(engine);
+    expect(syncEngine.trie.items).toEqual(0);
+
+    await syncEngine.initialize();
+
+    // There might be more messages related to user creation, but it's sufficient to check for casts
+    expect(syncEngine.trie.items).toBeGreaterThanOrEqual(3);
+    expect(syncEngine.trie.rootHash).toBeTruthy();
+    expect(syncEngine.trie.get(new SyncId(messages[0]))).toBeTruthy();
+    expect(syncEngine.trie.get(new SyncId(messages[1]))).toBeTruthy();
+    expect(syncEngine.trie.get(new SyncId(messages[2]))).toBeTruthy();
+  });
 });

--- a/src/network/sync/syncEngine.ts
+++ b/src/network/sync/syncEngine.ts
@@ -36,6 +36,19 @@ class SyncEngine {
     });
   }
 
+  public async initialize() {
+    // TODO: cache the trie to disk, and use this only when the cache doesn't exist
+    let processedMessages = 0;
+    await this.engine.forEachMessage((message) => {
+      this.addMessage(message);
+      processedMessages += 1;
+      if (processedMessages % 10_000 === 0) {
+        log.info({ processedMessages }, 'Initializing sync engine');
+      }
+    });
+    log.info({ processedMessages }, 'Sync engine initialized');
+  }
+
   public addMessage(message: Message): void {
     this._trie.insert(new SyncId(message));
   }

--- a/src/storage/db/message.test.ts
+++ b/src/storage/db/message.test.ts
@@ -88,3 +88,21 @@ describe('getMessagesBySigner', () => {
     expect(follows).toEqual([follow1]);
   });
 });
+
+describe('forEachMessage', () => {
+  test('iterates over all messages', async () => {
+    await db.putMessage(cast1);
+    await db.putMessage(cast2);
+    await db.putMessage(follow1);
+
+    const messages: any[] = [];
+    await db.forEachMessage((message) => {
+      messages.push(message);
+    });
+
+    expect(messages.length).toEqual(3);
+    expect(messages).toContainEqual(cast1);
+    expect(messages).toContainEqual(cast2);
+    expect(messages).toContainEqual(cast1);
+  });
+});

--- a/src/storage/db/message.ts
+++ b/src/storage/db/message.ts
@@ -76,6 +76,16 @@ class MessageDB {
     return this.getMessages<T>(hashes);
   }
 
+  async forEachMessage(callback: (message: Message) => void) {
+    for await (const [, value] of this._db.iteratorByPrefix(this.messagesPrefix(), {
+      keys: false,
+      valueAsBuffer: false,
+    })) {
+      const msg = JSON.parse(value);
+      if (isMessage(msg)) callback(msg as Message);
+    }
+  }
+
   /* -------------------------------------------------------------------------- */
   /*                             Private Key Methods                            */
   /* -------------------------------------------------------------------------- */

--- a/src/storage/engine/index.ts
+++ b/src/storage/engine/index.ts
@@ -148,6 +148,10 @@ class Engine extends TypedEmitter<EngineEvents> {
     return this._messageDB.getMessages(hashes);
   }
 
+  public async forEachMessage(callback: (message: Message) => void) {
+    await this._messageDB.forEachMessage(callback);
+  }
+
   /* -------------------------------------------------------------------------- */
   /*                                Cast Methods                                */
   /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Motivation

Ensure trie is in sync with the messages already present in the engine on hub boot. Otherwise, we'll perform redundant syncs just to populate the merkle trie. Note, this is slow. For better performance, we should optimize the trie and cache it on disk and use this codepath only to repair the trie. Will implement in a followup PR.

## Change Summary

Iterate through all messages in the DB on boot and populate the merkle trie in the sync engine.

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

