### PR TITLE
fix(gossip): store addresses from existing connections into the address book

### DIFF
--- a/src/hub.ts
+++ b/src/hub.ts
@@ -186,7 +186,10 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
 
   async handleContactInfo(message: ContactInfoContent) {
     const rpcClient = await this.getRPCClientForPeer(message);
-    log.info({ identity: this.identity, peer: message.peerId }, 'received a Contact Info for sync');
+    log.info(
+      { identity: this.identity, peer: message.peerId, ip: rpcClient?.serverMultiaddr },
+      'received a Contact Info for sync'
+    );
     await this.diffSyncIfRequired(message, rpcClient);
   }
 
@@ -230,7 +233,7 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
       );
       return;
     }
-    const peerAddress = await this.gossipNode.getPeerAddress(peerId);
+    const peerAddress = await this.gossipNode.getPeerInfo(peerId);
     if (!peerAddress) {
       log.info(
         { function: 'getRPCClientForPeer', identity: this.identity, peer: peer },


### PR DESCRIPTION
## Motivation

Hub's don't know their public addresses. Libp2p doesn't figure out the public IP correctly and so we need to have something to fall back on.

## Change Summary

Since we bootstrap with a public multiaddr, libp2p should store that addr in the addressbook. 

This PR manually updates the addressbook to store the address of any open connections with a peer. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
