### PR TITLE
feat: prune messages in CastStore

### DIFF
--- a/src/storage/flatbuffers/messageModel.ts
+++ b/src/storage/flatbuffers/messageModel.ts
@@ -52,8 +52,8 @@ export default class MessageModel {
   }
 
   /** <user prefix byte, fid, set index byte, key> */
-  static primaryKey(fid: Uint8Array, set: UserMessagePostfix, key: Uint8Array): Buffer {
-    return Buffer.concat([this.userKey(fid), Buffer.from([set]), Buffer.from(key)]);
+  static primaryKey(fid: Uint8Array, set: UserMessagePostfix, key?: Uint8Array): Buffer {
+    return Buffer.concat([this.userKey(fid), Buffer.from([set]), key ? Buffer.from(key) : new Uint8Array()]);
   }
 
   /** <user prefix byte, fid, signer index byte, signer, type, key> */


### PR DESCRIPTION
## Motivation

Pruned cast store implementation. See discussion of pruning here: https://hackmd.io/@farcasterxyz/BJj3zuVVj

## Change Summary

* Add `pruneMessages` CastStore method that prunes messages by size and time

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged
