### PR TITLE
feat: add grpc service for submitting messages and events

### DIFF
--- a/src/network/rpc/flatbuffers/server.ts
+++ b/src/network/rpc/flatbuffers/server.ts
@@ -8,6 +8,7 @@ import { HubError, HubErrorCode } from '~/utils/hubErrors';
 import { followServiceImpls, followServiceMethods } from './followService';
 import { reactionServiceImpls, reactionServiceMethods } from './reactionService';
 import { verificationServiceImpls, verificationServiceMethods } from './verificationService';
+import { submitServiceImpls, submitServiceMethods } from './submitService';
 
 export const toServiceError = (err: HubError): grpc.ServiceError => {
   let grpcCode: number;
@@ -75,10 +76,12 @@ class Server {
   constructor(engine: Engine) {
     this.engine = engine;
     this.server = new grpc.Server();
+    this.server.addService(submitServiceMethods(), submitServiceImpls(engine));
     this.server.addService(castServiceMethods(), castServiceImpls(engine));
     this.server.addService(followServiceMethods(), followServiceImpls(engine));
     this.server.addService(reactionServiceMethods(), reactionServiceImpls(engine));
     this.server.addService(verificationServiceMethods(), verificationServiceImpls(engine));
+    // TODO: add signers, user data, and sync services
   }
 
   async start(port = 0): Promise<number> {

--- a/src/network/rpc/flatbuffers/submitService.test.ts
+++ b/src/network/rpc/flatbuffers/submitService.test.ts
@@ -1,0 +1,101 @@
+import Server from '~/network/rpc/flatbuffers/server';
+import { jestBinaryRocksDB } from '~/storage/db/jestUtils';
+import Client from '~/network/rpc/flatbuffers/client';
+import MessageModel from '~/storage/flatbuffers/messageModel';
+import Factories from '~/test/factories/flatbuffer';
+import Engine from '~/storage/engine/flatbuffers';
+import { CastAddModel, SignerAddModel } from '~/storage/flatbuffers/types';
+import { Wallet, utils } from 'ethers';
+import { generateEd25519KeyPair } from '~/utils/crypto';
+import ContractEventModel from '~/storage/flatbuffers/contractEventModel';
+import { KeyPair } from '~/types';
+import { HubError } from '~/utils/hubErrors';
+import { ContractEventType } from '~/utils/generated/contract_event_generated';
+
+const db = jestBinaryRocksDB('flatbuffers.rpc.submitService.test');
+const engine = new Engine(db);
+
+let server: Server;
+let client: Client;
+
+beforeAll(async () => {
+  server = new Server(engine);
+  const port = await server.start();
+  client = new Client(port);
+});
+
+afterAll(async () => {
+  client.close();
+  await server.stop();
+});
+
+const fid = Factories.FID.build();
+const wallet = Wallet.createRandom();
+let custodyEvent: ContractEventModel;
+let signer: KeyPair;
+let signerAdd: SignerAddModel;
+let castAdd: CastAddModel;
+
+beforeAll(async () => {
+  custodyEvent = new ContractEventModel(
+    await Factories.IdRegistryEvent.create(
+      { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid) },
+      { transient: { wallet } }
+    )
+  );
+
+  signer = await generateEd25519KeyPair();
+  const signerAddData = await Factories.SignerAddData.create({
+    body: Factories.SignerBody.build({ signer: Array.from(signer.publicKey) }),
+    fid: Array.from(fid),
+  });
+  signerAdd = new MessageModel(
+    await Factories.Message.create({ data: Array.from(signerAddData.bb?.bytes() ?? []) }, { transient: { wallet } })
+  ) as SignerAddModel;
+
+  const castAddData = await Factories.CastAddData.create({
+    fid: Array.from(fid),
+  });
+  castAdd = new MessageModel(
+    await Factories.Message.create({ data: Array.from(castAddData.bb?.bytes() ?? []) }, { transient: { signer } })
+  ) as CastAddModel;
+});
+
+describe('submitMessage', () => {
+  describe('with signer', () => {
+    beforeEach(async () => {
+      await engine.mergeIdRegistryEvent(custodyEvent);
+      await engine.mergeMessage(signerAdd);
+    });
+
+    test('succeeds', async () => {
+      const result = await client.submitMessage(castAdd);
+      expect(result._unsafeUnwrap()).toEqual(castAdd);
+      const getCast = await client.getCast(castAdd.fid(), castAdd.tsHash());
+      expect(getCast._unsafeUnwrap()).toEqual(castAdd);
+    });
+  });
+
+  test('fails without signer', async () => {
+    const result = await client.submitMessage(castAdd);
+    expect(result._unsafeUnwrapErr()).toEqual(new HubError('bad_request.validation_failure', 'unknown user'));
+  });
+});
+
+describe('submitContractEvent', () => {
+  test('succeeds', async () => {
+    const result = await client.submitContractEvent(custodyEvent);
+    expect(result._unsafeUnwrap()).toEqual(custodyEvent);
+  });
+
+  test('fails with invalid event', async () => {
+    const invalidEvent = new ContractEventModel(
+      await Factories.IdRegistryEvent.create(
+        { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid), type: 0 as ContractEventType },
+        { transient: { wallet } }
+      )
+    );
+    const result = await client.submitContractEvent(invalidEvent);
+    expect(result._unsafeUnwrapErr()).toEqual(new HubError('bad_request.validation_failure', 'invalid event type'));
+  });
+});


### PR DESCRIPTION
## Motivation

Need a way for clients to submit messages and events over gRPC

## Change Summary

Adds gRPC service with `submitMessage` and `submitContractEvent` methods

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged
