### PR TITLE
fix(RPCServer): use result value instead of result in multiaddr str

### DIFF
--- a/src/network/rpc/server.ts
+++ b/src/network/rpc/server.ts
@@ -139,7 +139,9 @@ export class RPCServer {
   get multiaddr() {
     const addr = this.address;
     if (!addr) return undefined;
-    return `${ipMultiAddrStrFromAddressInfo(addr)}/tcp/${addr.port}`;
+    const addrInfo = ipMultiAddrStrFromAddressInfo(addr);
+    if (addrInfo.isErr()) return undefined;
+    return `${addrInfo.value}/tcp/${addr.port}`;
   }
 
   get address() {


### PR DESCRIPTION
## Motivation

The multiaddr was interpolating a Result object rather than the value inside the result, resulting in an incorrect mutliaddr string:
```
"[object Object]/tcp/50458"
```

## Change Summary

Updated the multiaddr function to check the result of `ipMultiAddrStrFromAddressInfo` and if successful return a string with the result value interpolated in the multiaddr string, else return undefined.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
