### PR TITLE
refactor(p2p): network/p2p uses HubResults and HubErrors

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,14 +60,19 @@ app
       cliOptions.ip ?? hubConfig.ip,
       cliOptions.gossipPort ?? hubConfig.gossipPort
     );
+
     if (hubAddressInfo.isErr()) {
       throw hubAddressInfo.error;
     }
-    const ipMultiAddr = ipMultiAddrStrFromAddressInfo(hubAddressInfo.value);
+
+    const ipMultiAddrResult = ipMultiAddrStrFromAddressInfo(hubAddressInfo.value);
+    if (ipMultiAddrResult.isErr()) {
+      throw ipMultiAddrResult.error;
+    }
 
     const options: HubOptions = {
       peerId,
-      ipMultiAddr,
+      ipMultiAddr: ipMultiAddrResult.value,
       gossipPort: hubAddressInfo.value.port,
       networkUrl: cliOptions.networkUrl ?? hubConfig.networkUrl,
       IdRegistryAddress: cliOptions.firAddress ?? hubConfig.firAddress,

--- a/src/network/p2p/connectionFilter.ts
+++ b/src/network/p2p/connectionFilter.ts
@@ -21,7 +21,7 @@ export class ConnectionFilter implements ConnectionGater {
   }
 
   denyDialPeer = async (peerId: PeerId): Promise<boolean> => {
-    const deny = await this.shouldDeny(peerId.toString());
+    const deny = this.shouldDeny(peerId.toString());
     if (deny) {
       logger.info(`ConnectionFilter denyDialPeer: denied a connection with ${peerId}`);
     }
@@ -29,7 +29,7 @@ export class ConnectionFilter implements ConnectionGater {
   };
 
   denyDialMultiaddr = async (peerId: PeerId, _multiaddr: Multiaddr): Promise<boolean> => {
-    const deny = await this.shouldDeny(peerId.toString());
+    const deny = this.shouldDeny(peerId.toString());
     if (deny) {
       logger.info(`ConnectionFilter denyDialMultiaddr: denied a connection with ${peerId}`);
     }
@@ -45,7 +45,7 @@ export class ConnectionFilter implements ConnectionGater {
   };
 
   denyOutboundConnection = async (peerId: PeerId, _maConn: MultiaddrConnection): Promise<boolean> => {
-    const deny = await this.shouldDeny(peerId.toString());
+    const deny = this.shouldDeny(peerId.toString());
     if (deny) {
       logger.info(`ConnectionFilter denyOutboundConnection: denied a connection with ${peerId}`);
     }
@@ -53,7 +53,7 @@ export class ConnectionFilter implements ConnectionGater {
   };
 
   denyInboundEncryptedConnection = async (peerId: PeerId, _maConn: MultiaddrConnection): Promise<boolean> => {
-    const deny = await this.shouldDeny(peerId.toString());
+    const deny = this.shouldDeny(peerId.toString());
     if (deny) {
       logger.info(`ConnectionFilter denyInboundEncryptedConnection: denied a connection with ${peerId}`);
     }
@@ -61,7 +61,7 @@ export class ConnectionFilter implements ConnectionGater {
   };
 
   denyOutboundEncryptedConnection = async (peerId: PeerId, _maConn: MultiaddrConnection): Promise<boolean> => {
-    const deny = await this.shouldDeny(peerId.toString());
+    const deny = this.shouldDeny(peerId.toString());
     if (deny) {
       logger.info(`ConnectionFilter denyOutboundEncryptedConnection: denied a connection with ${peerId}`);
     }
@@ -69,7 +69,7 @@ export class ConnectionFilter implements ConnectionGater {
   };
 
   denyInboundUpgradedConnection = async (peerId: PeerId, _maConn: MultiaddrConnection): Promise<boolean> => {
-    const deny = await this.shouldDeny(peerId.toString());
+    const deny = this.shouldDeny(peerId.toString());
     if (deny) {
       logger.info(`ConnectionFilter denyInboundUpgradedConnection: denied a connection with ${peerId}`);
     }
@@ -77,7 +77,7 @@ export class ConnectionFilter implements ConnectionGater {
   };
 
   denyOutboundUpgradedConnection = async (peerId: PeerId, _maConn: MultiaddrConnection): Promise<boolean> => {
-    const deny = await this.shouldDeny(peerId.toString());
+    const deny = this.shouldDeny(peerId.toString());
     if (deny) {
       logger.info(`ConnectionFilter denyOutboundUpgradedConnection: denied a connection with ${peerId}`);
     }
@@ -85,24 +85,20 @@ export class ConnectionFilter implements ConnectionGater {
   };
 
   filterMultiaddrForPeer = async (peer: PeerId): Promise<boolean> => {
-    const deny = await this.shouldDeny(peer.toString());
-    return !deny;
+    return !this.shouldDeny(peer.toString());
   };
 
   /* -------------------------------------------------------------------------- */
   /*                               Private Methods                              */
   /* -------------------------------------------------------------------------- */
 
-  // DISCUSS: why are we accepting a null and why are we returning a promise?
-  // The function appears to have no async calls
-
-  private shouldDeny(peerId: string | null) {
-    if (!peerId) return Promise.resolve(true);
-    if (this.allowedPeers === undefined) return Promise.resolve(false);
+  private shouldDeny(peerId: string) {
+    if (!peerId) return true;
+    if (this.allowedPeers === undefined) return false;
 
     const found = this.allowedPeers.find((value) => {
       return peerId && value === peerId;
     });
-    return Promise.resolve(found === undefined);
+    return found === undefined;
   }
 }

--- a/src/network/p2p/connectionFilter.ts
+++ b/src/network/p2p/connectionFilter.ts
@@ -93,6 +93,9 @@ export class ConnectionFilter implements ConnectionGater {
   /*                               Private Methods                              */
   /* -------------------------------------------------------------------------- */
 
+  // DISCUSS: why are we accepting a null and why are we returning a promise?
+  // The function appears to have no async calls
+
   private shouldDeny(peerId: string | null) {
     if (!peerId) return Promise.resolve(true);
     if (this.allowedPeers === undefined) return Promise.resolve(false);

--- a/src/network/p2p/node.test.ts
+++ b/src/network/p2p/node.test.ts
@@ -57,10 +57,9 @@ const trackMessages = () => {
 describe('node unit tests', () => {
   test('fails to bootstrap to invalid addresses', async () => {
     const node = new Node();
-    await expect(() => {
-      return node.start([multiaddr()]);
-    }).rejects.toThrow(ServerError);
-    // still have to stop it since the underlying libp2p node does start up before bootstrap fails
+    const error = (await node.start([multiaddr()]))._unsafeUnwrapErr();
+    expect(error.errCode).toEqual('unavailable');
+    expect(error.message).toContain('could not connect to any bootstrap nodes');
     await node.stop();
   });
 

--- a/src/network/p2p/node.test.ts
+++ b/src/network/p2p/node.test.ts
@@ -119,7 +119,7 @@ describe('node unit tests', () => {
     const error = (await node.start([], options))._unsafeUnwrapErr();
 
     expect(error.errCode).toEqual('unavailable');
-    expect(error.message).toMatch('unexpected transport/port information');
+    expect(error.message).toMatch('unexpected multiaddr transport/port information');
     expect(node.isStarted()).toBeFalsy();
     await node.stop();
   });
@@ -132,7 +132,7 @@ describe('node unit tests', () => {
     const error = (await node.start([], options))._unsafeUnwrapErr();
 
     expect(error.errCode).toEqual('unavailable');
-    expect(error.message).toMatch('no protocol with code: 108');
+    expect(error.message).toMatch('invalid multiaddr');
     expect(node.isStarted()).toBeFalsy();
     await node.stop();
   });

--- a/src/network/p2p/node.ts
+++ b/src/network/p2p/node.ts
@@ -25,7 +25,7 @@ interface NodeEvents {
    * Triggered when a new message is received. Provides the topic the message was received on
    * as well as the result of decoding the message
    */
-  message: (topic: string, message: Result<GossipMessage, string>) => void;
+  message: (topic: string, message: Result<GossipMessage, string> | HubResult<GossipMessage>) => void;
   /** Triggered when a peer is connected. Provides the Libp2p Connection object. */
   peerConnect: (connection: Connection) => void;
   /** Triggered when a peer is disconnected. Provides the Libp2p Connecion object. */

--- a/src/network/p2p/protocol.ts
+++ b/src/network/p2p/protocol.ts
@@ -94,13 +94,10 @@ export const encodeMessage = (message: GossipMessage): HubResult<Uint8Array> => 
 export const decodeMessage = (data: Uint8Array): HubResult<GossipMessage> => {
   const json = new TextDecoder().decode(data);
 
-  const messageResult: HubResult<string> = safeJsonParse(json);
-  if (messageResult.isErr()) return err(messageResult.error);
-
-  const message = messageResult.value;
-  if (!message || !isGossipMessage(message)) {
-    return err(new HubError('bad_request.parse_failure', 'invalid gossip message'));
-  }
-
-  return ok(message);
+  return safeJsonParse(json).andThen((message) => {
+    if (!message || !isGossipMessage(message)) {
+      return err(new HubError('bad_request.parse_failure', 'invalid gossip message'));
+    }
+    return ok(message);
+  });
 };

--- a/src/network/rpc/client.ts
+++ b/src/network/rpc/client.ts
@@ -20,7 +20,11 @@ export class RPCClient {
       replacer,
       reviver,
     });
-    this._serverMultiAddr = `${ipMultiAddrStrFromAddressInfo(address)}/tcp/${address.port}`;
+    const multiAddrResult = ipMultiAddrStrFromAddressInfo(address);
+
+    // TODO: fix up because constructors ideally do not throw.
+    if (multiAddrResult.isErr()) throw multiAddrResult.error;
+    this._serverMultiAddr = `${multiAddrResult.value}/tcp/${address.port}`;
   }
 
   /** Returns a multiaddr of the RPC server this client is connected to */

--- a/src/network/sync/syncId.ts
+++ b/src/network/sync/syncId.ts
@@ -1,4 +1,5 @@
 import { Message } from '~/types';
+import { HubError } from '~/utils/hubErrors';
 
 const TIMESTAMP_LENGTH = 10;
 const HASH_LENGTH = 128; // We're using 64 byte blake2b hashes
@@ -18,10 +19,10 @@ class SyncId {
     this._hash = message.hash;
     // Hashlength +2 to account for the 0x
     if (this._hash.length !== HASH_LENGTH + 2 || !this._hash.startsWith('0x')) {
-      throw new Error(`Invalid hash: ${this._hash}`);
+      throw new HubError('bad_request.parse_failure', `Invalid hash: ${this._hash}`);
     }
     if (this.timestampString.length !== TIMESTAMP_LENGTH) {
-      throw new Error(`Invalid timestamp: ${this.timestampString}`);
+      throw new HubError('bad_request.parse_failure', `Invalid timestamp: ${this.timestampString}`);
     }
   }
 

--- a/src/test/perf/bench.ts
+++ b/src/test/perf/bench.ts
@@ -14,7 +14,6 @@ import { waitForSync } from '~/test/perf/verify';
  *
  * When executed, it submits a series of events to the Hub network and measures the
  * time taken for each set of requests to be processed.
- *
  */
 
 const parseNumber = (string: string) => {
@@ -43,7 +42,12 @@ const cliOptions = app.opts();
 const rpcMultiAddrs: string[] = cliOptions.hubs;
 const rpcClients = rpcMultiAddrs.map((addr) => {
   const address = multiaddr(addr);
-  return new RPCClient(addressInfoFromNodeAddress(address.nodeAddress()));
+  const addressInfoResult = addressInfoFromNodeAddress(address.nodeAddress());
+  if (addressInfoResult.isErr()) {
+    throw addressInfoResult.error;
+  }
+
+  return new RPCClient(addressInfoResult.value);
 });
 
 // sets up hubs

--- a/src/utils/hubErrors.ts
+++ b/src/utils/hubErrors.ts
@@ -57,12 +57,15 @@ type HubErrorCode =
   /* The request cannot be completed as constructed, do not retry */
   | 'bad_request'
   | 'bad_request.parse_failure'
+  | 'bad_request.validation_failure'
   /* The requested resource could not be found */
   | 'not_found'
   /* TBD */
   | 'db_error'
   /* The request could not be completed, it may or may not be safe to retry */
   | 'unavailable'
+  | 'unavailable.network_failure'
+  | 'unavailable.storage_failure'
   /* An unknown error was encountered */
   | 'unknown';
 

--- a/src/utils/hubErrors.ts
+++ b/src/utils/hubErrors.ts
@@ -24,13 +24,18 @@ export class HubError extends Error {
   /* Indicates if if error message can be presented to the user */
   public readonly presentable: boolean = false;
 
-  constructor(errCode: HubErrorCode, options: Partial<HubErrorOpts>) {
+  constructor(errCode: HubErrorCode, options: Partial<HubErrorOpts> | string) {
+    if (typeof options === 'string') {
+      options = { message: options };
+    }
+
     if (!options.message) {
       options.message = options.cause?.message || '';
     }
 
     super(options.message, { cause: options.cause });
 
+    this.name = 'HubError';
     this.errCode = errCode;
   }
 }
@@ -51,6 +56,7 @@ type HubErrorCode =
   | 'unauthorized'
   /* The request cannot be completed as constructed, do not retry */
   | 'bad_request'
+  | 'bad_request.parse_failure'
   /* The requested resource could not be found */
   | 'not_found'
   /* TBD */

--- a/src/utils/p2p.test.ts
+++ b/src/utils/p2p.test.ts
@@ -21,6 +21,12 @@ describe('p2p utils tests', () => {
     expect(error.message).toEqual('invalid multiaddr');
   });
 
+  test('fail to parse an empty string', async () => {
+    const error = parseAddress('')._unsafeUnwrapErr();
+    expect(error.errCode).toEqual('bad_request');
+    expect(error.message).toEqual('multiaddr must not be empty');
+  });
+
   test('check valid node addresses', async () => {
     const result = checkNodeAddrs('/ip4/127.0.0.1/', '/ip4/127.0.0.1/tcp/8080');
     expect(result.isOk()).toBeTruthy();

--- a/src/utils/p2p.test.ts
+++ b/src/utils/p2p.test.ts
@@ -57,11 +57,12 @@ describe('p2p utils tests', () => {
     const ip4Addr = { address: '127.0.0.1', family: 'IPv4', port: 1234 };
     const ip6Addr = { address: '2600:1700:6cf0:990:2052:a166:fb35:830a', family: 'IPv6', port: 1234 };
 
-    let multiAddrStr = p2pMultiAddrStr(ip4Addr, peerId.toString());
+    let multiAddrStr = p2pMultiAddrStr(ip4Addr, peerId.toString())._unsafeUnwrap();
     const multiAddr = multiaddr(multiAddrStr);
     expect(multiAddrStr).toBeDefined();
     expect(multiAddr).toBeDefined();
-    multiAddrStr = p2pMultiAddrStr(ip6Addr, peerId.toString());
+
+    multiAddrStr = p2pMultiAddrStr(ip6Addr, peerId.toString())._unsafeUnwrap();
     expect(multiAddrStr).toBeDefined();
     expect(multiaddr(multiAddrStr)).toBeDefined();
   });
@@ -91,7 +92,7 @@ describe('p2p utils tests', () => {
     const addressInfo = addressInfoFromParts('127.0.0.1', 0);
     expect(addressInfo.isOk()).toBeTruthy();
 
-    const multiAddrStr = ipMultiAddrStrFromAddressInfo(addressInfo._unsafeUnwrap());
+    const multiAddrStr = ipMultiAddrStrFromAddressInfo(addressInfo._unsafeUnwrap())._unsafeUnwrap();
     expect(multiAddrStr).toEqual('/ip4/127.0.0.1');
 
     const multiAddr = multiaddr(multiAddrStr);
@@ -103,9 +104,9 @@ describe('p2p utils tests', () => {
     expect(addressInfo.isOk()).toBeTruthy();
 
     addressInfo._unsafeUnwrap().family = 'ip12';
-    expect(() => {
-      ipMultiAddrStrFromAddressInfo(addressInfo._unsafeUnwrap());
-    }).toThrow();
+    const error = ipMultiAddrStrFromAddressInfo(addressInfo._unsafeUnwrap())._unsafeUnwrapErr();
+    expect(error.errCode).toEqual('bad_request');
+    expect(error.message).toMatch('invalid AddressInfo family');
   });
 
   test('converts a valid nodeAddress to an addressInfo', () => {
@@ -115,8 +116,7 @@ describe('p2p utils tests', () => {
       port: 0,
     };
 
-    const addressInfo = addressInfoFromNodeAddress(nodeAddr);
-    expect(addressInfo).toBeTruthy();
+    const addressInfo = addressInfoFromNodeAddress(nodeAddr)._unsafeUnwrap();
     expect(addressInfo.address).toEqual(nodeAddr.address);
     expect(addressInfo.port).toEqual(nodeAddr.port);
     expect(addressInfo.family).toEqual('IPv4');
@@ -129,8 +129,8 @@ describe('p2p utils tests', () => {
       port: 0,
     };
 
-    expect(() => {
-      addressInfoFromNodeAddress(nodeAddr);
-    }).toThrow();
+    const error = addressInfoFromNodeAddress(nodeAddr)._unsafeUnwrapErr();
+    expect(error.errCode).toEqual('bad_request');
+    expect(error.message).toMatch('invalid nodeAddress family');
   });
 });

--- a/src/utils/p2p.ts
+++ b/src/utils/p2p.ts
@@ -66,11 +66,9 @@ export const ipMultiAddrStrFromAddressInfo = (addressInfo: AddressInfo): HubResu
  * Does not preserve port or transport information
  */
 export const p2pMultiAddrStr = (addressInfo: AddressInfo, peerID: string): HubResult<string> => {
-  return ipMultiAddrStrFromAddressInfo(addressInfo).map((ipMultiAddrStr) => {
-    return `${ipMultiAddrStr}/tcp/${addressInfo.port}/p2p/${peerID}`;
-  });
-
-  // const ipMultiAddrStr = ipMultiAddrStrFromAddressInfo(addressInfo);
+  return ipMultiAddrStrFromAddressInfo(addressInfo).map(
+    (ipMultiAddrStr) => `${ipMultiAddrStr}/tcp/${addressInfo.port}/p2p/${peerID}`
+  );
 };
 
 /**
@@ -127,8 +125,8 @@ const checkIpAddr = (ipAddr: string): HubResult<void> => {
   return ok(undefined);
 };
 
-const checkCombinedAddr = (ipAddr: string): HubResult<void> => {
-  const parseListenIpAddrResult = parseAddress(ipAddr);
+const checkCombinedAddr = (combinedAddr: string): HubResult<void> => {
+  const parseListenIpAddrResult = parseAddress(combinedAddr);
   if (parseListenIpAddrResult.isErr()) return err(parseListenIpAddrResult.error);
 
   const optionsResult = Result.fromThrowable(

--- a/src/utils/p2p.ts
+++ b/src/utils/p2p.ts
@@ -4,55 +4,19 @@ import { err, ok, Result } from 'neverthrow';
 import { FarcasterError, ServerError } from '~/utils/errors';
 import { get } from 'http';
 import { logger } from '~/utils/logger';
+import { HubError, HubResult } from '~/utils/hubErrors';
 
 /** Parses an address to verify it is actually a valid MultiAddr */
-export const parseAddress = (multiaddrStr: string): Result<Multiaddr, FarcasterError> => {
-  try {
-    return ok(multiaddr(multiaddrStr));
-  } catch (error: any) {
-    return err(new ServerError('Invalid MultiAddr: ' + error.message));
-  }
+export const parseAddress = (multiaddrStr: string): HubResult<Multiaddr> => {
+  return Result.fromThrowable(
+    () => multiaddr(multiaddrStr),
+    (err) => new HubError('bad_request.parse_failure', { cause: err as Error, message: 'invalid multiaddr' })
+  )();
 };
 
 /** Checks that the IP address to bind to is valid and that the combined IP, transport, and port multiaddr is valid  */
-export const checkNodeAddrs = (listenIPAddr: string, listenCombinedAddr: string): Result<void, FarcasterError> => {
-  let parsedAddr = parseAddress(listenIPAddr);
-  let result = parsedAddr.match(
-    (addr) => {
-      if (!addr) return err(new ServerError('Invalid IP MultiAddr: could not parse multiaddr'));
-      let options;
-      try {
-        options = addr.toOptions();
-      } catch (error) {
-        return ok(undefined);
-        // intentional no-op since the IP MultiAddr is not expected to have port or transport information and will throw
-      }
-      if (options.port !== undefined || options.transport !== undefined) {
-        return err(new ServerError('Invalid IP MultiAddr: unexpected transport/port information'));
-      }
-      return ok(undefined);
-    },
-    (error) => {
-      return err(new ServerError(error));
-    }
-  );
-  if (result.isErr()) return result;
-
-  // check that the combined address is actually valid
-  parsedAddr = parseAddress(listenCombinedAddr);
-  result = parsedAddr.match(
-    (addr) => {
-      if (!addr) return err(new ServerError('Invalid Node MultiAddr: could not parse multiaddr'));
-      const options = addr.toOptions();
-      if (options.transport != 'tcp') return err(new ServerError('Invalid Node MultiAddr: transport must be tcp'));
-      return ok(undefined);
-    },
-    (error) => {
-      return err(new ServerError(error));
-    }
-  );
-
-  return result;
+export const checkNodeAddrs = (listenIPAddr: string, listenCombinedAddr: string): HubResult<void> => {
+  return Result.combine([checkIpAddr(listenIPAddr), checkCombinedAddr(listenCombinedAddr)]).map(() => undefined);
 };
 
 /** Get an AddressInfo object from a given NodeAddress object */
@@ -81,7 +45,6 @@ export const addressInfoFromParts = (address: string, port: number) => {
 };
 
 /**
- *
  * Creates an IP-only multiaddr formatted string from an AddressInfo
  *
  * Does not preserve port or transport information
@@ -95,7 +58,6 @@ export const ipMultiAddrStrFromAddressInfo = (addressInfo: AddressInfo) => {
 };
 
 /**
- *
  * Creates an IP-only multiaddr formatted string from an AddressInfo
  *
  * Does not preserve port or transport information
@@ -133,4 +95,42 @@ export const getPublicIp = async (): Promise<Result<string, FarcasterError>> => 
       reject(new ServerError(err));
     }
   });
+};
+
+/* -------------------------------------------------------------------------- */
+/*                               Private Methods                              */
+/* -------------------------------------------------------------------------- */
+
+const checkIpAddr = (ipAddr: string): HubResult<void> => {
+  const parseListenIpAddrResult = parseAddress(ipAddr);
+  if (parseListenIpAddrResult.isErr()) return err(parseListenIpAddrResult.error);
+
+  // DISCUSS: we previously had a null check here (which seems impossible), but we have no
+  // empty string check which is possible
+  const parsedListenIPAddr = parseListenIpAddrResult.value;
+
+  const toOptionsResult = Result.fromThrowable(
+    () => parsedListenIPAddr.toOptions(),
+    (error) => err(error)
+  )();
+  // An IP address should not have options and should throw if well-formed
+  if (toOptionsResult.isErr()) return ok(undefined);
+
+  const options = toOptionsResult.value;
+  if (options.port !== undefined || options.transport !== undefined) {
+    return err(new HubError('bad_request', 'unexpected multiaddr transport/port information'));
+  }
+  return ok(undefined);
+};
+
+const checkCombinedAddr = (ipAddr: string): HubResult<void> => {
+  return parseAddress(ipAddr).match(
+    (addr) => {
+      // DISCUSS: can toOptions throw here? Should we fail if it does?
+      if (addr.toOptions().transport != 'tcp')
+        return err(new HubError('bad_request.parse_failure', 'Invalid Node MultiAddr: transport must be tcp'));
+      return ok(undefined);
+    },
+    (error) => err(error)
+  );
 };

--- a/src/utils/safe.ts
+++ b/src/utils/safe.ts
@@ -1,0 +1,12 @@
+import { Result } from 'neverthrow';
+import { HubError } from '~/utils/hubErrors';
+
+export const safeJsonStringify = Result.fromThrowable(
+  JSON.stringify,
+  () => new HubError('bad_request.parse_failure', 'json stringify failure')
+);
+
+export const safeJsonParse = Result.fromThrowable(
+  JSON.parse,
+  () => new HubError('bad_request.parse_failure', 'json parse failure')
+);


### PR DESCRIPTION
## Motivation

See: #213 

## Change Summary

Refactors all files under network/p2p and utils/p2p to use HubResults and HubErrors for error handling

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
