### PR TITLE
feat: prune verification, signer, and user data stores

### DIFF
--- a/src/storage/flatbuffers/idRegistryEventModel.ts
+++ b/src/storage/flatbuffers/idRegistryEventModel.ts
@@ -1,8 +1,7 @@
 import { ByteBuffer } from 'flatbuffers';
 import RocksDB, { Transaction } from '~/storage/db/binaryrocksdb';
-import { RootPrefix, UserPostfix } from '~/storage/flatbuffers/types';
+import { RootPrefix } from '~/storage/flatbuffers/types';
 import { IdRegistryEvent, IdRegistryEventType } from '~/utils/generated/id_registry_event_generated';
-import SignerStore from '../sets/flatbuffers/signerStore';
 
 /** IdRegistryEventModel provides helpers to read and write Flatbuffers ContractEvents from RocksDB */
 export default class IdRegistryEventModel {

--- a/src/storage/sets/flatbuffers/userDataStore.test.ts
+++ b/src/storage/sets/flatbuffers/userDataStore.test.ts
@@ -5,8 +5,9 @@ import { UserDataAddModel, UserPostfix } from '~/storage/flatbuffers/types';
 import { UserDataType } from '~/utils/generated/message_generated';
 import UserDataSet from '~/storage/sets/flatbuffers/userDataStore';
 import { HubError } from '~/utils/hubErrors';
-import { bytesIncrement } from '~/storage/flatbuffers/utils';
+import { bytesIncrement, getFarcasterTime } from '~/storage/flatbuffers/utils';
 import StoreEventHandler from '~/storage/sets/flatbuffers/storeEventHandler';
+import UserDataStore from '~/storage/sets/flatbuffers/userDataStore';
 
 const db = jestBinaryRocksDB('flatbuffers.userDataSet.test');
 const eventHandler = new StoreEventHandler();
@@ -274,6 +275,78 @@ describe('userfname', () => {
 
         await assertUserFnameAddWins(addFnameLater);
       });
+    });
+  });
+});
+
+describe('pruneMessages', () => {
+  let prunedMessages: MessageModel[];
+  const pruneMessageListener = (message: MessageModel) => {
+    prunedMessages.push(message);
+  };
+
+  beforeAll(() => {
+    eventHandler.on('pruneMessage', pruneMessageListener);
+  });
+
+  beforeEach(() => {
+    prunedMessages = [];
+  });
+
+  afterAll(() => {
+    eventHandler.off('pruneMessage', pruneMessageListener);
+  });
+
+  let add1: UserDataAddModel;
+  let add2: UserDataAddModel;
+  let add3: UserDataAddModel;
+  let add4: UserDataAddModel;
+  let add5: UserDataAddModel;
+
+  const generateAddWithTimestamp = async (
+    fid: Uint8Array,
+    timestamp: number,
+    type: UserDataType
+  ): Promise<UserDataAddModel> => {
+    const addBody = Factories.UserDataBody.build({ type });
+    const addData = await Factories.UserDataAddData.create({ fid: Array.from(fid), timestamp, body: addBody });
+    const addMessage = await Factories.Message.create({ data: Array.from(addData.bb?.bytes() ?? []) });
+    return new MessageModel(addMessage) as UserDataAddModel;
+  };
+
+  beforeAll(async () => {
+    const time = getFarcasterTime() - 10;
+    add1 = await generateAddWithTimestamp(fid, time + 1, UserDataType.Pfp);
+    add2 = await generateAddWithTimestamp(fid, time + 2, UserDataType.Display);
+    add3 = await generateAddWithTimestamp(fid, time + 3, UserDataType.Bio);
+    add4 = await generateAddWithTimestamp(fid, time + 4, UserDataType.Location);
+    add5 = await generateAddWithTimestamp(fid, time + 5, UserDataType.Url);
+  });
+
+  describe('with size limit', () => {
+    const sizePrunedStore = new UserDataStore(db, eventHandler, { pruneSizeLimit: 3 });
+
+    test('no-ops when no messages have been merged', async () => {
+      const result = await sizePrunedStore.pruneMessages(fid);
+      expect(result._unsafeUnwrap()).toEqual(undefined);
+      expect(prunedMessages).toEqual([]);
+    });
+
+    test('prunes earliest add messages', async () => {
+      const messages = [add1, add2, add3, add4, add5];
+      for (const message of messages) {
+        await sizePrunedStore.merge(message);
+      }
+
+      const result = await sizePrunedStore.pruneMessages(fid);
+      expect(result._unsafeUnwrap()).toEqual(undefined);
+
+      expect(prunedMessages).toEqual([add1, add2]);
+
+      for (const message of prunedMessages as UserDataAddModel[]) {
+        const getAdd = () => sizePrunedStore.getUserDataAdd(fid, message.body().type());
+        await expect(getAdd()).rejects.toThrow(HubError);
+      }
     });
   });
 });

--- a/src/storage/sets/flatbuffers/userDataStore.ts
+++ b/src/storage/sets/flatbuffers/userDataStore.ts
@@ -1,7 +1,7 @@
 import RocksDB, { Transaction } from '~/storage/db/binaryrocksdb';
 import MessageModel from '~/storage/flatbuffers/messageModel';
 import { ResultAsync, ok } from 'neverthrow';
-import { UserDataAddModel, UserPostfix } from '~/storage/flatbuffers/types';
+import { StorePruneOptions, UserDataAddModel, UserPostfix } from '~/storage/flatbuffers/types';
 import { isUserDataAdd } from '~/storage/flatbuffers/typeguards';
 import { bytesCompare } from '~/storage/flatbuffers/utils';
 import { MessageType, UserDataType } from '~/utils/generated/message_generated';
@@ -10,6 +10,8 @@ import StoreEventHandler from '~/storage/sets/flatbuffers/storeEventHandler';
 import NameRegistryEventModel from '~/storage/flatbuffers/nameRegistryEventModel';
 import { eventCompare } from '~/utils/contractEvent';
 import { NameRegistryEventType } from '~/utils/generated/nameregistry_generated';
+
+const PRUNE_SIZE_LIMIT_DEFAULT = 100;
 
 /**
  * UserDataStore persists UserData messages in RocksDB using a grow-only CRDT set to guarantee
@@ -33,10 +35,12 @@ import { NameRegistryEventType } from '~/utils/generated/nameregistry_generated'
 class UserDataStore {
   private _db: RocksDB;
   private _eventHandler: StoreEventHandler;
+  private _pruneSizeLimit: number;
 
-  constructor(db: RocksDB, eventHandler: StoreEventHandler) {
+  constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
     this._db = db;
     this._eventHandler = eventHandler;
+    this._pruneSizeLimit = options.pruneSizeLimit ?? PRUNE_SIZE_LIMIT_DEFAULT;
   }
 
   /**
@@ -141,6 +145,61 @@ class UserDataStore {
     // Emit a revokeMessage event for each message
     for (const message of userDataAdds) {
       this._eventHandler.emit('revokeMessage', message);
+    }
+
+    return ok(undefined);
+  }
+
+  async pruneMessages(fid: Uint8Array): HubAsyncResult<void> {
+    // Count number of UserDataAdd messages for this fid
+    // TODO: persist this count to avoid having to retrieve it with each call
+    const prefix = MessageModel.primaryKey(fid, UserPostfix.UserDataMessage);
+    let count = 0;
+    for await (const [,] of this._db.iteratorByPrefix(prefix, { keyAsBuffer: true, values: false })) {
+      count = count + 1;
+    }
+
+    // Calculate the number of messages that need to be pruned, based on the store's size limit
+    let sizeToPrune = count - this._pruneSizeLimit;
+
+    // Keep track of the messages that get pruned so that we can emit pruneMessage events after the transaction settles
+    const messageToPrune: UserDataAddModel[] = [];
+
+    // Create a rocksdb transaction to include all the mutations
+    let pruneTsx = this._db.transaction();
+
+    // Create a rocksdb iterator for all messages with the given prefix
+    const pruneIterator = MessageModel.getPruneIterator(this._db, fid, UserPostfix.UserDataMessage);
+
+    const getNextResult = () => ResultAsync.fromPromise(MessageModel.getNextToPrune(pruneIterator), () => undefined);
+
+    // For each message in order, prune it if the store is over the size limit
+    let nextMessage = await getNextResult();
+    while (nextMessage.isOk() && sizeToPrune > 0) {
+      const message = nextMessage.value;
+
+      // Add a delete operation to the transaction depending on the message type
+      if (isUserDataAdd(message)) {
+        pruneTsx = this.deleteUserDataAddTransaction(pruneTsx, message);
+      } else {
+        throw new HubError('unknown', 'invalid message type');
+      }
+
+      // Store the message in order to emit the pruneMessage event later, decrement the number of messages
+      // yet to prune, and try to get the next message from the iterator
+      messageToPrune.push(message);
+      sizeToPrune = Math.max(0, sizeToPrune - 1);
+      nextMessage = await getNextResult();
+    }
+
+    if (messageToPrune.length > 0) {
+      // Commit the transaction to rocksdb
+      await this._db.commit(pruneTsx);
+
+      // For each of the pruned messages, emit a pruneMessage event
+      for (const message of messageToPrune) {
+        this._eventHandler.emit('pruneMessage', message);
+      }
     }
 
     return ok(undefined);


### PR DESCRIPTION
## Motivation

Add `pruneMessages` method to remaining stores.

## Change Summary

* Add `pruneMessages` to verification store with default size limit of 50 messages
* Add `pruneMessages` to signer store with default size limit of 100 messages
* Add `pruneMessages` to user data store with default size limit of 100 messages

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
