### PR TITLE
fix(config): Default to IPv6 for Gossip and RPC 

### DIFF
--- a/.config/hub.config.ts
+++ b/.config/hub.config.ts
@@ -17,7 +17,7 @@ export const Config = {
   /** An "allow list" of Peer Ids. Blocks all other connections */
   // allowedPeers: [],
   /** The IP address libp2p should listen on. */
-  ip: '127.0.0.1',
+  ip: '::',
   /** The TCP port libp2p should listen on. */
   gossipPort: 0,
   /** The RPC port to use. */

--- a/src/network/rpc/server.ts
+++ b/src/network/rpc/server.ts
@@ -125,7 +125,7 @@ export class RPCServer {
     return new Promise((resolve, reject) => {
       try {
         // start the tcp server
-        this._tcpServer = this._jsonServer.tcp().listen(port, '127.0.0.1', () => {
+        this._tcpServer = this._jsonServer.tcp().listen(port, () => {
           log.info({ address: this.multiaddr, function: 'start' }, 'RPC server started');
           resolve();
         });


### PR DESCRIPTION
## Motivation

AWS healthchecks fail on expoed ports if the application is not listening on IPv6.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
