### PR TITLE
feat: sign hash of message data instead of data bytes

### DIFF
--- a/src/test/factories/flatbuffer.test.ts
+++ b/src/test/factories/flatbuffer.test.ts
@@ -69,7 +69,7 @@ describe('MessageFactory', () => {
   test('generates signature', async () => {
     const verifySignature = ed.verify(
       message.signatureArray() || new Uint8Array(),
-      data.bb?.bytes() || new Uint8Array(),
+      message.hashArray() || new Uint8Array(),
       message.signerArray() || new Uint8Array()
     );
     expect(verifySignature).resolves.toEqual(true);

--- a/src/test/factories/flatbuffer.ts
+++ b/src/test/factories/flatbuffer.ts
@@ -40,7 +40,7 @@ import { generateEd25519KeyPair } from '~/utils/crypto';
 import * as ed from '@noble/ed25519';
 import { arrayify } from 'ethers/lib/utils';
 import { ethers, Wallet } from 'ethers';
-import { signMessageData, signVerificationEthAddressClaim } from '~/utils/eip712';
+import { signMessageHash, signVerificationEthAddressClaim } from '~/utils/eip712';
 import { VerificationEthAddressClaim } from '~/storage/flatbuffers/types';
 import { ContractEvent, ContractEventT, ContractEventType } from '~/utils/generated/contract_event_generated';
 import { toFarcasterTime } from '~/storage/flatbuffers/utils';
@@ -371,15 +371,15 @@ const MessageFactory = Factory.define<MessageT, { signer?: KeyPair; wallet?: Wal
       if (params.signature.length === 0) {
         if (transientParams.signer) {
           const signer = transientParams.signer;
-          params.signature = Array.from(await ed.sign(new Uint8Array(params.data), signer.privateKey));
+          params.signature = Array.from(await ed.sign(new Uint8Array(params.hash), signer.privateKey));
           params.signer = Array.from(signer.publicKey);
         } else if (transientParams.wallet) {
-          params.signature = Array.from(await signMessageData(new Uint8Array(params.data), transientParams.wallet));
+          params.signature = Array.from(await signMessageHash(new Uint8Array(params.hash), transientParams.wallet));
           params.signatureScheme = SignatureScheme.Eip712;
           params.signer = Array.from(arrayify(transientParams.wallet.address));
         } else {
           const signer = await generateEd25519KeyPair();
-          params.signature = Array.from(await ed.sign(new Uint8Array(params.data), signer.privateKey));
+          params.signature = Array.from(await ed.sign(new Uint8Array(params.hash), signer.privateKey));
           params.signer = Array.from(signer.publicKey);
         }
       }

--- a/src/utils/eip712.test.ts
+++ b/src/utils/eip712.test.ts
@@ -4,11 +4,12 @@ import { VerificationEthAddressClaim } from '~/storage/flatbuffers/types';
 import Factories from '~/test/factories/flatbuffer';
 import { FarcasterNetwork } from '~/utils/generated/message_generated';
 import {
-  signMessageData,
+  signMessageHash,
   signVerificationEthAddressClaim,
-  verifyMessageDataSignature,
+  verifyMessageHashSignature,
   verifyVerificationEthAddressClaimSignature,
 } from '~/utils/eip712';
+import { blake3 } from '@noble/hashes/blake3';
 
 const wallet = Wallet.createRandom();
 
@@ -60,13 +61,14 @@ describe('signVerificationEthAddressClaim', () => {
   });
 });
 
-describe('signMessageData', () => {
+describe('signMessageHash', () => {
   test('succeeds', async () => {
     const messageData = await Factories.SignerAddData.create();
     const bytes = messageData.bb?.bytes() ?? new Uint8Array();
-    const signature = await signMessageData(bytes, wallet);
+    const hash = blake3(bytes, { dkLen: 16 });
+    const signature = await signMessageHash(hash, wallet);
     expect(signature).toBeTruthy();
-    const recoveredAddress = verifyMessageDataSignature(bytes, signature);
+    const recoveredAddress = verifyMessageHashSignature(hash, signature);
     expect(recoveredAddress).toEqual(utils.arrayify(wallet.address));
   });
 });

--- a/src/utils/eip712.ts
+++ b/src/utils/eip712.ts
@@ -30,7 +30,7 @@ const EIP_712_FARCASTER_VERIFICATION_CLAIM = [
 
 const EIP_712_FARCASTER_MESSAGE_DATA = [
   {
-    name: 'data',
+    name: 'hash',
     type: 'bytes',
   },
 ];
@@ -62,18 +62,18 @@ export const verifyVerificationEthAddressClaimSignature = (
   );
 };
 
-export const signMessageData = async (data: Uint8Array, wallet: Wallet): Promise<Uint8Array> => {
+export const signMessageHash = async (hash: Uint8Array, wallet: Wallet): Promise<Uint8Array> => {
   return arrayify(
-    await wallet._signTypedData(EIP_712_FARCASTER_DOMAIN, { MessageData: EIP_712_FARCASTER_MESSAGE_DATA }, { data })
+    await wallet._signTypedData(EIP_712_FARCASTER_DOMAIN, { MessageData: EIP_712_FARCASTER_MESSAGE_DATA }, { hash })
   );
 };
 
-export const verifyMessageDataSignature = (data: Uint8Array, signature: Uint8Array): Uint8Array => {
+export const verifyMessageHashSignature = (hash: Uint8Array, signature: Uint8Array): Uint8Array => {
   return arrayify(
     utils.verifyTypedData(
       EIP_712_FARCASTER_DOMAIN,
       { MessageData: EIP_712_FARCASTER_MESSAGE_DATA },
-      { data },
+      { hash },
       signature
     )
   );


### PR DESCRIPTION
## Motivation

Signatures should include the message's hash to avoid replay attacks if/when we introduce new hash schemes.

## Change Summary

Verify that message signatures are signatures of the hash of the message rather than of the message data bytes.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged
