### PR TITLE
chore: Add Eth Network Provider to the new hub.

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ app
   .command('start')
   .description('Start a Hub')
   .option('-c, --config <filepath>', 'Path to a config file with options', DEFAULT_CONFIG_FILE)
-  .option('-n --network-url <url>', 'ID Registry network URL')
+  .option('-n --network-url <url>', 'ETH Node RPC URL to connect to')
   .option('-f, --fir-address <address>', 'The address of the FIR contract')
   .option('-b, --bootstrap <peer-multiaddrs...>', 'A list of peer multiaddrs to bootstrap libp2p')
   .option('-a, --allowed-peers <peerIds...>', 'An allow-list of peer ids permitted to connect to the hub')

--- a/src/storage/engine/flatbuffers/providers/ethEventsProvider.ts
+++ b/src/storage/engine/flatbuffers/providers/ethEventsProvider.ts
@@ -126,7 +126,10 @@ export class EthEventsProvider {
   private async connectAndSyncHistoricalEvents() {
     const latestBlockResult = await ResultAsync.fromPromise(this._jsonRpcProvider.getBlock('latest'), (err) => err);
     if (latestBlockResult.isErr()) {
-      log.error({ err: latestBlockResult.error }, 'failed to connect to ethereum node');
+      log.error(
+        { err: latestBlockResult.error },
+        'failed to connect to ethereum node. Check your network URL (e.g. --network-url)'
+      );
       return;
     }
 


### PR DESCRIPTION
## Motivation

Add the ETH network connection to the new Hub

## Change Summary

Initialize and start the `ethEventsProvider` in the new hub.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

## Additional Context

Moving this over from the old hub to the new hub.
