### PR TITLE
refactor(followStore): add unit test coverage, change conflict logic

### DIFF
--- a/src/storage/sets/flatbuffers/followStore.ts
+++ b/src/storage/sets/flatbuffers/followStore.ts
@@ -1,12 +1,33 @@
 import RocksDB, { Transaction } from '~/storage/db/binaryrocksdb';
-import { BadRequestError } from '~/utils/errors';
 import MessageModel, { FID_BYTES, TRUE_VALUE } from '~/storage/flatbuffers/messageModel';
 import { ResultAsync } from 'neverthrow';
 import { FollowAddModel, FollowRemoveModel, RootPrefix, UserPostfix } from '~/storage/flatbuffers/types';
 import { isFollowAdd, isFollowRemove } from '~/storage/flatbuffers/typeguards';
 import { bytesCompare } from '~/storage/flatbuffers/utils';
 import { MessageType } from '~/utils/generated/message_generated';
+import { HubError } from '~/utils/hubErrors';
 
+/**
+ * Follow Store persists Follow Messages in RocksDB using a two-phase CRDT set to guarantee
+ * eventual consistency.
+ *
+ * A Follow is performed by user and has a target user. It is added with a FollowAdd and removed
+ * with a FollowRemove. Conflicts between follow messages are resolved with the following rules:
+ *
+ * 1. Highest timestamp wins
+ * 2. Remove wins over Adds
+ * 3. Highest lexicographic hash wins
+ *
+ * FollowMessages are stored ordinally in RocksDB indexed by a unique key `fid:tsHash` which makes
+ * truncating a user's earliest messages easy. Indices are built for the two phase sets
+ * (adds, removes) as well as byTargetUser.
+ *
+ * The key-value entries created by the Follow Store are:
+ *
+ * 1. fid:tsHash -> follow message
+ * 2. fid:set:targetUserFid -> fid:tsHash (Set Index)
+ * 3. fid:set:targetUserFid:tsHash -> fid:tsHash (Target User Index)
+ */
 class FollowStore {
   private _db: RocksDB;
 
@@ -14,29 +35,48 @@ class FollowStore {
     this._db = db;
   }
 
-  /** RocksDB key of the form <user prefix (1 byte), fid (32 bytes), follow removes key (1 byte), user id (variable bytes)> */
-  static followRemovesKey(fid: Uint8Array, user?: Uint8Array): Buffer {
-    return Buffer.concat([
-      MessageModel.userKey(fid),
-      Buffer.from([UserPostfix.FollowRemoves]),
-      user ? Buffer.from(user) : new Uint8Array(),
-    ]);
-  }
-
-  /** RocksDB key of the form <user prefix (1 byte), fid (32 bytes), follow adds key (1 byte), user id (variable bytes)> */
-  static followAddsKey(fid: Uint8Array, user?: Uint8Array): Buffer {
+  /**
+   * Generates a unique key used to store a FollowAdd message key in the FollowAdds Set index
+   *
+   * @param fid farcaster id of the user who created the follow
+   * @param targetUserFid user is being followed
+   * @returns RocksDB key of the form <root_prefix>:<fid>:<user_postfix>:<user?>
+   */
+  static followAddsKey(fid: Uint8Array, targetUserFid?: Uint8Array): Buffer {
     return Buffer.concat([
       MessageModel.userKey(fid),
       Buffer.from([UserPostfix.FollowAdds]),
-      user ? Buffer.from(user) : new Uint8Array(),
+      targetUserFid ? Buffer.from(targetUserFid) : new Uint8Array(),
     ]);
   }
 
-  /** RocksDB key of the form <followByUser prefix (1 byte), user id (32 bytes), fid (32 bytes), message timestamp hash (8 bytes)> */
-  static followsByUserKey(user: Uint8Array, fid?: Uint8Array, tsHash?: Uint8Array): Buffer {
+  /**
+   * Generates a unique key used to store a FollowRemove message key in the FollowRemoves Set index
+   *
+   * @param fid farcaster id of the user who created the follow
+   * @param targetUserFid user who created the follow
+   * @returns RocksDB key of the form <root_prefix>:<fid>:<user_postfix>:<user?>
+   */
+  static followRemovesKey(fid: Uint8Array, targetUserFid?: Uint8Array): Buffer {
+    return Buffer.concat([
+      MessageModel.userKey(fid),
+      Buffer.from([UserPostfix.FollowRemoves]),
+      targetUserFid ? Buffer.from(targetUserFid) : new Uint8Array(),
+    ]);
+  }
+
+  /**
+   * Generates a unique key used to store a FollowAdds Message in the FollowsByUser index
+   *
+   * @param targetUserFid user who created the follow
+   * @param fid the fid of the user who created the follow
+   * @param tsHash the timestamp hash of the follow message
+   * @returns RocksDB index key of the form <root_prefix>:<fid>:<type?>:<fid?>:<tsHash?>
+   */
+  static followsByTargetUserKey(targetUserFid: Uint8Array, fid?: Uint8Array, tsHash?: Uint8Array): Buffer {
     const bytes = new Uint8Array(1 + FID_BYTES + (fid ? FID_BYTES : 0) + (tsHash ? tsHash.length : 0));
     bytes.set([RootPrefix.FollowsByUser], 0);
-    bytes.set(user, 1 + FID_BYTES - user.length); // pad for alignment
+    bytes.set(targetUserFid, 1 + FID_BYTES - targetUserFid.length); // pad for alignment
     if (fid) {
       bytes.set(fid, 1 + FID_BYTES + FID_BYTES - fid.length); // pad fid for alignment
     }
@@ -46,15 +86,15 @@ class FollowStore {
     return Buffer.from(bytes);
   }
 
-  /** Look up FollowAdd message by user */
-  async getFollowAdd(fid: Uint8Array, user: Uint8Array): Promise<FollowAddModel> {
-    const messageTsHash = await this._db.get(FollowStore.followAddsKey(fid, user));
+  /** Look up FollowAdd message by target user */
+  async getFollowAdd(fid: Uint8Array, targetUserFid: Uint8Array): Promise<FollowAddModel> {
+    const messageTsHash = await this._db.get(FollowStore.followAddsKey(fid, targetUserFid));
     return MessageModel.get<FollowAddModel>(this._db, fid, UserPostfix.FollowMessage, messageTsHash);
   }
 
-  /** Look up FollowRemove message by user */
-  async getFollowRemove(fid: Uint8Array, user: Uint8Array): Promise<FollowRemoveModel> {
-    const messageTsHash = await this._db.get(FollowStore.followRemovesKey(fid, user));
+  /** Look up FollowRemove message by target user */
+  async getFollowRemove(fid: Uint8Array, targetUserFid: Uint8Array): Promise<FollowRemoveModel> {
+    const messageTsHash = await this._db.get(FollowStore.followRemovesKey(fid, targetUserFid));
     return MessageModel.get<FollowRemoveModel>(this._db, fid, UserPostfix.FollowMessage, messageTsHash);
   }
 
@@ -79,8 +119,8 @@ class FollowStore {
   }
 
   /** Get all FollowAdd messages for a user */
-  async getFollowsByUser(user: Uint8Array): Promise<FollowAddModel[]> {
-    const byUserPostfix = FollowStore.followsByUserKey(user);
+  async getFollowsByTargetUser(fid: Uint8Array): Promise<FollowAddModel[]> {
+    const byUserPostfix = FollowStore.followsByTargetUserKey(fid);
     const messageKeys: Buffer[] = [];
     for await (const [key] of this._db.iteratorByPrefix(byUserPostfix, { keyAsBuffer: true, values: false })) {
       const fid = Uint8Array.from(key).subarray(byUserPostfix.length, byUserPostfix.length + FID_BYTES);
@@ -90,7 +130,7 @@ class FollowStore {
     return MessageModel.getMany(this._db, messageKeys);
   }
 
-  /** Merge a FollowAdd or FollowRemove message into the set */
+  /** Merges a FollowAdd or FollowRemove message into the FollowStore */
   async merge(message: MessageModel): Promise<void> {
     if (isFollowRemove(message)) {
       return this.mergeRemove(message);
@@ -100,7 +140,7 @@ class FollowStore {
       return this.mergeAdd(message);
     }
 
-    throw new BadRequestError('invalid message type');
+    throw new HubError('bad_request.validation_failure', 'invalid follow message');
   }
 
   /* -------------------------------------------------------------------------- */
@@ -108,34 +148,28 @@ class FollowStore {
   /* -------------------------------------------------------------------------- */
 
   private async mergeAdd(message: FollowAddModel): Promise<void> {
-    // Define follow id for lookups
     const followId = message.body().user()?.fidArray() ?? new Uint8Array();
 
     let tsx = await this.resolveMergeConflicts(this._db.transaction(), followId, message);
 
-    // No-op if resolveMergeConflicts did not return a transaction
-    if (!tsx) return undefined;
+    if (!tsx) return undefined; // Assume no-op if txn was not returned
 
-    // Add putFollowAdd operations to the RocksDB transaction
+    // Add ops to store the message by messageKey and index the the messageKey by set
     tsx = this.putFollowAddTransaction(tsx, message);
 
-    // Commit the RocksDB transaction
     return this._db.commit(tsx);
   }
 
   private async mergeRemove(message: FollowRemoveModel): Promise<void> {
-    // Define follow id for lookups
     const followId = message.body().user()?.fidArray() ?? new Uint8Array();
 
     let tsx = await this.resolveMergeConflicts(this._db.transaction(), followId, message);
 
-    // No-op if resolveMergeConflicts did not return a transaction
-    if (!tsx) return undefined;
+    if (!tsx) return undefined; // Assume no-op if txn was not returned
 
-    // Add putFollowRemove operations to the RocksDB transaction
+    // Add ops to store the message by messageKey and index the the messageKey by set
     tsx = this.putFollowRemoveTransaction(tsx, message);
 
-    // Commit the RocksDB transaction
     return this._db.commit(tsx);
   }
 
@@ -145,20 +179,29 @@ class FollowStore {
     bType: MessageType,
     bTsHash: Uint8Array
   ): number {
-    const tsHashOrder = bytesCompare(aTsHash, bTsHash);
-    if (tsHashOrder !== 0) {
-      return tsHashOrder;
+    // Compare timestamps (first 4 bytes of tsHash) to enforce Last-Write-Wins
+    const timestampOrder = bytesCompare(aTsHash.subarray(0, 4), bTsHash.subarray(0, 4));
+    if (timestampOrder !== 0) {
+      return timestampOrder;
     }
 
+    // Compare message types to enforce that RemoveWins in case of LWW ties.
     if (aType === MessageType.FollowRemove && bType === MessageType.FollowAdd) {
       return 1;
     } else if (aType === MessageType.FollowAdd && bType === MessageType.FollowRemove) {
       return -1;
     }
 
-    return 0;
+    // Compare hashes (last 4 bytes of tsHash) to break ties between messages of the same type and timestamp
+    return bytesCompare(aTsHash.subarray(4), bTsHash.subarray(4));
   }
 
+  /**
+   * Determines the RocksDB keys that must be modified to settle merge conflicts as a result of
+   * adding a Follow to the Store.
+   *
+   * @returns a RocksDB transaction if keys must be added or removed, undefined otherwise.
+   */
   private async resolveMergeConflicts(
     tsx: Transaction,
     followId: Uint8Array,
@@ -222,19 +265,20 @@ class FollowStore {
     return tsx;
   }
 
+  /* Builds a RocksDB transaction to insert a FollowAdd message and construct its indices */
   private putFollowAddTransaction(tsx: Transaction, message: FollowAddModel): Transaction {
-    // Put message and index by signer
+    // Puts the message into the database
     tsx = MessageModel.putTransaction(tsx, message);
 
-    // Put followAdds index
+    // Puts the message key into the FollowAdds set index
     tsx = tsx.put(
       FollowStore.followAddsKey(message.fid(), message.body().user()?.fidArray() ?? new Uint8Array()),
       Buffer.from(message.tsHash())
     );
 
-    // Index by user
+    // Puts the message key into the byTargetUser index
     tsx = tsx.put(
-      FollowStore.followsByUserKey(
+      FollowStore.followsByTargetUserKey(
         message.body().user()?.fidArray() ?? new Uint8Array(),
         message.fid(),
         message.tsHash()
@@ -245,28 +289,30 @@ class FollowStore {
     return tsx;
   }
 
+  /* Builds a RocksDB transaction to remove a FollowAdd message and delete its indices */
   private deleteFollowAddTransaction(tsx: Transaction, message: FollowAddModel): Transaction {
-    // Delete from user index
+    // Delete the message key from the byTargetUser index
     tsx = tsx.del(
-      FollowStore.followsByUserKey(
+      FollowStore.followsByTargetUserKey(
         message.body().user()?.fidArray() ?? new Uint8Array(),
         message.fid(),
         message.tsHash()
       )
     );
 
-    // Delete from followAdds
+    // Delete the message key from the FollowAdds set index
     tsx = tsx.del(FollowStore.followAddsKey(message.fid(), message.body().user()?.fidArray() ?? new Uint8Array()));
 
     // Delete message
     return MessageModel.deleteTransaction(tsx, message);
   }
 
+  /* Builds a RocksDB transaction to insert a FollowRemove message and construct its indices */
   private putFollowRemoveTransaction(tsx: Transaction, message: FollowRemoveModel): Transaction {
-    // Add to db
+    // Puts the message
     tsx = MessageModel.putTransaction(tsx, message);
 
-    // Add to followRemoves
+    // Puts the message key into the FollowRemoves set index
     tsx = tsx.put(
       FollowStore.followRemovesKey(message.fid(), message.body().user()?.fidArray() ?? new Uint8Array()),
       Buffer.from(message.tsHash())
@@ -275,11 +321,12 @@ class FollowStore {
     return tsx;
   }
 
+  /* Builds a RocksDB transaction to remove a FollowRemove message and delete its indices */
   private deleteFollowRemoveTransaction(tsx: Transaction, message: FollowRemoveModel): Transaction {
-    // Delete from followRemoves
+    // Delete the message key from the FollowRemoves set index
     tsx = tsx.del(FollowStore.followRemovesKey(message.fid(), message.body().user()?.fidArray() ?? new Uint8Array()));
 
-    // Delete message
+    // Delete the message
     return MessageModel.deleteTransaction(tsx, message);
   }
 }

--- a/src/storage/sets/flatbuffers/reactionStore.ts
+++ b/src/storage/sets/flatbuffers/reactionStore.ts
@@ -20,7 +20,7 @@ import { bytesCompare } from '~/storage/flatbuffers/utils';
  * 3. Highest lexicographic hash wins
  *
  * ReactionMessages are stored ordinally in RocksDB indexed by a unique key `fid:tsHash`,
- * which makes truncating a user's earliest messages easy. Indices are also build for each phase
+ * which makes truncating a user's earliest messages easy. Indices are also built for each phase
  * set (adds, removes) to make lookups easy when checking if a collision exists. An index is also
  * build for the target to make it easy to fetch all reactions for a target.
  *
@@ -273,7 +273,8 @@ class ReactionStore {
   }
 
   /**
-   * Determines the RocksDB keys that must be modified to settle merge conflicts as a result of adding a Reaction to the Store.
+   * Determines the RocksDB keys that must be modified to settle merge conflicts as a result of
+   * adding a Reaction to the Store.
    *
    * @returns a RocksDB transaction if keys must be added or removed, undefined otherwise
    */

--- a/src/storage/sets/followSet.ts
+++ b/src/storage/sets/followSet.ts
@@ -28,7 +28,7 @@ class FollowSet {
     return this._db.getFollowAdd(fid, target);
   }
 
-  async getFollowsByUser(fid: number): Promise<Set<FollowAdd>> {
+  async getFollowsByTargetUser(fid: number): Promise<Set<FollowAdd>> {
     const follows = await this._db.getFollowAddsByUser(fid);
     return new Set(follows);
   }


### PR DESCRIPTION
## Motivation

Fixing an issue where follows set did not implement LWW-RW rules as intended, and refactoring the set to have more documentation and unit test coverage

## Change Summary

See above

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
