### PR TITLE
feat: Debug config for jest tests in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  "configurations": [
+    {
+      "type": "node",
+      "name": "vscode-jest-tests.v2",
+      "request": "launch",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "program": "./node_modules/.bin/jest",
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "NODE_OPTIONS": "--experimental-vm-modules jest"
+      },
+      "args": [
+        "jest",
+        "--runInBand",
+        "--watchAll=false",
+        "--testNamePattern",
+        "${jest.testNamePattern}",
+        "--runTestsByPath",
+        "${jest.testFile}"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation

Vscode config file to easily launch a single test with the debugger attached.

## Change Summary


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

## Additional Context

Make it easier to launch a debugger and attach a test in vscode. I don't know if we're checking in configs, but I saw a `.vscode` directory, so I thought it might be useful. Please close this if we're not supposed to check in configs into the repo. 