### PR TITLE
add a failing test case

### DIFF
--- a/src/utils/eip712.test.ts
+++ b/src/utils/eip712.test.ts
@@ -31,6 +31,85 @@ describe('signVerificationEthAddressClaim', () => {
     const recoveredAddress = verifyVerificationEthAddressClaimSignature(claim, signature);
     expect(recoveredAddress).toEqual(arrayify(ethSigner.signerKey));
   });
+
+  test('encoding twice works', async () => {
+    const fid1 = new Uint8Array(4);
+    fid1[0] = 8;
+    fid1[1] = 32;
+    fid1[2] = 69;
+    fid1[3] = 255;
+
+    const fid2 = new Uint8Array(4);
+    fid2[0] = 8;
+    fid2[1] = 32;
+    fid2[2] = 69;
+    fid2[3] = 255;
+
+    const claim1: VerificationEthAddressClaim = {
+      fid: fid1,
+      address: ethSigner.signerKey,
+      blockHash: arrayify(faker.datatype.hexadecimal({ length: 64, case: 'lower' })),
+      network: FarcasterNetwork.Testnet,
+    };
+    const claim2: VerificationEthAddressClaim = {
+      fid: fid2,
+      address: claim1.address,
+      blockHash: claim1.blockHash,
+      network: claim1.network,
+    };
+
+    const signature1 = await signVerificationEthAddressClaim(claim1, ethSigner.wallet);
+    expect(signature1).toBeTruthy();
+
+    const signature2 = await signVerificationEthAddressClaim(claim2, ethSigner.wallet);
+    expect(signature2).toBeTruthy();
+
+    const hex1 = Buffer.from(signature1).toString('hex');
+    const hex2 = Buffer.from(signature2).toString('hex');
+
+    expect(hex1).toEqual(hex2);
+  });
+
+  test('32bit fid & 256bit fid encode the same', async () => {
+    const fid1 = new Uint8Array(4);
+    fid1[0] = 8;
+    fid1[1] = 32;
+    fid1[2] = 69;
+    fid1[3] = 255;
+
+    const fid2 = new Uint8Array(32);
+    fid2[0] = 8;
+    fid2[1] = 32;
+    fid2[2] = 69;
+    fid2[3] = 255;
+    for (let i = 4; i < 31; i++) {
+      fid2[i] = 0;
+    }
+
+    const claim1: VerificationEthAddressClaim = {
+      fid: fid1,
+      address: ethSigner.signerKey,
+      blockHash: arrayify(faker.datatype.hexadecimal({ length: 64, case: 'lower' })),
+      network: FarcasterNetwork.Testnet,
+    };
+    const claim2: VerificationEthAddressClaim = {
+      fid: fid2,
+      address: claim1.address,
+      blockHash: claim1.blockHash,
+      network: claim1.network,
+    };
+
+    const signature1 = await signVerificationEthAddressClaim(claim1, ethSigner.wallet);
+    expect(signature1).toBeTruthy();
+
+    const signature2 = await signVerificationEthAddressClaim(claim2, ethSigner.wallet);
+    expect(signature2).toBeTruthy();
+
+    const hex1 = Buffer.from(signature1).toString('hex');
+    const hex2 = Buffer.from(signature2).toString('hex');
+
+    expect(hex1).toEqual(hex2);
+  });
 });
 
 describe('signMessageData', () => {


### PR DESCRIPTION
## Motivation

EIP712 encoding is picky with uint8 array size.

## Change Summary

fid need to be treated as 32byte uint8arrays

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
