### PR TITLE
test: Increase test timeouts

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,7 @@ import type { JestConfigWithTsJest } from 'ts-jest';
 const jestConfig: JestConfigWithTsJest = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
+  testTimeout: 30000,
   moduleNameMapper: {
     '^~/(.*)$': '<rootDir>/src/$1',
     '^(.+)_generated.js$': '$1_generated.ts', // Support flatc generated files

--- a/src/network/p2p/node.test.ts
+++ b/src/network/p2p/node.test.ts
@@ -7,7 +7,7 @@ import { sleep } from '~/utils/crypto';
 const NUM_NODES = 10;
 
 const TEST_TIMEOUT_LONG = 60 * 1000;
-const TEST_TIMEOUT_SHORT = 10 * 1000;
+const TEST_TIMEOUT_SHORT = 30 * 1000;
 
 let nodes: Node[];
 // map peerId -> topics -> Messages per topic

--- a/src/network/rpc/rpc.test.ts
+++ b/src/network/rpc/rpc.test.ts
@@ -54,7 +54,7 @@ let addDelegateSigner: SignerAdd;
 let server: RPCServer;
 let client: RPCClient;
 
-const TEST_TIMEOUT_SHORT = 10_000;
+const TEST_TIMEOUT_SHORT = 30_000;
 
 class mockRPCHandler implements RPCHandler {
   getUsers(): Promise<Set<number>> {

--- a/src/storage/engine/engine.mock.test.ts
+++ b/src/storage/engine/engine.mock.test.ts
@@ -6,7 +6,7 @@ import { mockEvents, MockFCEvent, mockFid, populateEngine } from '~/storage/engi
 const testDb = jestRocksDB('engine.mock.test');
 const engine = new Engine(testDb);
 
-const TEST_TIMEOUT_SHORT = 10 * 1000; // 10 sec timeout
+const TEST_TIMEOUT_SHORT = 30 * 1000; // 30 sec timeout
 const TEST_TIMEOUT_LONG = 2 * 60 * 1000; // 2 min timeout
 
 beforeEach(async () => {

--- a/src/test/e2e/hub.test.ts
+++ b/src/test/e2e/hub.test.ts
@@ -10,7 +10,7 @@ import { Message } from '~/types';
 import { jest } from '@jest/globals';
 import { HubError } from '~/utils/hubErrors';
 
-const TEST_TIMEOUT_SHORT = 10 * 1000;
+const TEST_TIMEOUT_SHORT = 30 * 1000;
 const TEST_TIMEOUT_LONG = 2 * 60 * 1000;
 const opts: HubOptions = { localIpAddrsOnly: true };
 


### PR DESCRIPTION
## Motivation
Increase test timeouts to reduce flakiness

## Change Summary

Set the default timeout to 30s and the timeout for the 4 individual test cases that always fail to also 30s.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

## Additional Context

Issue: https://github.com/farcasterxyz/hub/issues/269
