### PR TITLE
chore: do not fail coverage if patch is below target

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,9 @@ coverage:
       default:
         target: 85%
         threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 0%
+        base: auto
+        if_ci_failed: success


### PR DESCRIPTION
## Motivation

Patch failures cause a lot of false positives 

## Change Summary

Decreasing coverage on a patch does not fail CI as long as overall test coverage is above the target

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
