### PR TITLE
chore: enable noUncheckedIndexedAccess

### DIFF
--- a/src/network/p2p/node.test.ts
+++ b/src/network/p2p/node.test.ts
@@ -17,7 +17,7 @@ let messages: Map<string, Map<string, GossipMessage[] | undefined>>;
 const connectAll = async (nodes: Node[]) => {
   const connectionResults = await Promise.all(
     nodes.slice(1).map((n) => {
-      return n.connect(nodes[0]);
+      return n.connect(nodes[0] as Node);
     })
   );
   connectionResults.forEach((r) => {
@@ -173,7 +173,7 @@ describe('gossip network', () => {
       };
 
       // publish via some random node
-      const randomNode = nodes[Math.floor(Math.random() * nodes.length)];
+      const randomNode = nodes[Math.floor(Math.random() * nodes.length)] as Node;
       expect(randomNode.publish(message)).resolves.toBeUndefined();
       // sleep 5 heartbeat ticks
       await sleep(5_000);

--- a/src/network/sync/syncEngine.test.ts
+++ b/src/network/sync/syncEngine.test.ts
@@ -8,6 +8,7 @@ import { SyncId } from '~/network/sync/syncId';
 import { anyString, instance, mock, when } from 'ts-mockito';
 import { RPCClient } from '~/network/rpc';
 import { ok } from 'neverthrow';
+import { CastShort } from '~/types';
 
 const testDb = jestRocksDB(`engine.syncEngine.test`);
 
@@ -144,8 +145,8 @@ describe('SyncEngine', () => {
     // There might be more messages related to user creation, but it's sufficient to check for casts
     expect(syncEngine.trie.items).toBeGreaterThanOrEqual(3);
     expect(syncEngine.trie.rootHash).toBeTruthy();
-    expect(syncEngine.trie.get(new SyncId(messages[0]))).toBeTruthy();
-    expect(syncEngine.trie.get(new SyncId(messages[1]))).toBeTruthy();
-    expect(syncEngine.trie.get(new SyncId(messages[2]))).toBeTruthy();
+    expect(syncEngine.trie.get(new SyncId(messages[0] as CastShort))).toBeTruthy();
+    expect(syncEngine.trie.get(new SyncId(messages[1] as CastShort))).toBeTruthy();
+    expect(syncEngine.trie.get(new SyncId(messages[2] as CastShort))).toBeTruthy();
   });
 });

--- a/src/network/sync/trieNode.test.ts
+++ b/src/network/sync/trieNode.test.ts
@@ -20,7 +20,7 @@ describe('TrieNode', () => {
     if (children.length > 1) {
       return node;
     }
-    return traverse(children[0][1]);
+    return traverse((children[0] as [string, TrieNode])[1]);
   };
 
   describe('insert', () => {
@@ -75,8 +75,9 @@ describe('TrieNode', () => {
       // Timestamp portion of the key is not collapsed, but the hash portion is
       for (let i = 0; i < TIMESTAMP_LENGTH; i++) {
         const children = Array.from(node.children);
+        const firstChild = children[0] as [string, TrieNode];
         expect(children.length).toEqual(1);
-        node = children[0][1];
+        node = firstChild[1];
       }
 
       expect(node.isLeaf).toEqual(true);
@@ -96,15 +97,17 @@ describe('TrieNode', () => {
       const splitNode = traverse(root);
       expect(splitNode.items).toEqual(2);
       const children = Array.from(splitNode.children);
+      const firstChild = children[0] as [string, TrieNode];
+      const secondChild = children[1] as [string, TrieNode];
       expect(children.length).toEqual(2);
       // hash1 node
-      expect(children[0][0]).toEqual('a');
-      expect(children[0][1].isLeaf).toBeTruthy();
-      expect(children[0][1].value).toEqual(id1.hashString);
+      expect(firstChild[0]).toEqual('a');
+      expect(firstChild[1].isLeaf).toBeTruthy();
+      expect(firstChild[1].value).toEqual(id1.hashString);
       // hash2 node
-      expect(children[1][0]).toEqual('b');
-      expect(children[1][1].isLeaf).toBeTruthy();
-      expect(children[1][1].value).toEqual(id2.hashString);
+      expect(secondChild[0]).toEqual('b');
+      expect(secondChild[1].isLeaf).toBeTruthy();
+      expect(secondChild[1].value).toEqual(id2.hashString);
     });
   });
 

--- a/src/network/sync/trieNode.ts
+++ b/src/network/sync/trieNode.ts
@@ -46,7 +46,7 @@ class TrieNode {
    * every node that was traversed.
    */
   public insert(key: string, value: string, current_index = 0): boolean {
-    const char = key[current_index];
+    const char = key.charAt(current_index);
 
     // Do not compact the timestamp portion of the trie, since it's used to compare snapshots
     if (current_index >= TIMESTAMP_LENGTH && this.isLeaf && !this._value) {
@@ -95,7 +95,7 @@ class TrieNode {
       return true;
     }
 
-    const char = key[current_index];
+    const char = key.charAt(current_index);
     if (!this._children.has(char)) {
       return false;
     }
@@ -133,7 +133,7 @@ class TrieNode {
       return this._value;
     }
 
-    const char = key[current_index];
+    const char = key.charAt(current_index);
     if (!this._children.has(char)) {
       return undefined;
     }
@@ -143,7 +143,7 @@ class TrieNode {
 
   // Generates a snapshot for the current node and below. current_index is the index of the prefix the method is operating on
   public getSnapshot(prefix: string, current_index = 0): TrieSnapshot {
-    const char = prefix[current_index];
+    const char = prefix.charAt(current_index);
     if (current_index === prefix.length - 1) {
       const excludedHash = this._excludedHash(char);
       return {
@@ -186,7 +186,7 @@ class TrieNode {
     if (prefix.length === 0) {
       return this;
     }
-    const char = prefix[0];
+    const char = prefix.charAt(0);
     if (!this._children.has(char)) {
       return undefined;
     }
@@ -243,7 +243,7 @@ class TrieNode {
       // This should never happen, check is here for type safety
       throw new HubError('bad_request', 'Cannot split a leaf node without a key and value');
     }
-    const newChildChar = this._key[current_index];
+    const newChildChar = this._key.charAt(current_index);
     this._addChild(newChildChar);
     this._children.get(newChildChar)?.insert(this._key, this._value, current_index + 1);
     this._setKeyValue(undefined, undefined);

--- a/src/storage/flatbuffers/utils.ts
+++ b/src/storage/flatbuffers/utils.ts
@@ -26,8 +26,8 @@ export const bytesCompare = (a: Uint8Array, b: Uint8Array): number => {
 export const bytesIncrement = (bytes: Uint8Array): Uint8Array => {
   let i = bytes.length - 1;
   while (i >= 0) {
-    if (bytes[i] < 255) {
-      bytes[i] = bytes[i] + 1;
+    if ((bytes[i] as number) < 255) {
+      bytes[i] = (bytes[i] as number) + 1;
       return bytes;
     } else {
       bytes[i] = 0;
@@ -40,8 +40,8 @@ export const bytesIncrement = (bytes: Uint8Array): Uint8Array => {
 export const bytesDecrement = (bytes: Uint8Array): Uint8Array => {
   let i = bytes.length - 1;
   while (i >= 0) {
-    if (bytes[i] > 0) {
-      bytes[i] = bytes[i] - 1;
+    if ((bytes[i] as number) > 0) {
+      bytes[i] = (bytes[i] as number) - 1;
       return bytes;
     } else {
       if (i === 0) {

--- a/src/storage/provider/idRegistryProvider.ts
+++ b/src/storage/provider/idRegistryProvider.ts
@@ -47,7 +47,7 @@ class IdRegistryProvider extends TypedEmitter<IdRegistryEvents> {
   }
 
   get minBlockNumber() {
-    return this.blocksQueue[0];
+    return this.blocksQueue[0] as number;
   }
 
   /**

--- a/src/test/e2e/differentialSync.test.ts
+++ b/src/test/e2e/differentialSync.test.ts
@@ -68,6 +68,7 @@ const TEST_TIMEOUT = 2 * 60 * 1000; // 2 min timeout
 
 describe('differentialSync', () => {
   let userInfos: UserInfo[];
+  let firstUserInfo: UserInfo;
 
   beforeEach(async () => {
     await serverDb.clear();
@@ -90,6 +91,7 @@ describe('differentialSync', () => {
       Follows: 50,
       Reactions: 0,
     });
+    firstUserInfo = userInfos[0] as UserInfo;
   }, TEST_TIMEOUT);
 
   afterEach(async () => {
@@ -147,10 +149,10 @@ describe('differentialSync', () => {
       const now = Date.now();
       const messages = await Factories.CastShort.createList(
         newMessages,
-        { data: { fid: userInfos[0].fid } },
+        { data: { fid: firstUserInfo.fid } },
         {
           transient: {
-            signer: userInfos[0].delegateSigner,
+            signer: firstUserInfo.delegateSigner,
             minDate: new Date(now - 1000 * 100), // Between 100-50 seconds ago
             maxDate: new Date(now - 1000 * 50),
           },
@@ -197,10 +199,10 @@ describe('differentialSync', () => {
       // Remove a user's messages
       const now = Date.now();
       const message = await Factories.SignerRemove.create(
-        { data: { fid: userInfos[0].fid, body: { delegate: userInfos[0].delegateSigner.signerKey } } },
+        { data: { fid: firstUserInfo.fid, body: { delegate: firstUserInfo.delegateSigner.signerKey } } },
         {
           transient: {
-            signer: userInfos[0].ethereumSigner,
+            signer: firstUserInfo.ethereumSigner,
             minDate: new Date(now - 1000 * 100), // Between 100-50 seconds ago (before sync threshold)
             maxDate: new Date(now - 1000 * 50),
           },
@@ -229,8 +231,8 @@ describe('differentialSync', () => {
       // Merge a signer remove within sync threshold (should not be picked up for sync)
       const now = Date.now();
       const message = await Factories.SignerRemove.create(
-        { data: { fid: userInfos[0].fid, body: { delegate: userInfos[0].delegateSigner.signerKey }, signedAt: now } },
-        { transient: { signer: userInfos[0].ethereumSigner } }
+        { data: { fid: firstUserInfo.fid, body: { delegate: firstUserInfo.delegateSigner.signerKey }, signedAt: now } },
+        { transient: { signer: firstUserInfo.ethereumSigner } }
       );
       const res = await hubAStorageEngine.mergeMessage(message);
       expect(res.isOk()).toBeTruthy();
@@ -252,10 +254,10 @@ describe('differentialSync', () => {
     async () => {
       const now = Date.now();
       const signerRemove = await Factories.SignerRemove.create(
-        { data: { fid: userInfos[0].fid, body: { delegate: userInfos[0].delegateSigner.signerKey } } },
+        { data: { fid: firstUserInfo.fid, body: { delegate: firstUserInfo.delegateSigner.signerKey } } },
         {
           transient: {
-            signer: userInfos[0].ethereumSigner,
+            signer: firstUserInfo.ethereumSigner,
             minDate: new Date(now - 1000 * 100), // Between 100-50 seconds ago
             maxDate: new Date(now - 1000 * 50),
           },

--- a/src/test/e2e/hub.test.ts
+++ b/src/test/e2e/hub.test.ts
@@ -9,6 +9,7 @@ import { ContactInfoContent, Content, GossipMessage, NETWORK_TOPIC_PRIMARY } fro
 import { Message } from '~/types';
 import { jest } from '@jest/globals';
 import { HubError } from '~/utils/hubErrors';
+import { Multiaddr } from '@multiformats/multiaddr';
 
 const TEST_TIMEOUT_SHORT = 10 * 1000;
 const TEST_TIMEOUT_LONG = 2 * 60 * 1000;
@@ -88,7 +89,7 @@ describe('Hub running tests', () => {
       // bootstrap hub2 off of hub1
       expect(hub.gossipAddresses);
       // need a better way to pick one of the multiaddrs
-      const secondHub = new Hub({ bootstrapAddrs: [hub.gossipAddresses[0]], ...opts });
+      const secondHub = new Hub({ bootstrapAddrs: [hub.gossipAddresses[0] as Multiaddr], ...opts });
       expect(secondHub).toBeDefined();
       // Use a flag to help clean up if the test fails at any point
       let shouldStop = true;

--- a/src/test/perf/bench.ts
+++ b/src/test/perf/bench.ts
@@ -53,7 +53,7 @@ const rpcClients = rpcMultiAddrs.map((addr) => {
 // sets up hubs
 const userInfos = await setupNetwork(rpcClients, { users: cliOptions['users'], mode: SetupMode.RANDOM_SINGLE });
 // creates scenario data
-const scenario = await makeBasicScenario(rpcClients[0], userInfos);
+const scenario = await makeBasicScenario(rpcClients[0] as RPCClient, userInfos);
 // submits the scenario for playback
 await playback(scenario, { order: PlaybackOrder.SEQ });
 // verifies network sync

--- a/src/test/perf/setup.ts
+++ b/src/test/perf/setup.ts
@@ -49,7 +49,7 @@ export const setupNetwork = async (rpcClients: RPCClient[], config: SetupConfig)
   post(`Generated ${config.users} users. UserInfo has ${userInfos.length} items`, start, stop);
 
   // pick a random RPC node
-  const client = rpcClients[Math.floor(Math.random() * rpcClients.length)];
+  const client = rpcClients[Math.floor(Math.random() * rpcClients.length)] as RPCClient;
 
   // submit users
   start = performance.now();

--- a/src/test/perf/utils.ts
+++ b/src/test/perf/utils.ts
@@ -2,7 +2,7 @@ import { JSONRPCError } from 'jayson/promise';
 import { err, ok, Result } from 'neverthrow';
 import ProgressBar from 'progress';
 import { RPCClient } from '~/network/rpc';
-import { IdRegistryEvent, Message } from '~/types';
+import { Body, IdRegistryEvent, Message, MessageType } from '~/types';
 import { logger } from '~/utils/logger';
 
 /** Submits a list of messages to the given RPC client */
@@ -43,8 +43,12 @@ export const shuffleMessages = (messages: Message[]) => {
   for (let i = shuffledMessages.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     // safe to disable because inputs are controlled and known
-    // eslint-disable-next-line security/detect-object-injection
-    [shuffledMessages[i], shuffledMessages[j]] = [shuffledMessages[j], shuffledMessages[i]];
+    /* eslint-disable security/detect-object-injection */
+    [shuffledMessages[i], shuffledMessages[j]] = [
+      shuffledMessages[j] as Message<MessageType, Body>,
+      shuffledMessages[i] as Message<MessageType, Body>,
+    ];
+    /* eslint-enable security/detect-object-injection */
   }
   return shuffledMessages;
 };
@@ -67,13 +71,13 @@ const getCounts = (results: Result<any, any>[]): SubmitCounts => {
   const counts = results
     .map((r) => [Number(r.isOk()), Number(r.isErr())])
     .reduce((results, result) => {
-      results[0] += result[0];
-      results[1] += result[1];
+      results[0] += result[0] as number;
+      results[1] += result[1] as number;
       return results;
     });
   return {
-    success: counts[0],
-    fail: counts[1],
+    success: counts[0] as number,
+    fail: counts[1] as number,
   };
 };
 

--- a/src/urls/castUrl.ts
+++ b/src/urls/castUrl.ts
@@ -71,6 +71,9 @@ export class CastHash {
       params = maybeParsed.value;
     } else {
       const castHashSpec = CastHash.spec.parameters.values[1];
+      if (castHashSpec === undefined) {
+        throw new Error(`URL missing cast hash`);
+      }
       if (!RegExp(castHashSpec.regex).test(params.value)) {
         throw new Error(`Invalid ${castHashSpec.name} provided: ${params.value}`);
       }

--- a/src/urls/chainAccountUrl.ts
+++ b/src/urls/chainAccountUrl.ts
@@ -27,11 +27,22 @@ export class ChainAccountURL extends ChainURL {
 
       // caip-js alone is not enough to catch invalid URLs
       // e.g. `eip155:1:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb`
-      const regexBody = [
-        AccountId.spec.parameters.values[0].regex, // namespace (e.g. `eip155`)
-        AccountId.spec.parameters.values[1].regex, // reference (e.g. `1`)
-        AccountId.spec.parameters.values[2].regex, // address (e.g. `0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb`)
-      ].join(AccountId.spec.parameters.delimiter);
+      const namespaceParam = AccountId.spec.parameters.values[0]; // namespace (e.g. `eip155`)
+      if (namespaceParam === undefined) {
+        return err(new BadRequestError(`ChainAccountURL.parse: missing 'namespace' parameter`));
+      }
+      const referenceParam = AccountId.spec.parameters.values[1]; // reference (e.g. `1`)
+      if (referenceParam === undefined) {
+        return err(new BadRequestError(`ChainAccountURL.parse: missing 'reference' parameter`));
+      }
+      const addressParam = AccountId.spec.parameters.values[2]; // address (e.g. `0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb`)
+      if (addressParam === undefined) {
+        return err(new BadRequestError(`ChainAccountURL.parse: missing 'address' parameter`));
+      }
+
+      const regexBody = [namespaceParam.regex, referenceParam.regex, addressParam.regex].join(
+        AccountId.spec.parameters.delimiter
+      );
       const referenceRegex = new RegExp('^' + regexBody + '$');
       if (!referenceRegex.test(remainder)) {
         return err(new BadRequestError(`ChainAccountURL.parse: invalid AccountID`));

--- a/src/urls/chainUrl.ts
+++ b/src/urls/chainUrl.ts
@@ -24,8 +24,13 @@ export class ChainURL extends BaseChainURL {
       const chainIdParams = ChainId.parse(remainder);
       const chainId = new ChainId(chainIdParams);
 
+      const chainIdParam = ChainId.spec.parameters.values[1];
+      if (chainIdParam === undefined) {
+        return err(new BadRequestError('ChainURL.parse: missing chain ID'));
+      }
+
       // check for extra invalid data before or after the chain ID
-      const referenceRegex = new RegExp('^' + ChainId.spec.parameters.values[1].regex + '$');
+      const referenceRegex = new RegExp('^' + chainIdParam.regex + '$');
       if (!referenceRegex.test(chainId.reference)) {
         return err(new BadRequestError(`ChainURL.parse: invalid extra data after ChainId: '${remainder}`));
       }

--- a/src/urls/userUrl.ts
+++ b/src/urls/userUrl.ts
@@ -55,6 +55,9 @@ export class UserId {
       params = maybeParsed.value;
     } else {
       const userIdSpec = UserId.spec.parameters.values[1];
+      if (!userIdSpec) {
+        throw new Error('URL missing userId');
+      }
       if (!RegExp(userIdSpec.regex).test(params.value)) {
         throw new Error(`Invalid ${userIdSpec.name} provided: ${params.value}`);
       }

--- a/src/urls/utils.ts
+++ b/src/urls/utils.ts
@@ -3,7 +3,7 @@
  * Utilities from this file are required, but the original versions are not exported in the built version of the caip-js
  * library.
  */
-import { IdentifierSpec, Params } from 'caip/dist/types';
+import { IdentifierSpec, KeyValue, ParameterSpec, Params } from 'caip/dist/types';
 
 export const splitParams = (id: string, spec: IdentifierSpec): string[] => id.split(spec.parameters.delimiter);
 
@@ -11,7 +11,7 @@ export const getParams = <T>(id: string, spec: IdentifierSpec): T => {
   const arr = splitParams(id, spec);
   const params: any = {};
   arr.forEach((value, index) => {
-    params[spec.parameters.values[index].name] = value;
+    params[(spec.parameters.values[index] as ParameterSpec).name] = value;
   });
   return params as T;
 };
@@ -19,7 +19,7 @@ export const getParams = <T>(id: string, spec: IdentifierSpec): T => {
 export const joinParams = (params: Params, spec: IdentifierSpec): string =>
   Object.values(spec.parameters.values)
     .map((parameter) => {
-      const param = params[parameter.name];
+      const param = params[parameter.name] as KeyValue;
       return typeof param === 'string' ? param : joinParams(param, parameter as IdentifierSpec);
     })
     .join(spec.parameters.delimiter);
@@ -29,7 +29,7 @@ export const isValidId = (id: string, spec: IdentifierSpec): boolean => {
   const params = splitParams(id, spec);
   if (params.length !== Object.keys(spec.parameters.values).length) return false;
   const matches = params
-    .map((param, index) => new RegExp(spec.parameters.values[index].regex).test(param))
+    .map((param, index) => new RegExp((spec.parameters.values[index] as ParameterSpec).regex).test(param))
     .filter((x) => !!x);
   if (matches.length !== params.length) return false;
   return true;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,8 +33,7 @@
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
-    // TODO: fixing this is tracked here: https://github.com/farcasterxyz/hub/issues/151
-    // "noUncheckedIndexedAccess": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": false, // causes hard failures when iterating in dev, enforce with eslint instead
     "noUnusedParameters": false
   },


### PR DESCRIPTION
## Motivation

See #151 

## Change Summary

Enables the `noUncheckedIndexedAccess` in `tsconfig.json`. Update usages of property accesses to comply, generally following the rule:
- in tests or util files, use `as`
- in application code, use runtime checks


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
