### PR TITLE
feat(p2p): advertise public IP over gossip

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@libp2p/peer-id-factory": "^1.0.18",
     "@libp2p/pubsub-peer-discovery": "^6.0.2",
     "@libp2p/tcp": "^3.1.1",
+    "@libp2p/utils": "^3.0.2",
     "@multiformats/multiaddr": "^11.0.0",
     "@noble/ed25519": "^1.6.1",
     "caip": "^1.1.0",

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -56,6 +56,13 @@ export interface HubOptions {
 
   /** Resets the DB on start, if true */
   resetDB?: boolean;
+
+  /**
+   * Only allows the Hub to connect to and advertise local IP addresses
+   *
+   * Only used by tests
+   */
+  localIpAddrsOnly?: boolean;
 }
 
 /** @returns A randomized string of the format `rocksdb.tmp.*` used for the DB Name */
@@ -137,7 +144,8 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
         // creates an AddrInfo for Gossip
         let gossipInfo = {};
         const localAddrs = this.gossipAddresses;
-        if (localAddrs.length > 0) {
+        // publishes the public IP address of this Hub if public addressing is allowed
+        if (localAddrs.length > 0 && !this.options.localIpAddrsOnly) {
           const ipAddr = await getPublicIp();
           const port = localAddrs[0].nodeAddress().port;
           addressInfoFromParts(ipAddr, port).map((gossipAddress) => {

--- a/src/network/p2p/connectionFilter.ts
+++ b/src/network/p2p/connectionFilter.ts
@@ -14,9 +14,9 @@ import { logger } from '~/utils/logger';
  * Using arrow functions allows their recursivePartial enumerator to parse the object.
  */
 export class ConnectionFilter implements ConnectionGater {
-  private allowedPeers: string[];
+  private allowedPeers: string[] | undefined;
 
-  constructor(addrs: string[]) {
+  constructor(addrs: string[] | undefined) {
     this.allowedPeers = addrs;
   }
 
@@ -41,7 +41,6 @@ export class ConnectionFilter implements ConnectionGater {
      * A PeerId is not always known on incipient connections.
      * Don't filter incipient connections, later filters will catch it.
      */
-    logger.info(_maConn, `ConnectionFilter denyInboundConnection: denied a connection`);
     return false;
   };
 
@@ -96,6 +95,8 @@ export class ConnectionFilter implements ConnectionGater {
 
   private shouldDeny(peerId: string | null) {
     if (!peerId) return Promise.resolve(true);
+    if (this.allowedPeers === undefined) return Promise.resolve(false);
+
     const found = this.allowedPeers.find((value) => {
       return peerId && value === peerId;
     });

--- a/src/network/p2p/protocol.test.ts
+++ b/src/network/p2p/protocol.test.ts
@@ -9,6 +9,7 @@ import {
   UserContent,
 } from '~/network/p2p/protocol';
 import { isGossipMessage } from '~/types/typeguards';
+import { createEd25519PeerId } from '@libp2p/peer-id-factory';
 
 let cast: CastShort;
 let idRegistryEvent: IdRegistryEvent;
@@ -89,10 +90,11 @@ describe('encode/decode', () => {
     expect(decoded._unsafeUnwrap()).toStrictEqual(message);
   });
 
-  test('encode and decode a ContactInfo message', () => {
+  test('encode and decode a ContactInfo message', async () => {
+    const peerId = await createEd25519PeerId();
     const message: GossipMessage<ContactInfoContent> = {
       content: {
-        peerId: '',
+        peerId: peerId.toString(),
         excludedHashes: ['asd', 'def'],
         count: 0,
       },

--- a/src/network/p2p/protocol.ts
+++ b/src/network/p2p/protocol.ts
@@ -50,12 +50,15 @@ export type IdRegistryContent = {
  * ContactInfoContent allows gossip nodes to share additional information about each other
  * over the gossip network.
  *
+ * @publicKey - The publicKey of the correspinding peer
+ * @gossipAddress - The address at which this node is listening for Gossip messages. Unset if Gossip is not public.
  * @rpcAddress - The address at which this node is serving RPC requests. Unset if RPC is not offered.
  * @excludedHashes - The excluded hashes of the sender's current trie snapshot
  * @count - The number of messages under the root
  */
 export type ContactInfoContent = {
   peerId: string;
+  gossipAddress?: AddressInfo;
   rpcAddress?: AddressInfo;
   excludedHashes: string[];
   count: number;
@@ -86,7 +89,6 @@ export const decodeMessage = (data: Uint8Array): Result<GossipMessage, string> =
     const json = new TextDecoder().decode(data);
     const message: GossipMessage = JSON.parse(json);
 
-    // Error checking? exception handling?
     if (!message || !isGossipMessage(message)) {
       return err('Failed to decode Gossip message...');
     }

--- a/src/test/e2e/hub.test.ts
+++ b/src/test/e2e/hub.test.ts
@@ -12,7 +12,7 @@ import { jest } from '@jest/globals';
 
 const TEST_TIMEOUT_SHORT = 10 * 1000;
 const TEST_TIMEOUT_LONG = 2 * 60 * 1000;
-const opts: HubOptions = {};
+const opts: HubOptions = { localIpAddrsOnly: true };
 
 let hub: Hub;
 
@@ -78,17 +78,17 @@ describe('Hub running tests', () => {
     'bootstrap one Hub off of another',
     async () => {
       // populate Hub1's engine
-      await populateEngine(hub.engine, 5, {
+      await populateEngine(hub.engine, 1, {
         Verifications: 1,
         Casts: 10,
-        Follows: 50,
+        Follows: 10,
         Reactions: 0, // TODO: Ignore reactions until https://github.com/farcasterxyz/hub/issues/178 is fixed
       });
 
       // bootstrap hub2 off of hub1
       expect(hub.gossipAddresses);
       // need a better way to pick one of the multiaddrs
-      const secondHub = new Hub({ bootstrapAddrs: [hub.gossipAddresses[0]] });
+      const secondHub = new Hub({ bootstrapAddrs: [hub.gossipAddresses[0]], ...opts });
       expect(secondHub).toBeDefined();
       // Use a flag to help clean up if the test fails at any point
       let shouldStop = true;

--- a/src/types/typeguards.ts
+++ b/src/types/typeguards.ts
@@ -170,17 +170,28 @@ export const isIdRegistryContent = (content: Content): content is IdRegistryCont
 
 export const isContactInfo = (content: Content): content is ContactInfoContent => {
   try {
-    const { peerId, rpcAddress, excludedHashes, count } = content as ContactInfoContent;
+    const { peerId, gossipAddress, rpcAddress, excludedHashes, count } = content as ContactInfoContent;
 
-    const validAddress = rpcAddress
+    const validRpcAddress = rpcAddress
       ? typeof rpcAddress.address === 'string' &&
         typeof rpcAddress.family === 'string' &&
         typeof rpcAddress.port === 'number'
       : true;
 
-    const excludedHashesValid = Array.isArray(excludedHashes) && excludedHashes.every((h) => typeof h === 'string');
+    const validGossipAddress = gossipAddress
+      ? typeof gossipAddress.address === 'string' &&
+        typeof gossipAddress.family === 'string' &&
+        typeof gossipAddress.port === 'number'
+      : true;
 
-    return typeof peerId === 'string' && validAddress && excludedHashesValid && typeof count === 'number';
+    const excludedHashesValid = Array.isArray(excludedHashes) && excludedHashes.every((h) => typeof h === 'string');
+    return (
+      typeof peerId === 'string' &&
+      validGossipAddress &&
+      validRpcAddress &&
+      excludedHashesValid &&
+      typeof count === 'number'
+    );
   } catch (error) {
     return false;
   }

--- a/src/utils/p2p.test.ts
+++ b/src/utils/p2p.test.ts
@@ -7,7 +7,6 @@ import {
   addressInfoFromParts,
   ipMultiAddrStrFromAddressInfo,
   addressInfoFromNodeAddress,
-  getPublicIp,
   p2pMultiAddrStr,
 } from '~/utils/p2p';
 
@@ -39,12 +38,6 @@ describe('p2p utils tests', () => {
       '/ip4/2600:1700:6cf0:990:2052:a166:fb35:830a',
       '/ip4/2600:1700:6cf0:990:2052:a166:fb35:830a/tcp/8080'
     );
-  });
-
-  test('get public IP', async () => {
-    const ip = await getPublicIp();
-    expect(ip).toBeDefined();
-    expect(isIP(ip)).toBeTruthy();
   });
 
   test('p2p multiaddr formatted string', async () => {

--- a/src/utils/p2p.test.ts
+++ b/src/utils/p2p.test.ts
@@ -1,10 +1,14 @@
+import { createEd25519PeerId } from '@libp2p/peer-id-factory';
 import { multiaddr, NodeAddress } from '@multiformats/multiaddr';
+import { isIP } from 'net';
 import {
   parseAddress,
   checkNodeAddrs,
   addressInfoFromParts,
   ipMultiAddrStrFromAddressInfo,
   addressInfoFromNodeAddress,
+  getPublicIp,
+  p2pMultiAddrStr,
 } from '~/utils/p2p';
 
 describe('p2p utils tests', () => {
@@ -35,6 +39,26 @@ describe('p2p utils tests', () => {
       '/ip4/2600:1700:6cf0:990:2052:a166:fb35:830a',
       '/ip4/2600:1700:6cf0:990:2052:a166:fb35:830a/tcp/8080'
     );
+  });
+
+  test('get public IP', async () => {
+    const ip = await getPublicIp();
+    expect(ip).toBeDefined();
+    expect(isIP(ip)).toBeTruthy();
+  });
+
+  test('p2p multiaddr formatted string', async () => {
+    const peerId = await createEd25519PeerId();
+    const ip4Addr = { address: '127.0.0.1', family: 'IPv4', port: 1234 };
+    const ip6Addr = { address: '2600:1700:6cf0:990:2052:a166:fb35:830a', family: 'IPv6', port: 1234 };
+
+    let multiAddrStr = p2pMultiAddrStr(ip4Addr, peerId.toString());
+    const multiAddr = multiaddr(multiAddrStr);
+    expect(multiAddrStr).toBeDefined();
+    expect(multiAddr).toBeDefined();
+    multiAddrStr = p2pMultiAddrStr(ip6Addr, peerId.toString());
+    expect(multiAddrStr).toBeDefined();
+    expect(multiaddr(multiAddrStr)).toBeDefined();
   });
 
   test('addressInfo from valid IPv4 inputs', async () => {

--- a/src/utils/p2p.ts
+++ b/src/utils/p2p.ts
@@ -2,6 +2,8 @@ import { Multiaddr, multiaddr, NodeAddress } from '@multiformats/multiaddr';
 import { AddressInfo, isIP } from 'net';
 import { err, ok, Result } from 'neverthrow';
 import { FarcasterError, ServerError } from '~/utils/errors';
+import { get } from 'http';
+import { logger } from '~/utils/logger';
 
 /** Parses an address to verify it is actually a valid MultiAddr */
 export const parseAddress = (multiaddrStr: string): Result<Multiaddr, FarcasterError> => {
@@ -90,4 +92,45 @@ export const ipMultiAddrStrFromAddressInfo = (addressInfo: AddressInfo) => {
   const family = addressInfo.family === 'IPv6' ? 'ip6' : 'ip4';
   const multiaddrStr = `/${family}/${addressInfo.address}`;
   return multiaddrStr;
+};
+
+/**
+ *
+ * Creates an IP-only multiaddr formatted string from an AddressInfo
+ *
+ * Does not preserve port or transport information
+ */
+export const p2pMultiAddrStr = (addressInfo: AddressInfo, peerID: string) => {
+  const ipMultiAddrStr = ipMultiAddrStrFromAddressInfo(addressInfo);
+  return `${ipMultiAddrStr}/tcp/${addressInfo.port}/p2p/${peerID}`;
+};
+
+/**
+ *
+ * Fetches the publicly visible IP address of the running process
+ *
+ * @returns the public IPv4 or IPv6 as a string
+ */
+let lastIpFetch = { timestamp: new Date().getTime(), ip: '' };
+export const getPublicIp = async (): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const now = new Date().getTime();
+    const since = now - lastIpFetch.timestamp;
+    if (since <= 10 * 60 * 1000 && lastIpFetch.ip != '') {
+      logger.debug({ component: 'utils/p2p', ip: lastIpFetch.ip }, `Cached public IP`);
+      resolve(lastIpFetch.ip);
+      return;
+    }
+    try {
+      get({ host: 'api64.ipify.org', port: 80, path: '/' }, (resp) => {
+        resp.on('data', (ip: Buffer) => {
+          logger.info({ component: 'utils/p2p', ip: ip.toString() }, `Fetched public IP`);
+          lastIpFetch = { timestamp: now, ip: ip.toString() };
+          resolve(ip.toString());
+        });
+      });
+    } catch (err: any) {
+      reject(err);
+    }
+  });
 };

--- a/src/utils/p2p.ts
+++ b/src/utils/p2p.ts
@@ -112,13 +112,13 @@ export const p2pMultiAddrStr = (addressInfo: AddressInfo, peerID: string) => {
  * @returns the public IPv4 or IPv6 as a string
  */
 let lastIpFetch = { timestamp: new Date().getTime(), ip: '' };
-export const getPublicIp = async (): Promise<string> => {
+export const getPublicIp = async (): Promise<Result<string, FarcasterError>> => {
   return new Promise((resolve, reject) => {
     const now = new Date().getTime();
     const since = now - lastIpFetch.timestamp;
     if (since <= 10 * 60 * 1000 && lastIpFetch.ip != '') {
       logger.debug({ component: 'utils/p2p', ip: lastIpFetch.ip }, `Cached public IP`);
-      resolve(lastIpFetch.ip);
+      resolve(ok(lastIpFetch.ip));
       return;
     }
     try {
@@ -126,11 +126,11 @@ export const getPublicIp = async (): Promise<string> => {
         resp.on('data', (ip: Buffer) => {
           logger.info({ component: 'utils/p2p', ip: ip.toString() }, `Fetched public IP`);
           lastIpFetch = { timestamp: now, ip: ip.toString() };
-          resolve(ip.toString());
+          resolve(ok(ip.toString()));
         });
       });
     } catch (err: any) {
-      reject(err);
+      reject(new ServerError(err));
     }
   });
 };


### PR DESCRIPTION
## Motivation

libp2p does not automatically resolve Peer's addresses. We needed a way to figure out how to reach peers discovered via Gossip. 

## Change Summary

- Fetch public IP's using the [ipify.org](https://www.ipify.org/) API.
- Publish public IP's over gossip

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
