### PR TITLE
fix(VerificationStore): increase test coverage, change conflict resolution, add docs

### DIFF
--- a/src/storage/flatbuffers/types.ts
+++ b/src/storage/flatbuffers/types.ts
@@ -105,6 +105,19 @@ export interface ReactionRemoveModel extends MessageModel {
   body(): ReactionBody;
 }
 
+/**
+ * A Verification that proves ownership of an Ethereum address with a two-way signature.
+ *
+ * The Ethereum address must produce an EIP-712 signature of the fid, address, blockHash, and
+ * Farcaster Network. The signature is stored in the body of the message along with the address
+ * of the Ethereum address which is then signed by one of the user's signers, establishing a
+ * two-way link between the Ethereum address and the user's Farcaster identity. An Ethereum address
+ * can only be verified once per fid, but can be verified to multiple fids.
+ *
+ * body.address - the ethereum address being verified
+ * body.ethSignature - the signature of the message
+ * body.blockHash - user-reported latest ethereum block hash at time of signing
+ */
 export interface VerificationAddEthAddressModel extends MessageModel {
   body(): VerificationAddEthAddressBody;
 }

--- a/src/storage/sets/flatbuffers/signerStore.ts
+++ b/src/storage/sets/flatbuffers/signerStore.ts
@@ -17,7 +17,7 @@ import ContractEventModel from '~/storage/flatbuffers/contractEventModel';
  * signed by the custody address that currently holds the fid are considered active. All other
  * Farcaster Messages must be signed by an active signer.
  *
- * Signers can be removed with a SignerREmove message signed by the user's custody address.
+ * Signers can be removed with a SignerRemove message signed by the user's custody address.
  * Removing a signer also removes all messages signed by it, and should only be invoked if a
  * compromise is suspected.
  *

--- a/src/storage/sets/flatbuffers/verificationStore.test.ts
+++ b/src/storage/sets/flatbuffers/verificationStore.test.ts
@@ -9,7 +9,7 @@ import { generateEthereumSigner } from '~/utils/crypto';
 import { FarcasterNetwork } from '~/utils/generated/message_generated';
 import { arrayify } from 'ethers/lib/utils';
 
-const db = jestBinaryRocksDB('flatbuffers.verificationSet.test');
+const db = jestBinaryRocksDB('flatbuffers.verificationStore.test');
 const set = new VerificationStore(db);
 const fid = Factories.FID.build();
 

--- a/src/storage/sets/flatbuffers/verificationStore.ts
+++ b/src/storage/sets/flatbuffers/verificationStore.ts
@@ -181,12 +181,11 @@ class VerificationStore {
     bType: MessageType,
     bTsHash: Uint8Array
   ): number {
-    const tsHashOrder = bytesCompare(aTsHash, bTsHash);
-    if (tsHashOrder !== 0) {
-      return tsHashOrder;
+    // Compare timestamps (first 4 bytes of tsHash) to enforce Last-Write-Wins
+    const timestampOrder = bytesCompare(aTsHash.subarray(0, 4), bTsHash.subarray(0, 4));
+    if (timestampOrder !== 0) {
+      return timestampOrder;
     }
-
-    // TODO: change comparison type
 
     if (aType === MessageType.VerificationRemove && bType === MessageType.VerificationAddEthAddress) {
       return 1;
@@ -194,7 +193,8 @@ class VerificationStore {
       return -1;
     }
 
-    return 0;
+    // Compare hashes (last 4 bytes of tsHash) to break ties between messages of the same type and timestamp
+    return bytesCompare(aTsHash.subarray(4), bTsHash.subarray(4));
   }
 
   private async resolveMergeConflicts(

--- a/src/storage/sets/flatbuffers/verificationStore.ts
+++ b/src/storage/sets/flatbuffers/verificationStore.ts
@@ -20,27 +20,19 @@ import { MessageType } from '~/utils/generated/message_generated';
  * 2. Remove wins over Adds
  * 3. Highest lexicographic hash wins
  *
- * TODO: complete docs once discussion items are sorted out.
+ * VerificationAddEthAddress is currently the only supported Verification type today. The key-value
+ * entries created by Verification Store are:
  *
+ * 1. fid:tsHash -> reaction message
+ * 2. fid:set:address -> fid:tsHash (Set Index)
  */
+
 class VerificationStore {
   private _db: RocksDB;
 
   constructor(db: RocksDB) {
     this._db = db;
   }
-
-  // DISCUSS: A verification type needs a unique key to resolve conflicts correctly. The
-  // VerificationAddEthereumAddress uses the Ethereum address as this identifier. But it is quite
-  // possible that we may add a verification type that has a unique property other than address.
-  // One idea to make this easier to extend is to have a generic "identifier" property on the model
-  // which is always set directly to the key and all methods calling any subtype of Verification
-  // can safely assume it exists. Another option is building a method on top of the model that
-  // can return the field, which allows us to combine por manipulate fields. Either approach offers
-  // more flexibility than the current approach which has methods strictly tied to "Address".
-
-  // DISCUSS: a similar problem to the one above exists for ordinality, where we depend on
-  // "sub properties" like the blockhash to resolve conflicts.
 
   /**
    * Generates a unique key used to store a VerificationAdds message key in the VerificationsAdds


### PR DESCRIPTION
## Change Summary

- fix: sorting of messages should be performed by timestamp, then type, then hash similar to other stores
- added documentation for classes and methods
- increase test coverage for branches in merge

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)