### PR TITLE
perf: Improve trie memory efficiency

### DIFF
--- a/src/network/sync/trieNode.test.ts
+++ b/src/network/sync/trieNode.test.ts
@@ -1,0 +1,121 @@
+import { Factories } from '~/test/factories';
+import { TrieNode } from '~/network/sync/trieNode';
+import { TIMESTAMP_LENGTH } from '~/network/sync/syncId';
+import { createHash } from 'crypto';
+
+const emptyHash = createHash('sha256').digest('hex');
+
+describe('TrieNode', () => {
+  // Traverse the node until we find a leaf or path splits into multiple choices
+  const traverse = (node: TrieNode): TrieNode => {
+    if (node.isLeaf) {
+      return node;
+    }
+    const children = Array.from(node.children);
+    if (children.length > 1) {
+      return node;
+    }
+    return traverse(children[0][1]);
+  };
+
+  describe('insert', () => {
+    test('succeeds inserting a single item', async () => {
+      const root = new TrieNode();
+      const id = Factories.SyncId.build();
+
+      expect(root.items).toEqual(0);
+      expect(root.hash).toEqual('');
+
+      root.insert(id.toString(), id.hashString);
+
+      expect(root.items).toEqual(1);
+      expect(root.hash).toBeTruthy();
+    });
+
+    test('insert compacts hashstring component of syncid to single node for efficiency', async () => {
+      const root = new TrieNode();
+      const id = Factories.SyncId.build();
+
+      root.insert(id.toString(), id.hashString);
+      let node = root;
+      // Timestamp portion of the key is not collapsed, but the hash portion is
+      for (let i = 0; i < TIMESTAMP_LENGTH; i++) {
+        const children = Array.from(node.children);
+        expect(children.length).toEqual(1);
+        node = children[0][1];
+      }
+
+      expect(node.isLeaf).toEqual(true);
+      expect(node.value).toEqual(id.hashString);
+    });
+
+    test('inserting another key with a common prefix splits the node', async () => {
+      // Generate two ids with the same timestamp and the same hash prefix. The trie should split the node
+      // where they diverge
+      const date = new Date(1665182332000);
+      const hash1 =
+        '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86a4321';
+      const hash2 =
+        '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86b1234';
+      const id1 = Factories.SyncId.build(undefined, { transient: { date, hash: hash1 } });
+      const id2 = Factories.SyncId.build(undefined, { transient: { date, hash: hash2 } });
+
+      const root = new TrieNode();
+      root.insert(id1.toString(), id1.hashString);
+      root.insert(id2.toString(), id2.hashString);
+
+      const splitNode = traverse(root);
+      expect(splitNode.items).toEqual(2);
+      const children = Array.from(splitNode.children);
+      expect(children.length).toEqual(2);
+      // hash1 node
+      expect(children[0][0]).toEqual('a');
+      expect(children[0][1].isLeaf).toBeTruthy();
+      expect(children[0][1].value).toEqual(id1.hashString);
+      // hash2 node
+      expect(children[1][0]).toEqual('b');
+      expect(children[1][1].isLeaf).toBeTruthy();
+      expect(children[1][1].value).toEqual(id2.hashString);
+    });
+  });
+
+  describe('delete', () => {
+    test('deleting a single item removes the node', async () => {
+      const root = new TrieNode();
+      const id = Factories.SyncId.build();
+
+      root.insert(id.toString(), id.hashString);
+      expect(root.items).toEqual(1);
+
+      root.delete(id.toString());
+      expect(root.items).toEqual(0);
+      expect(root.hash).toEqual(emptyHash);
+    });
+
+    test('deleting a single item from a split node should preserve previous hash', async () => {
+      const date = new Date(1665182332000);
+      const hash1 =
+        '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86a4321';
+      const hash2 =
+        '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86b1234';
+      const id1 = Factories.SyncId.build(undefined, { transient: { date, hash: hash1 } });
+      const id2 = Factories.SyncId.build(undefined, { transient: { date, hash: hash2 } });
+
+      const root = new TrieNode();
+      root.insert(id1.toString(), id1.hashString);
+      const previousRootHash = root.hash;
+      const leafNode = traverse(root);
+      root.insert(id2.toString(), id2.hashString);
+
+      expect(root.hash).not.toEqual(previousRootHash);
+
+      root.delete(id2.toString());
+
+      const newLeafNode = traverse(root);
+      expect(newLeafNode).toEqual(leafNode);
+      expect(root.hash).toEqual(previousRootHash);
+    });
+  });
+
+  // describe('get', () => {});
+});

--- a/src/network/sync/trieNode.test.ts
+++ b/src/network/sync/trieNode.test.ts
@@ -4,6 +4,11 @@ import { TIMESTAMP_LENGTH } from '~/network/sync/syncId';
 import { createHash } from 'crypto';
 
 const emptyHash = createHash('sha256').digest('hex');
+const sharedDate = new Date(1665182332000);
+const sharedPrefixHashA =
+  '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86a4321';
+const sharedPrefixHashB =
+  '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86b1234';
 
 describe('TrieNode', () => {
   // Traverse the node until we find a leaf or path splits into multiple choices
@@ -81,13 +86,8 @@ describe('TrieNode', () => {
     test('inserting another key with a common prefix splits the node', async () => {
       // Generate two ids with the same timestamp and the same hash prefix. The trie should split the node
       // where they diverge
-      const date = new Date(1665182332000);
-      const hash1 =
-        '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86a4321';
-      const hash2 =
-        '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86b1234';
-      const id1 = Factories.SyncId.build(undefined, { transient: { date, hash: hash1 } });
-      const id2 = Factories.SyncId.build(undefined, { transient: { date, hash: hash2 } });
+      const id1 = Factories.SyncId.build(undefined, { transient: { date: sharedDate, hash: sharedPrefixHashA } });
+      const id2 = Factories.SyncId.build(undefined, { transient: { date: sharedDate, hash: sharedPrefixHashB } });
 
       const root = new TrieNode();
       root.insert(id1.toString(), id1.hashString);
@@ -123,18 +123,8 @@ describe('TrieNode', () => {
 
     test('deleting a single item from a node with multiple items removes the item', async () => {
       const root = new TrieNode();
-      const id1 = Factories.SyncId.build(undefined, {
-        transient: {
-          date: new Date(1668521739000),
-          hash: '0x329682c47215ce27323ef13e884b001057274a1896b19c3afeaf167081f79e34ec799d02f42c3dbdaefe45f1ed10e3934bda3c24018b442142e3eb561a5ad317',
-        },
-      });
-      const id2 = Factories.SyncId.build(undefined, {
-        transient: {
-          date: new Date(1668521739000),
-          hash: '0xbaa1463bc7f7bfe358098ae3ec69d1951699b3cce97f2dbdd91116323ff4449b04b040bf70320e1800f50cd2aa036f9dab4154f3965fe535792e7b521409798c',
-        },
-      });
+      const id1 = Factories.SyncId.build(undefined, { transient: { date: sharedDate } });
+      const id2 = Factories.SyncId.build(undefined, { transient: { date: sharedDate } });
 
       root.insert(id1.toString(), id1.hashString);
       const previousHash = root.hash;
@@ -148,13 +138,8 @@ describe('TrieNode', () => {
     });
 
     test('deleting a single item from a split node should preserve previous hash', async () => {
-      const date = new Date(1665182332000);
-      const hash1 =
-        '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86a4321';
-      const hash2 =
-        '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86b1234';
-      const id1 = Factories.SyncId.build(undefined, { transient: { date, hash: hash1 } });
-      const id2 = Factories.SyncId.build(undefined, { transient: { date, hash: hash2 } });
+      const id1 = Factories.SyncId.build(undefined, { transient: { date: sharedDate, hash: sharedPrefixHashA } });
+      const id2 = Factories.SyncId.build(undefined, { transient: { date: sharedDate, hash: sharedPrefixHashB } });
 
       const root = new TrieNode();
       root.insert(id1.toString(), id1.hashString);
@@ -197,13 +182,8 @@ describe('TrieNode', () => {
     });
 
     test('getting an non-existent item that share the same prefix with an existing item returns undefined', async () => {
-      const date = new Date(1665182332000);
-      const hash1 =
-        '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86a4321';
-      const hash2 =
-        '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86b1234';
-      const id1 = Factories.SyncId.build(undefined, { transient: { date, hash: hash1 } });
-      const id2 = Factories.SyncId.build(undefined, { transient: { date, hash: hash2 } });
+      const id1 = Factories.SyncId.build(undefined, { transient: { date: sharedDate, hash: sharedPrefixHashA } });
+      const id2 = Factories.SyncId.build(undefined, { transient: { date: sharedDate, hash: sharedPrefixHashB } });
 
       const root = new TrieNode();
       root.insert(id1.toString(), id1.hashString);

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -105,31 +105,24 @@ const CastURLFactory = Factory.define<CastURL, { cast: Cast }, CastURL>(({ trans
   return new CastURL(new CastId(`fid:${fid}/cast:${hash}`));
 });
 
-const SyncIdFactory = Factory.define<SyncId, { date: Date; hash: string; str: string }, SyncId>(
-  ({ transientParams }) => {
-    let { date, hash } = transientParams;
-    const { str } = transientParams;
-    if (str) {
-      date = new Date(parseInt(str.slice(0, TIMESTAMP_LENGTH), 10) * 1000);
-      hash = str.slice(TIMESTAMP_LENGTH);
-    }
-    const dummyMessage: Message<MessageType.CastShort, CastShortBody> = {
-      data: {
-        signedAt: (date || faker.date.recent()).getTime(),
-        body: { text: '' },
-        fid: 1,
-        type: MessageType.CastShort,
-        network: FarcasterNetwork.Mainnet,
-      },
-      hash: hash || faker.datatype.hexadecimal({ length: HASH_LENGTH }).toLowerCase(),
-      hashType: HashAlgorithm.Blake2b,
-      signature: '',
-      signatureType: SignatureAlgorithm.Ed25519,
-      signer: '',
-    };
-    return new SyncId(dummyMessage);
-  }
-);
+const SyncIdFactory = Factory.define<SyncId, { date: Date; hash: string }, SyncId>(({ transientParams }) => {
+  const { date, hash } = transientParams;
+  const dummyMessage: Message<MessageType.CastShort, CastShortBody> = {
+    data: {
+      signedAt: (date || faker.date.recent()).getTime(),
+      body: { text: '' },
+      fid: 1,
+      type: MessageType.CastShort,
+      network: FarcasterNetwork.Mainnet,
+    },
+    hash: hash || faker.datatype.hexadecimal({ length: HASH_LENGTH }).toLowerCase(),
+    hashType: HashAlgorithm.Blake2b,
+    signature: '',
+    signatureType: SignatureAlgorithm.Ed25519,
+    signer: '',
+  };
+  return new SyncId(dummyMessage);
+});
 
 /**
  * ProtocolFactories are used to construct valid Farcaster Protocol JSON objects.

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -26,12 +26,14 @@ import {
   FollowAdd,
   FollowRemove,
   Cast,
+  CastShortBody,
 } from '~/types';
 import { hashMessage, signEd25519, hashFCObject, generateEd25519Signer, generateEthereumSigner } from '~/utils/crypto';
 import { CastURL, CastId, ChainAccountURL, UserId, UserURL } from '~/urls';
 // import { ChainAccountURL } from '~/urls/chainAccountUrl';
 // import {  } from '~/urls/castUrl';
 import { AccountId } from 'caip';
+import { HASH_LENGTH, SyncId, TIMESTAMP_LENGTH } from '~/network/sync/syncId';
 
 const generateTimestamp = (minDate: Date | undefined, maxDate: Date | undefined): number => {
   minDate = minDate || new Date(2020, 0, 1);
@@ -103,6 +105,32 @@ const CastURLFactory = Factory.define<CastURL, { cast: Cast }, CastURL>(({ trans
   return new CastURL(new CastId(`fid:${fid}/cast:${hash}`));
 });
 
+const SyncIdFactory = Factory.define<SyncId, { date: Date; hash: string; str: string }, SyncId>(
+  ({ transientParams }) => {
+    let { date, hash } = transientParams;
+    const { str } = transientParams;
+    if (str) {
+      date = new Date(parseInt(str.slice(0, TIMESTAMP_LENGTH), 10) * 1000);
+      hash = str.slice(TIMESTAMP_LENGTH);
+    }
+    const dummyMessage: Message<MessageType.CastShort, CastShortBody> = {
+      data: {
+        signedAt: (date || faker.date.recent()).getTime(),
+        body: { text: '' },
+        fid: 1,
+        type: MessageType.CastShort,
+        network: FarcasterNetwork.Mainnet,
+      },
+      hash: hash || faker.datatype.hexadecimal({ length: HASH_LENGTH }).toLowerCase(),
+      hashType: HashAlgorithm.Blake2b,
+      signature: '',
+      signatureType: SignatureAlgorithm.Ed25519,
+      signer: '',
+    };
+    return new SyncId(dummyMessage);
+  }
+);
+
 /**
  * ProtocolFactories are used to construct valid Farcaster Protocol JSON objects.
  */
@@ -110,6 +138,7 @@ export const Factories = {
   EthereumAddressURL: EthereumAddressURLFactory,
   CastUrl: CastURLFactory,
   UserURL: UserURLFactory,
+  SyncId: SyncIdFactory,
 
   /** Generate a valid Cast with randomized properties */
   CastShort: Factory.define<CastShort, MessageFactoryTransientParams, CastShort>(({ onCreate, transientParams }) => {


### PR DESCRIPTION
## Motivation

Improves the trie memory efficiency by not creating nodes if there is only one value. Since our sync ids are long, and will very rarely collide, this should yeild substantial savings.

## Change Summary

Previously, when inserting a key, the trie will create a node for each character in the key until the end of the string and then insert the value. Now, after the timestamp portion of the string, we'll immediately create a leaf node if it's the only value. Or split the node until they don't share a common prefix anymore and insert the value.

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)

## Additional Context

We're currently choosing not to copmact the timestamp portion of the trie, we could do it if we wanted to, but it breaks a lot of tests and the benefit in marginal. 

