### PR TITLE
Fix and suppress eslint security warnings

### DIFF
--- a/src/network/p2p/connectionFilter.test.ts
+++ b/src/network/p2p/connectionFilter.test.ts
@@ -1,7 +1,6 @@
 import { createEd25519PeerId } from '@libp2p/peer-id-factory';
 import { multiaddr } from '@multiformats/multiaddr';
 import { ConnectionFilter } from '~/network/p2p/connectionFilter';
-import { mockMultiaddrConnPair } from '@libp2p/interface-mocks';
 import { PeerId } from '@libp2p/interface-peer-id';
 
 let allowedPeerId: PeerId;
@@ -23,51 +22,39 @@ describe('connectionFilter tests', () => {
 
   test('denies all connections by default', async () => {
     const filter = new ConnectionFilter([]);
-    const { inbound: _localConnection, outbound: remoteConnection } = mockMultiaddrConnPair({
-      addrs: [multiaddr(localMultiAddrStr), multiaddr(allowedMultiAddrStr)],
-      remotePeer: allowedPeerId,
-    });
     await expect(filter.denyDialPeer(allowedPeerId)).resolves.toBeTruthy();
-    await expect(filter.denyDialMultiaddr(allowedPeerId, multiaddr(allowedMultiAddrStr))).resolves.toBeTruthy();
+    await expect(filter.denyDialMultiaddr(allowedPeerId)).resolves.toBeTruthy();
     // Incepient Inbound Connections are always allowed
-    await expect(filter.denyInboundConnection(remoteConnection)).resolves.toBeFalsy();
-    await expect(filter.denyInboundEncryptedConnection(allowedPeerId, remoteConnection)).resolves.toBeTruthy();
-    await expect(filter.denyInboundUpgradedConnection(allowedPeerId, remoteConnection)).resolves.toBeTruthy();
-    await expect(filter.denyOutboundConnection(allowedPeerId, remoteConnection)).resolves.toBeTruthy();
-    await expect(filter.denyOutboundEncryptedConnection(allowedPeerId, remoteConnection)).resolves.toBeTruthy();
-    await expect(filter.denyOutboundUpgradedConnection(allowedPeerId, remoteConnection)).resolves.toBeTruthy();
+    await expect(filter.denyInboundConnection()).resolves.toBeFalsy();
+    await expect(filter.denyInboundEncryptedConnection(allowedPeerId)).resolves.toBeTruthy();
+    await expect(filter.denyInboundUpgradedConnection(allowedPeerId)).resolves.toBeTruthy();
+    await expect(filter.denyOutboundConnection(allowedPeerId)).resolves.toBeTruthy();
+    await expect(filter.denyOutboundEncryptedConnection(allowedPeerId)).resolves.toBeTruthy();
+    await expect(filter.denyOutboundUpgradedConnection(allowedPeerId)).resolves.toBeTruthy();
     await expect(filter.filterMultiaddrForPeer(allowedPeerId)).resolves.toBeFalsy();
   });
 
   test('allows selected peers', async () => {
     const filter = new ConnectionFilter([allowedPeerId.toString()]);
-    const { inbound: _localConnection, outbound: remoteConnection } = mockMultiaddrConnPair({
-      addrs: [multiaddr(localMultiAddrStr), multiaddr(allowedMultiAddrStr)],
-      remotePeer: allowedPeerId,
-    });
     await expect(filter.denyDialPeer(allowedPeerId)).resolves.toBeFalsy();
-    await expect(filter.denyDialMultiaddr(allowedPeerId, multiaddr(allowedMultiAddrStr))).resolves.toBeFalsy();
+    await expect(filter.denyDialMultiaddr(allowedPeerId)).resolves.toBeFalsy();
     // Incepient Inbound Connections are always allowed
-    await expect(filter.denyInboundConnection(remoteConnection)).resolves.toBeFalsy();
-    await expect(filter.denyInboundEncryptedConnection(allowedPeerId, remoteConnection)).resolves.toBeFalsy();
-    await expect(filter.denyInboundUpgradedConnection(allowedPeerId, remoteConnection)).resolves.toBeFalsy();
-    await expect(filter.denyOutboundConnection(allowedPeerId, remoteConnection)).resolves.toBeFalsy();
-    await expect(filter.denyOutboundEncryptedConnection(allowedPeerId, remoteConnection)).resolves.toBeFalsy();
-    await expect(filter.denyOutboundUpgradedConnection(allowedPeerId, remoteConnection)).resolves.toBeFalsy();
+    await expect(filter.denyInboundConnection()).resolves.toBeFalsy();
+    await expect(filter.denyInboundEncryptedConnection(allowedPeerId)).resolves.toBeFalsy();
+    await expect(filter.denyInboundUpgradedConnection(allowedPeerId)).resolves.toBeFalsy();
+    await expect(filter.denyOutboundConnection(allowedPeerId)).resolves.toBeFalsy();
+    await expect(filter.denyOutboundEncryptedConnection(allowedPeerId)).resolves.toBeFalsy();
+    await expect(filter.denyOutboundUpgradedConnection(allowedPeerId)).resolves.toBeFalsy();
     await expect(filter.filterMultiaddrForPeer(allowedPeerId)).resolves.toBeTruthy();
   });
 
   test('filters unknown peers', async () => {
     const filter = new ConnectionFilter([allowedPeerId.toString()]);
-    const { inbound: _localConnection, outbound: remoteConnection } = mockMultiaddrConnPair({
-      addrs: [multiaddr(localMultiAddrStr), multiaddr(filteredMultiAddrStr)],
-      remotePeer: blockedPeerId,
-    });
     await expect(filter.denyDialPeer(allowedPeerId)).resolves.toBeFalsy();
     await expect(filter.denyDialPeer(blockedPeerId)).resolves.toBeTruthy();
     // Incepient Inbound Connections are always allowed
-    await expect(filter.denyInboundConnection(remoteConnection)).resolves.toBeFalsy();
-    await expect(filter.denyOutboundConnection(blockedPeerId, remoteConnection)).resolves.toBeTruthy();
+    await expect(filter.denyInboundConnection()).resolves.toBeFalsy();
+    await expect(filter.denyOutboundConnection(blockedPeerId)).resolves.toBeTruthy();
     await expect(filter.filterMultiaddrForPeer(blockedPeerId)).resolves.toBeFalsy();
   });
 });

--- a/src/network/p2p/connectionFilter.ts
+++ b/src/network/p2p/connectionFilter.ts
@@ -1,6 +1,5 @@
-import { ConnectionGater, MultiaddrConnection } from '@libp2p/interface-connection';
+import { ConnectionGater } from '@libp2p/interface-connection';
 import { PeerId } from '@libp2p/interface-peer-id';
-import { Multiaddr } from '@multiformats/multiaddr';
 import { logger } from '~/utils/logger';
 
 /**
@@ -28,7 +27,7 @@ export class ConnectionFilter implements ConnectionGater {
     return deny;
   };
 
-  denyDialMultiaddr = async (peerId: PeerId, _multiaddr: Multiaddr): Promise<boolean> => {
+  denyDialMultiaddr = async (peerId: PeerId): Promise<boolean> => {
     const deny = this.shouldDeny(peerId.toString());
     if (deny) {
       logger.info(`ConnectionFilter denyDialMultiaddr: denied a connection with ${peerId}`);
@@ -36,7 +35,7 @@ export class ConnectionFilter implements ConnectionGater {
     return deny;
   };
 
-  denyInboundConnection = async (_maConn: MultiaddrConnection): Promise<boolean> => {
+  denyInboundConnection = async (): Promise<boolean> => {
     /**
      * A PeerId is not always known on incipient connections.
      * Don't filter incipient connections, later filters will catch it.
@@ -44,7 +43,7 @@ export class ConnectionFilter implements ConnectionGater {
     return false;
   };
 
-  denyOutboundConnection = async (peerId: PeerId, _maConn: MultiaddrConnection): Promise<boolean> => {
+  denyOutboundConnection = async (peerId: PeerId): Promise<boolean> => {
     const deny = this.shouldDeny(peerId.toString());
     if (deny) {
       logger.info(`ConnectionFilter denyOutboundConnection: denied a connection with ${peerId}`);
@@ -52,7 +51,7 @@ export class ConnectionFilter implements ConnectionGater {
     return deny;
   };
 
-  denyInboundEncryptedConnection = async (peerId: PeerId, _maConn: MultiaddrConnection): Promise<boolean> => {
+  denyInboundEncryptedConnection = async (peerId: PeerId): Promise<boolean> => {
     const deny = this.shouldDeny(peerId.toString());
     if (deny) {
       logger.info(`ConnectionFilter denyInboundEncryptedConnection: denied a connection with ${peerId}`);
@@ -60,7 +59,7 @@ export class ConnectionFilter implements ConnectionGater {
     return deny;
   };
 
-  denyOutboundEncryptedConnection = async (peerId: PeerId, _maConn: MultiaddrConnection): Promise<boolean> => {
+  denyOutboundEncryptedConnection = async (peerId: PeerId): Promise<boolean> => {
     const deny = this.shouldDeny(peerId.toString());
     if (deny) {
       logger.info(`ConnectionFilter denyOutboundEncryptedConnection: denied a connection with ${peerId}`);
@@ -68,7 +67,7 @@ export class ConnectionFilter implements ConnectionGater {
     return deny;
   };
 
-  denyInboundUpgradedConnection = async (peerId: PeerId, _maConn: MultiaddrConnection): Promise<boolean> => {
+  denyInboundUpgradedConnection = async (peerId: PeerId): Promise<boolean> => {
     const deny = this.shouldDeny(peerId.toString());
     if (deny) {
       logger.info(`ConnectionFilter denyInboundUpgradedConnection: denied a connection with ${peerId}`);
@@ -76,7 +75,7 @@ export class ConnectionFilter implements ConnectionGater {
     return deny;
   };
 
-  denyOutboundUpgradedConnection = async (peerId: PeerId, _maConn: MultiaddrConnection): Promise<boolean> => {
+  denyOutboundUpgradedConnection = async (peerId: PeerId): Promise<boolean> => {
     const deny = this.shouldDeny(peerId.toString());
     if (deny) {
       logger.info(`ConnectionFilter denyOutboundUpgradedConnection: denied a connection with ${peerId}`);

--- a/src/network/sync/merkleTrie.ts
+++ b/src/network/sync/merkleTrie.ts
@@ -63,6 +63,8 @@ class MerkleTrie {
   public getDivergencePrefix(prefix: string, excludedHashes: string[]): string {
     const ourExcludedHashes = this.getSnapshot(prefix).excludedHashes;
     for (let i = 0; i < prefix.length; i++) {
+      // NOTE: `i` is controlled by for loop and hence not at risk of object injection.
+      // eslint-disable-next-line security/detect-object-injection
       if (ourExcludedHashes[i] !== excludedHashes[i]) {
         return prefix.slice(0, i);
       }

--- a/src/network/sync/syncEngine.ts
+++ b/src/network/sync/syncEngine.ts
@@ -73,6 +73,8 @@ class SyncEngine {
     const ourSnapshot = this.snapshot;
     const excludedHashesMatch =
       ourSnapshot.excludedHashes.length === excludedHashes.length &&
+      // NOTE: `index` is controlled by `every` and so not at risk of object injection.
+      // eslint-disable-next-line security/detect-object-injection
       ourSnapshot.excludedHashes.every((value, index) => value === excludedHashes[index]);
 
     log.debug(`shouldSync: excluded hashes check: ${excludedHashes}`);

--- a/src/storage/db/binaryrocksdb.ts
+++ b/src/storage/db/binaryrocksdb.ts
@@ -88,6 +88,8 @@ class RocksDB {
       } else {
         mkdir(this._db.location, { recursive: true }, (fsErr: Error | null) => {
           if (fsErr) reject(parseError(fsErr));
+          // NOTE: eslint falsely identifies `open(...)` as `fs.open`.
+          // eslint-disable-next-line security/detect-non-literal-fs-filename
           this._db.open({ createIfMissing: true, errorIfExists: false }, (e?: Error) => {
             if (!e) {
               this._hasOpened = true;

--- a/src/storage/db/rocksdb.ts
+++ b/src/storage/db/rocksdb.ts
@@ -87,6 +87,8 @@ class RocksDB {
       } else {
         mkdir(this._db.location, { recursive: true }, (fsErr: Error | null) => {
           if (fsErr) reject(parseError(fsErr));
+          // NOTE: eslint falsely identifies `open(...)` as `fs.open`.
+          // eslint-disable-next-line security/detect-non-literal-fs-filename
           this._db.open({ createIfMissing: true, errorIfExists: false }, (e?: Error) => {
             if (!e) {
               this._hasOpened = true;

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -33,7 +33,7 @@ import { CastURL, CastId, ChainAccountURL, UserId, UserURL } from '~/urls';
 // import { ChainAccountURL } from '~/urls/chainAccountUrl';
 // import {  } from '~/urls/castUrl';
 import { AccountId } from 'caip';
-import { HASH_LENGTH, SyncId, TIMESTAMP_LENGTH } from '~/network/sync/syncId';
+import { HASH_LENGTH, SyncId } from '~/network/sync/syncId';
 
 const generateTimestamp = (minDate: Date | undefined, maxDate: Date | undefined): number => {
   minDate = minDate || new Date(2020, 0, 1);

--- a/src/test/perf/scenario.ts
+++ b/src/test/perf/scenario.ts
@@ -75,9 +75,9 @@ const makeMessages = async (userInfos: UserInfo[], config: ScenarioConfig, event
   if (event > MockFCEvent.Verification) throw 'Invalid event type for messages';
 
   const total = userInfos.length * (config.Adds + config.Removes + config.RemovesWithoutAdds);
-  // safe to disable here since `event` is validated above
-  // eslint-disable-next-line security/detect-object-injection
   const progress = new ProgressBar(
+    // NOTE: An attacker cannot control the developer's test environment so it's safe to use `event` as an object key here.
+    // eslint-disable-next-line security/detect-object-injection
     `    Generating ${total} ${MockFCEvent[event]}s [:bar] :elapseds :ratemsgs/s :percent :etas`,
     {
       complete: '=',

--- a/src/urls/chainUrl.ts
+++ b/src/urls/chainUrl.ts
@@ -25,6 +25,8 @@ export class ChainURL extends BaseChainURL {
       const chainId = new ChainId(chainIdParams);
 
       // check for extra invalid data before or after the chain ID
+      // NOTE: The inserted regex `ChainID` is imported from the "caip" npm package and is trustworthy.
+      // eslint-disable-next-line security/detect-non-literal-regexp
       const referenceRegex = new RegExp('^' + ChainId.spec.parameters.values[1].regex + '$');
       if (!referenceRegex.test(chainId.reference)) {
         return err(new BadRequestError(`ChainURL.parse: invalid extra data after ChainId: '${remainder}`));

--- a/src/urls/utils.ts
+++ b/src/urls/utils.ts
@@ -7,10 +7,16 @@ import { IdentifierSpec, Params } from 'caip/dist/types';
 
 export const splitParams = (id: string, spec: IdentifierSpec): string[] => id.split(spec.parameters.delimiter);
 
+// NOTE: Please don't call this function with a user-controlled `spec`
+// variable.
 export const getParams = <T>(id: string, spec: IdentifierSpec): T => {
   const arr = splitParams(id, spec);
   const params: any = {};
   arr.forEach((value, index) => {
+    // NOTE: `index` is controlled by `forEach`.
+    // NOTE: In all invocations of `getParams` at the time of supression `spec`
+    // was statically defined by the developers within the invocing class.
+    // eslint-disable-next-line security/detect-object-injection
     params[spec.parameters.values[index].name] = value;
   });
   return params as T;
@@ -24,11 +30,20 @@ export const joinParams = (params: Params, spec: IdentifierSpec): string =>
     })
     .join(spec.parameters.delimiter);
 
+// NOTE: Please don't call this function with a user-controlled `spec`
+// variable.
 export const isValidId = (id: string, spec: IdentifierSpec): boolean => {
+  // NOTE: In all invocations of `isValidId` at the time of supression `spec`
+  // was statically defined by the developers within the invoking class.
+  // eslint-disable-next-line security/detect-non-literal-regexp
   if (!new RegExp(spec.regex).test(id)) return false;
   const params = splitParams(id, spec);
   if (params.length !== Object.keys(spec.parameters.values).length) return false;
   const matches = params
+    // NOTE: `index` is controlled by `map`.
+    // NOTE: In all invocations of `isValidId` at the time of supression `spec`
+    // was statically defined by the developers within the invocing class.
+    // eslint-disable-next-line security/detect-object-injection, security/detect-non-literal-regexp
     .map((param, index) => new RegExp(spec.parameters.values[index].regex).test(param))
     .filter((x) => !!x);
   if (matches.length !== params.length) return false;

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -54,8 +54,12 @@ const removeProps = (obj: Record<string, any>): void => {
   if (typeof obj === 'object' && obj != null) {
     Object.getOwnPropertyNames(obj).forEach((key) => {
       if (key[0] === '_') {
+        // NOTE `key` is controlled by `forEach`.
+        // eslint-disable-next-line security/detect-object-injection
         delete obj[key];
       } else {
+        // NOTE `key` is controlled by `forEach`.
+        // eslint-disable-next-line security/detect-object-injection
         removeProps(obj[key]);
       }
     });


### PR DESCRIPTION
hey, so I tried adressing #163. Here's the current left-over output of yearn lint

```
yarn lint
yarn run v1.22.18
warning package.json: License should be a valid SPDX license expression
$ eslint  src/ --color --ext .ts

/Users/timdaub/Projects/farcaster/hub/src/urls/chainAccountUrl.ts
  35:30  warning  Found non-literal argument to RegExp Constructor  security/detect-non-literal-regexp

✖ 1 problem (0 errors, 1 warning)
```

☝🏼 seeking advice on how to fix the last remaining warning.

I'll comment inline of this PR to document some of the decisions I took.

- security/detect-object-injection: Is a security concern when a user can control the key to an object access, so in all cases where we're aware that the user can by no means control the key, we can suppress the warning.