### PR TITLE
[NOMERGE] fix(libp2p): use plaintext instead of noise to pass healthchecks

### DIFF
--- a/src/network/p2p/node.ts
+++ b/src/network/p2p/node.ts
@@ -1,5 +1,5 @@
 import { GossipSub } from '@chainsafe/libp2p-gossipsub';
-import { Noise } from '@chainsafe/libp2p-noise';
+import { Plaintext } from 'libp2p/insecure';
 import { Connection } from '@libp2p/interface-connection';
 import { PeerId } from '@libp2p/interface-peer-id';
 import { Mplex } from '@libp2p/mplex';
@@ -276,7 +276,7 @@ export class Node extends TypedEmitter<NodeEvents> {
       },
       transports: [new TCP()],
       streamMuxers: [new Mplex()],
-      connectionEncryption: [new Noise()],
+      connectionEncryption: [new Plaintext()],
       peerDiscovery: [new PubSubPeerDiscovery()],
       pubsub: gossip,
     });


### PR DESCRIPTION
## Motivation

The hub is failing healthchecks when the NLB pings it on the gossip port, possible due to how Noise protocol works. Attempting to roll it back to plaintext to see if that helps. 

## Change Summary

See above

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
