### PR TITLE
feat: prototype new error handling pattern and refactor one method to use it 

### DIFF
--- a/src/network/p2p/node.test.ts
+++ b/src/network/p2p/node.test.ts
@@ -116,7 +116,10 @@ describe('node unit tests', () => {
   test('port and transport addrs in the Ip MultiAddr is not allowed', async () => {
     const node = new Node();
     const options = { ipMultiAddr: '/ip4/127.0.0.1/tcp/8080' };
-    await expect(node.start([], options)).rejects.toThrow();
+    const error = (await node.start([], options))._unsafeUnwrapErr();
+
+    expect(error.errCode).toEqual('unavailable');
+    expect(error.message).toMatch('unexpected transport/port information');
     expect(node.isStarted()).toBeFalsy();
     await node.stop();
   });
@@ -125,7 +128,11 @@ describe('node unit tests', () => {
     const node = new Node();
     // an IPv6 being supplied as an IPv4
     const options = { ipMultiAddr: '/ip4/2600:1700:6cf0:990:2052:a166:fb35:830a' };
-    await expect(node.start([], options)).rejects.toThrow();
+    expect((await node.start([], options))._unsafeUnwrapErr().errCode).toEqual('unavailable');
+    const error = (await node.start([], options))._unsafeUnwrapErr();
+
+    expect(error.errCode).toEqual('unavailable');
+    expect(error.message).toMatch('no protocol with code: 108');
     expect(node.isStarted()).toBeFalsy();
     await node.stop();
   });

--- a/src/utils/hubErrors.ts
+++ b/src/utils/hubErrors.ts
@@ -1,0 +1,64 @@
+import { Result } from 'neverthrow';
+
+interface HubErrorOpts {
+  message: string;
+  cause: Error | HubError;
+  presentable: boolean;
+}
+
+/**
+ * HubError is the only class that should be used to raise exceptions in the Hub.
+ *
+ * Error context is provided with an error code and a message which are easily serializable
+ * over network calls. Sub-classing should be avoided for this reason. Stack traces are included
+ * by default thanks to the Error super class.
+ *
+ * Errors should never be thrown and must be returned from functions using neverthrow's Return.
+ * It ensures that readers can easily determine if functions are safe, and that callers are forced
+ * to handle all error cases by the type system leading to fewer unhandled exceptions.
+ */
+export class HubError extends Error {
+  /* Hub classification of error types */
+  public readonly errCode: HubErrorCode;
+
+  /* Indicates if if error message can be presented to the user */
+  public readonly presentable: boolean = false;
+
+  constructor(errCode: HubErrorCode, options: Partial<HubErrorOpts>) {
+    if (!options.message) {
+      options.message = options.cause?.message || '';
+    }
+
+    super(options.message, { cause: options.cause });
+
+    this.errCode = errCode;
+  }
+}
+
+/**
+ * HubErrorCode defines all the types of errors that can be raised in the Hub.
+ *
+ * A string union type is chosen over an enumeration since TS enums are unusual types that generate
+ * javascript code and may cause downstream issues. See:
+ * https://www.executeprogram.com/blog/typescript-features-to-avoid
+ *
+ * TODO: Sub-divided into fine grained errors like "unauthorized.invalid_signature"
+ */
+type HubErrorCode =
+  /* The request did not have valid authentication credentials, retry with credentials  */
+  | 'unauthenticated'
+  /* The authenticated request did not have the authority to perform this action  */
+  | 'unauthorized'
+  /* The request cannot be completed as constructed, do not retry */
+  | 'bad_request'
+  /* The requested resource could not be found */
+  | 'not_found'
+  /* TBD */
+  | 'db_error'
+  /* The request could not be completed, it may or may not be safe to retry */
+  | 'unavailable'
+  /* An unknown error was encountered */
+  | 'unknown';
+
+// TODO: move elsewhere
+export type HubResult<T> = Result<T, HubError>;


### PR DESCRIPTION
## Motivation

See: https://github.com/farcasterxyz/hub/issues/213

## Change Summary

Introduces a new error class (HubError), a new error cataloging system (HubErrorCodes) and a standard result type for error prone functions (HubResult) that is built on neverthrow's Result. Also refactors one arbitrary method to demonstrate the syntax of the method in the application and tests. 

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
