### PR TITLE
bugfix: Edge case where a block would not be synced

### DIFF
--- a/src/hub.ts
+++ b/src/hub.ts
@@ -153,8 +153,13 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
       await this.binaryDb.clear();
     }
 
+    // Start the ETh events listener first
+    await this.ethRegistryProvider.start();
+
+    // And then start the sync engine
     await this.syncEngine.initialize();
 
+    // And the gossip node
     await this.gossipNode.start(this.options.bootstrapAddrs ?? [], {
       peerId: this.options.peerId,
       ipMultiAddr: this.options.ipMultiAddr,

--- a/src/storage/engine/flatbuffers/providers/ethEventsProvider.test.ts
+++ b/src/storage/engine/flatbuffers/providers/ethEventsProvider.test.ts
@@ -81,6 +81,7 @@ describe('process events', () => {
   beforeEach(() => {
     ethEventsProvider = new EthEventsProvider(engine, mockRPCProvider, mockIdRegistry, mockNameRegistry);
     mockRPCProvider.polling = true;
+    ethEventsProvider.start();
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Motivation
Fix a bug in the initial (historical) sync where a block might be missed

## Change Summary
If a block is created just before we start historical sync, the earliest block might get missed. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

## Additional Context

Follow up from #284 
