### PR TITLE
fix: Delete UserDataAdd for fname when it is transfered

### DIFF
--- a/src/storage/flatbuffers/idRegistryEventModel.ts
+++ b/src/storage/flatbuffers/idRegistryEventModel.ts
@@ -23,7 +23,7 @@ export default class IdRegistryEventModel {
   }
 
   /**
-   * Generates a unique key used to store the current custody address of a user -> fid
+   * Generates a unique key used to store the current custody address of a user -> IdRegistryEvent mapping
    *
    * @param address the custody address of the user
    *

--- a/src/storage/flatbuffers/nameRegistryEventModel.test.ts
+++ b/src/storage/flatbuffers/nameRegistryEventModel.test.ts
@@ -1,15 +1,26 @@
+import { arrayify } from 'ethers/lib/utils';
 import Factories from '~/test/factories/flatbuffer';
+import { generateEthereumSigner } from '~/utils/crypto';
 import { jestBinaryRocksDB } from '../db/jestUtils';
+import StoreEventHandler from '../sets/flatbuffers/storeEventHandler';
 import NameRegistryEventModel from './nameRegistryEventModel';
 
 const db = jestBinaryRocksDB('flatbuffers.nameRegistryEventModel.test');
+const eventHandler = new StoreEventHandler();
+
 const fname = Factories.Fname.build();
 
 let model: NameRegistryEventModel;
+let custody1Address: Uint8Array;
+let custody2Address: Uint8Array;
 
 beforeAll(async () => {
+  const custody1 = await generateEthereumSigner();
+  custody1Address = arrayify(custody1.signerKey);
+
   const nameRegistryEvent = await Factories.NameRegistryEvent.create({
     fname: Array.from(fname),
+    to: Array.from(custody1Address),
   });
   model = new NameRegistryEventModel(nameRegistryEvent);
 });
@@ -24,5 +35,25 @@ describe('static methods', () => {
     test('fails when event not found', async () => {
       await expect(NameRegistryEventModel.get(db, fname)).rejects.toThrow();
     });
+  });
+});
+
+describe('transfer', () => {
+  test('succeeds when fname is transfered', async () => {
+    await model.put(db);
+
+    const custody2 = await generateEthereumSigner();
+    custody2Address = arrayify(custody2.signerKey);
+
+    // Transfer evemt
+    const transferNameRegistryEvent = await Factories.NameRegistryEvent.create({
+      fname: Array.from(fname),
+      from: Array.from(custody1Address),
+      to: Array.from(custody2Address),
+    });
+    const model2 = new NameRegistryEventModel(transferNameRegistryEvent);
+    await model2.put(db);
+
+    await expect(NameRegistryEventModel.get(db, fname)).resolves.toEqual(model2);
   });
 });

--- a/src/storage/sets/flatbuffers/userDataStore.test.ts
+++ b/src/storage/sets/flatbuffers/userDataStore.test.ts
@@ -3,10 +3,10 @@ import { jestBinaryRocksDB } from '~/storage/db/jestUtils';
 import MessageModel from '~/storage/flatbuffers/messageModel';
 import { UserDataAddModel, UserPostfix } from '~/storage/flatbuffers/types';
 import { UserDataType } from '~/utils/generated/message_generated';
-import UserDataStore from '~/storage/sets/flatbuffers/userDataStore';
 import { HubError } from '~/utils/hubErrors';
 import { bytesIncrement } from '~/storage/flatbuffers/utils';
 import StoreEventHandler from '~/storage/sets/flatbuffers/storeEventHandler';
+import UserDataStore from './userDataStore';
 
 const db = jestBinaryRocksDB('flatbuffers.userDataSet.test');
 const eventHandler = new StoreEventHandler();

--- a/src/storage/sets/flatbuffers/userDataStore.test.ts
+++ b/src/storage/sets/flatbuffers/userDataStore.test.ts
@@ -269,10 +269,15 @@ describe('userfname', () => {
     await engine.mergeNameRegistryEvent(nameRegistryModelEvent);
     await engine.mergeMessage(signerAdd);
 
+    // First, add the fname to the first address
+    await expect(set.merge(addFname)).resolves.toEqual(undefined);
+    await assertUserFnameAddWins(addFname);
+
+    // Now, generate a new address
     const custody2 = await generateEthereumSigner();
     const custody2Address = arrayify(custody2.signerKey);
 
-    // transfer the name to custody2
+    // transfer the name to custody2address
     const nameRegistryEvent2 = await Factories.NameRegistryEvent.create({
       fname: Array.from(fname),
       from: Array.from(custody1Address),
@@ -283,10 +288,26 @@ describe('userfname', () => {
     const model = new NameRegistryEventModel(nameRegistryEvent2);
     await engine.mergeNameRegistryEvent(model);
 
-    const result = await engine.mergeMessage(addFname);
+    // Now, try to add the fname to the second address
+    const addData = await Factories.UserDataAddData.create({
+      ...addFname.data.unpack(),
+      timestamp: addFname.timestamp() + 1,
+    });
+    const addMessage = await Factories.Message.create(
+      {
+        data: Array.from(addData.bb?.bytes() ?? []),
+      },
+      { transient: { signer } }
+    );
+    const addFname2 = new MessageModel(addMessage) as UserDataAddModel;
+
+    const result = await engine.mergeMessage(addFname2);
     expect(result._unsafeUnwrapErr()).toEqual(
       new HubError('bad_request.validation_failure', 'fname custody address does not match fid custody address')
     );
+
+    // Also make sure the UserDataAdd message got removed
+    await expect(set.getUserDataAdd(fid, UserDataType.Fname)).rejects.toThrow(HubError);
   });
 
   describe('with a conflicting UserNameAdd with different timestamps', () => {

--- a/src/storage/sets/flatbuffers/userDataStore.test.ts
+++ b/src/storage/sets/flatbuffers/userDataStore.test.ts
@@ -15,6 +15,7 @@ import SignerStore from './signerStore';
 import UserDataStore from '~/storage/sets/flatbuffers/userDataStore';
 import Engine from '~/storage/engine/flatbuffers';
 import { Wallet } from 'ethers';
+import { NameRegistryEventType } from '~/utils/generated/nameregistry_generated';
 
 const db = jestBinaryRocksDB('flatbuffers.userDataSet.test');
 
@@ -274,7 +275,10 @@ describe('userfname', () => {
     // transfer the name to custody2
     const nameRegistryEvent2 = await Factories.NameRegistryEvent.create({
       fname: Array.from(fname),
+      from: Array.from(custody1Address),
       to: Array.from(custody2Address),
+      type: NameRegistryEventType.NameRegistryTransfer,
+      blockNumber: nameRegistryModelEvent.blockNumber() + 1,
     });
     const model = new NameRegistryEventModel(nameRegistryEvent2);
     await engine.mergeNameRegistryEvent(model);

--- a/src/storage/sets/flatbuffers/userDataStore.ts
+++ b/src/storage/sets/flatbuffers/userDataStore.ts
@@ -127,8 +127,6 @@ class UserDataStore {
 
     await this._db.commit(txn);
 
-    const fnameCustodyAddress = await NameRegistryEventModel.get(this._db, event.fname()).then((event) => event?.to());
-
     // Emit store event
     this._eventHandler.emit('mergeNameRegistryEvent', event);
 


### PR DESCRIPTION
## Motivation

When fname's are transfered, the corresponding `UserDataAdd` message from the previous owner needs to be revoked

## Change Summary

- Use the new `IdRegistryEventModel.getByCustodyAddress` method to look up events by custody address to get the fid
- Remove the corresponding UserDataAdd message from the old user

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

## Additional Context

