### PR TITLE
feat: Add gossip support for flatbuffers Hub

### DIFF
--- a/src/hub.ts
+++ b/src/hub.ts
@@ -24,7 +24,7 @@ import { FarcasterError, ServerError } from '~/utils/errors';
 import { SyncEngine } from '~/network/sync/syncEngine';
 import { logger } from '~/utils/logger';
 import { NodeMetadata } from '~/network/sync/merkleTrie';
-import { addressInfoFromParts, getPublicIp, p2pMultiAddrStr } from '~/utils/p2p';
+import { addressInfoFromParts, getPublicIp, ipFamilyToString, p2pMultiAddrStr } from '~/utils/p2p';
 import { peerIdFromString } from '@libp2p/peer-id';
 import { publicAddressesFirst } from '@libp2p/utils/address-sort';
 import { HubError } from '~/utils/hubErrors';
@@ -357,7 +357,7 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
     const nodeAddress = addr.multiaddr.nodeAddress();
     return new RPCClient({
       address: nodeAddress.address,
-      family: nodeAddress.family == 4 ? 'IPv4' : 'IPv6',
+      family: ipFamilyToString(nodeAddress.family),
       // Use the gossip rpc port instead of the port used by libp2p
       port: peer.rpcAddress.port,
     });

--- a/src/network/p2p/flatbuffers/node.test.ts
+++ b/src/network/p2p/flatbuffers/node.test.ts
@@ -1,0 +1,205 @@
+import { multiaddr } from '@multiformats/multiaddr/';
+import Factories from '~/test/factories/flatbuffer';
+import { Node } from '~/network/p2p/flatbuffers/node';
+import { NETWORK_TOPIC_PRIMARY } from '~/network/p2p/protocol';
+import { sleep } from '~/utils/crypto';
+import { GossipContent, GossipMessage, GossipMessageT } from '~/utils/generated/gossip_generated';
+import MessageModel from '~/storage/flatbuffers/messageModel';
+import { CastAddModel } from '~/storage/flatbuffers/types';
+
+const NUM_NODES = 10;
+
+const TEST_TIMEOUT_LONG = 60 * 1000;
+const TEST_TIMEOUT_SHORT = 10 * 1000;
+
+let nodes: Node[];
+// map peerId -> topics -> Messages per topic
+let messages: Map<string, Map<string, GossipMessage[] | undefined>>;
+
+/** Create a sequence of connections between all the nodes */
+const connectAll = async (nodes: Node[]) => {
+  const connectionResults = await Promise.all(
+    nodes.slice(1).map((n) => {
+      return n.connect(nodes[0] as Node);
+    })
+  );
+  connectionResults.forEach((r) => {
+    if (r) {
+      expect(r.isOk()).toBeTruthy();
+    }
+  });
+
+  // subscribe every node to the test topic
+  nodes.forEach((n) => n.gossip?.subscribe(NETWORK_TOPIC_PRIMARY));
+  // sleep 5 heartbeats to let the gossipsub network form
+  await sleep(5_000);
+};
+
+const trackMessages = () => {
+  nodes.forEach((n) => {
+    {
+      n.addListener('message', (topic, message) => {
+        expect(message.isOk()).toBeTruthy();
+
+        const peerId = n.peerId?.toString() ?? '';
+        let existingTopics = messages.get(peerId);
+        if (!existingTopics) existingTopics = new Map();
+        let existingMessages = existingTopics.get(topic);
+        if (!existingMessages) existingMessages = [];
+
+        existingMessages.push(message._unsafeUnwrap());
+        existingTopics.set(topic, existingMessages);
+        messages.set(peerId, existingTopics);
+      });
+      n.registerDebugListeners();
+    }
+  });
+};
+
+describe('node unit tests', () => {
+  test('fails to bootstrap to invalid addresses', async () => {
+    const node = new Node();
+    const error = (await node.start([multiaddr()]))._unsafeUnwrapErr();
+    expect(error.errCode).toEqual('unavailable');
+    expect(error.message).toContain('could not connect to any bootstrap nodes');
+    await node.stop();
+  });
+
+  test('fails to connect with a node that has not started', async () => {
+    const node = new Node();
+    await node.start([]);
+
+    let result = await node.connectAddress(multiaddr());
+    expect(result.isErr()).toBeTruthy();
+
+    const offlineNode = new Node();
+    result = await node.connect(offlineNode);
+    expect(result.isErr()).toBeTruthy();
+
+    await node.stop();
+  });
+
+  test(
+    'can only dial allowed nodes',
+    async () => {
+      const node1 = new Node();
+      await node1.start([]);
+
+      const node2 = new Node();
+      await node2.start([]);
+
+      // node 3 has node 1 in its allow list, but not node 2
+      const node3 = new Node();
+      if (node1.peerId) {
+        await node3.start([], { allowedPeerIdStrs: [node1.peerId.toString()] });
+      } else {
+        throw Error('Node1 not started, no peerId found');
+      }
+
+      try {
+        let dialResult = await node1.connect(node3);
+        expect(dialResult.isOk()).toBeTruthy();
+
+        dialResult = await node2.connect(node3);
+        expect(dialResult.isErr()).toBeTruthy();
+
+        dialResult = await node3.connect(node2);
+        expect(dialResult.isErr()).toBeTruthy();
+      } finally {
+        await node1.stop();
+        await node2.stop();
+        await node3.stop();
+      }
+    },
+    TEST_TIMEOUT_SHORT
+  );
+
+  test('port and transport addrs in the Ip MultiAddr is not allowed', async () => {
+    const node = new Node();
+    const options = { ipMultiAddr: '/ip4/127.0.0.1/tcp/8080' };
+    const error = (await node.start([], options))._unsafeUnwrapErr();
+
+    expect(error.errCode).toEqual('unavailable');
+    expect(error.message).toMatch('unexpected multiaddr transport/port information');
+    expect(node.isStarted()).toBeFalsy();
+    await node.stop();
+  });
+
+  test('invalid multiaddr format is not allowed', async () => {
+    const node = new Node();
+    // an IPv6 being supplied as an IPv4
+    const options = { ipMultiAddr: '/ip4/2600:1700:6cf0:990:2052:a166:fb35:830a' };
+    expect((await node.start([], options))._unsafeUnwrapErr().errCode).toEqual('unavailable');
+    const error = (await node.start([], options))._unsafeUnwrapErr();
+
+    expect(error.errCode).toEqual('unavailable');
+    expect(error.message).toMatch('invalid multiaddr');
+    expect(node.isStarted()).toBeFalsy();
+    await node.stop();
+  });
+});
+
+describe('gossip network', () => {
+  beforeAll(async () => {
+    nodes = [...Array(NUM_NODES)].map(() => new Node());
+    messages = new Map();
+  });
+
+  beforeEach(async () => {
+    messages.clear();
+    await Promise.all(nodes.map((node) => node.start([])));
+  });
+
+  afterEach(async () => {
+    await Promise.all(nodes.map((node) => node.stop()));
+  }, TEST_TIMEOUT_SHORT);
+
+  test(
+    'constructs a Gossip network and ensures all nodes are connected',
+    async () => {
+      await connectAll(nodes);
+      nodes.forEach((n) => expect(n.gossip?.getPeers().length).toBeGreaterThanOrEqual(1));
+    },
+    TEST_TIMEOUT_SHORT
+  );
+
+  test(
+    'sends a message to a gossip network',
+    async () => {
+      await connectAll(nodes);
+      trackMessages();
+
+      // create a message and send it to a random node.
+      const castAddData = await Factories.CastAddData.create({
+        fid: Array.from(Factories.FID.build()),
+      });
+      const castAdd = new MessageModel(
+        await Factories.Message.create({ data: Array.from(castAddData.bb?.bytes() ?? []) })
+      ) as CastAddModel;
+
+      const message: GossipMessageT = new GossipMessageT(GossipContent.Message, castAdd.message.unpack(), [
+        NETWORK_TOPIC_PRIMARY,
+      ]);
+
+      // publish via some random node
+      const randomNode = nodes[Math.floor(Math.random() * nodes.length)] as Node;
+      expect(randomNode.publish(message)).resolves.toBeUndefined();
+      // sleep 5 heartbeat ticks
+      await sleep(5_000);
+
+      // check that every node has the message
+      nodes.forEach((n) => {
+        // the sender won't have this message
+        if (n.peerId?.toString() === randomNode.peerId?.toString()) return;
+
+        const topics = messages.get(n.peerId?.toString() ?? '');
+        expect(topics).toBeDefined();
+        expect(topics?.has(NETWORK_TOPIC_PRIMARY)).toBeTruthy();
+        const topicMessages = topics?.get(NETWORK_TOPIC_PRIMARY) ?? [];
+        expect(topicMessages.length).toBe(1);
+        expect(topicMessages[0]?.unpack()).toEqual(message);
+      });
+    },
+    TEST_TIMEOUT_LONG
+  );
+});

--- a/src/network/p2p/flatbuffers/node.ts
+++ b/src/network/p2p/flatbuffers/node.ts
@@ -1,0 +1,318 @@
+import { GossipSub } from '@chainsafe/libp2p-gossipsub';
+import { Noise } from '@chainsafe/libp2p-noise';
+import { Connection } from '@libp2p/interface-connection';
+import { PeerId } from '@libp2p/interface-peer-id';
+import { Mplex } from '@libp2p/mplex';
+import { TCP } from '@libp2p/tcp';
+import { Multiaddr } from '@multiformats/multiaddr';
+import { createLibp2p, Libp2p } from 'libp2p';
+import { err, ok, Result, ResultAsync } from 'neverthrow';
+import { TypedEmitter } from 'tiny-typed-emitter';
+import { HubAsyncResult, HubError, HubResult } from '~/utils/hubErrors';
+import { GOSSIP_TOPICS } from '~/network/p2p/protocol';
+import { ConnectionFilter } from '../connectionFilter';
+import { logger } from '~/utils/logger';
+import { checkNodeAddrs } from '~/utils/p2p';
+import { PubSubPeerDiscovery } from '@libp2p/pubsub-peer-discovery';
+import { GossipContent, GossipMessage, GossipMessageT } from '~/utils/generated/gossip_generated';
+import { Builder, ByteBuffer } from 'flatbuffers';
+
+const MultiaddrLocalHost = '/ip4/127.0.0.1';
+
+const log = logger.child({ component: 'Node' });
+
+interface NodeEvents {
+  /**
+   * Triggered when a new message is received. Provides the topic the message was received on
+   * as well as the result of decoding the message
+   */
+  message: (topic: string, message: HubResult<GossipMessage>) => void;
+  /** Triggered when a peer is connected. Provides the Libp2p Connection object. */
+  peerConnect: (connection: Connection) => void;
+  /** Triggered when a peer is disconnected. Provides the Libp2p Connecion object. */
+  peerDisconnect: (connection: Connection) => void;
+}
+
+/** Node create options */
+interface NodeOptions {
+  /** PeerId to use as the Node's Identity. Generates a new ephemeral PeerId if not specified*/
+  peerId?: PeerId | undefined;
+  /** IP address in MultiAddr format to bind to */
+  ipMultiAddr?: string | undefined;
+  /** Port to listen for gossip. Picks a port at random if not specified. This is combined with the IPMultiAddr */
+  gossipPort?: number | undefined;
+  /** A list of addresses to peer with. PeersIds outside of this list will not be able to connect to this node */
+  allowedPeerIdStrs?: string[] | undefined;
+}
+
+/**
+ * A representation of a libp2p network node.
+ *
+ * Nodes participate in the p2p GossipSub network we create using libp2p.
+ */
+export class Node extends TypedEmitter<NodeEvents> {
+  private _node?: Libp2p;
+
+  /**
+   * Returns the PublicKey of the node
+   */
+  get peerId() {
+    return this._node?.peerId;
+  }
+
+  /**
+   * Returns all known addresses of the node
+   *
+   * This contains local addresses as well and will need to be
+   * checked for reachability prior to establishing connections
+   */
+  get multiaddrs() {
+    return this._node?.getMultiaddrs();
+  }
+
+  get addressBook() {
+    return this._node?.peerStore.addressBook;
+  }
+
+  async getPeerInfo(peerId: PeerId) {
+    const existingConnections = this._node?.connectionManager.getConnections(peerId);
+    for (const conn of existingConnections ?? []) {
+      const knownAddrs = await this._node?.peerStore.addressBook.get(peerId);
+      if (knownAddrs && !knownAddrs.find((addr) => addr.multiaddr.equals(conn.remoteAddr))) {
+        // updates the peer store
+        await this._node?.peerStore.addressBook.add(peerId, [conn.remoteAddr]);
+      }
+    }
+    return await this._node?.peerStore.get(peerId);
+  }
+
+  /**
+   * Returns a the GossipSub implementation used by the Node
+   */
+  get gossip() {
+    const pubsub = this._node?.pubsub;
+    return pubsub ? (pubsub as GossipSub) : undefined;
+  }
+
+  /**
+   * Creates and Starts the underlying libp2p node. Nodes must be started prior to any network configuration or communication.
+   *
+   * @param bootstrapAddrs  A list of addresses to bootstrap from. Attempts to connect with each peer in the list
+   * @param startOptions    Options to configure the node's behavior
+   */
+  async start(bootstrapAddrs: Multiaddr[], startOptions?: NodeOptions): Promise<HubResult<void>> {
+    const createResult = await this.createNode(startOptions ?? {});
+    if (createResult.isErr()) return err(createResult.error);
+
+    this._node = createResult.value;
+    this.registerListeners();
+
+    await this._node.start();
+    log.info(
+      { identity: this.identity, addresses: this._node.getMultiaddrs().map((a) => a.toString()) },
+      'Starting libp2p'
+    );
+
+    return this.bootstrap(bootstrapAddrs);
+  }
+
+  isStarted() {
+    return this._node?.isStarted();
+  }
+
+  /**
+   * Stops the node's participation on the libp2p network and tears down pubsub
+   */
+  async stop() {
+    await this._node?.stop();
+    log.info({ identity: this.identity }, 'Stopped libp2p...');
+  }
+
+  get identity() {
+    return this.peerId?.toString();
+  }
+
+  /**
+   * Publishes a message to the GossipSub network
+   * @message The GossipMessage to publish to the network
+   */
+  async publish(message: GossipMessageT) {
+    const topics = message.topics;
+    log.debug({ identity: this.identity }, `Publishing message to topics: ${topics}`);
+    const encodedMessage = this.encodeMessage(message);
+    encodedMessage.match(
+      async (msg) => {
+        const results = await Promise.all(topics.map((topic) => this.gossip?.publish(topic, msg)));
+        log.debug({ identity: this.identity, results }, 'Published to gossip peers');
+      },
+      async (err) => {
+        log.error(err, 'Failed to publish message.');
+      }
+    );
+  }
+
+  /**
+   * Connect with a peer Node
+   *
+   * @param node The peer Node to attempt a connection with
+   */
+  async connect(node: Node): Promise<HubResult<void>> {
+    const multiaddrs = node.multiaddrs;
+    if (multiaddrs) {
+      // how to select an addr here?
+      for (const addr of multiaddrs) {
+        try {
+          const result = await this.connectAddress(addr);
+          // bail after the first successful connection
+          if (result.isOk()) return ok(undefined);
+        } catch (error: any) {
+          log.error(error, 'Failed to connect to addr');
+          continue;
+        }
+      }
+    } else {
+      return err(new HubError('unavailable', { message: 'no peer id' }));
+    }
+    return err(new HubError('unavailable', { message: 'cannot connect to any peer' }));
+  }
+
+  /**
+   * Connect with a peer's NodeAddress
+   *
+   * @param address The NodeAddress to attempt a connection with
+   */
+  async connectAddress(address: Multiaddr): Promise<HubResult<void>> {
+    log.debug({ identity: this.identity, address }, `Attempting to connect to address ${address}`);
+    try {
+      const result = await this._node?.dial(address);
+      if (result) {
+        log.info({ identity: this.identity, address }, `Connected to peer at address: ${address}`);
+        return ok(undefined);
+      }
+    } catch (error: any) {
+      log.error(error, `Failed to connect to peer at address: ${address}`);
+      return err(new HubError('unavailable', error));
+    }
+    return err(new HubError('unavailable', { message: `cannot connect to peer: ${address}` }));
+  }
+
+  registerListeners() {
+    this._node?.connectionManager.addEventListener('peer:connect', (event) => {
+      this.emit('peerConnect', event.detail);
+    });
+    this._node?.connectionManager.addEventListener('peer:disconnect', (event) => {
+      this.emit('peerDisconnect', event.detail);
+    });
+    this.gossip?.addEventListener('message', (event) => {
+      // ignore messages that aren't in our list of topics (ignores gossipsub peer discovery messages)
+      if (GOSSIP_TOPICS.includes(event.detail.topic)) {
+        this.emit('message', event.detail.topic, this.decodeMessage(event.detail.data));
+      }
+    });
+  }
+
+  registerDebugListeners() {
+    // Debug
+    this._node?.addEventListener('peer:discovery', (event) => {
+      log.info({ identity: this.identity }, `Found peer: ${event.detail.multiaddrs}`);
+    });
+    this._node?.connectionManager.addEventListener('peer:connect', (event) => {
+      log.info({ identity: this.identity }, `Connection established to: ${event.detail.remotePeer.toString()}`);
+    });
+    this._node?.connectionManager.addEventListener('peer:disconnect', (event) => {
+      log.info({ identity: this.identity }, `Disconnected from: ${event.detail.remotePeer.toString()}`);
+    });
+    this.gossip?.addEventListener('message', (event) => {
+      log.info({ identity: this.identity }, `Received message for topic: ${event.detail.topic}`);
+    });
+    this.gossip?.addEventListener('subscription-change', (event) => {
+      log.info(
+        { identity: this.identity },
+        `Subscription change: ${event.detail.subscriptions.map((value) => {
+          value.topic;
+        })}`
+      );
+    });
+  }
+
+  /* -------------------------------------------------------------------------- */
+  /*                               Private Methods                              */
+  /* -------------------------------------------------------------------------- */
+
+  //TODO: Needs better typesafety
+  private encodeMessage(message: GossipMessageT): HubResult<Uint8Array> {
+    if (message.contentType === GossipContent.NONE) {
+      return err(new HubError('bad_request.invalid_param', 'Failed to encode message...'));
+    }
+    const builder = new Builder(1);
+    builder.finish(message.pack(builder));
+    return ok(builder.asUint8Array());
+  }
+
+  //TODO: Needs better typesafety
+  private decodeMessage(message: Uint8Array): HubResult<GossipMessage> {
+    const bb = new ByteBuffer(message);
+    const decodedMessage = GossipMessage.getRootAsGossipMessage(bb);
+    if (decodedMessage.contentType() === GossipContent.NONE) {
+      return err(new HubError('bad_request.invalid_param', 'Failed to decode message...'));
+    }
+    return ok(decodedMessage);
+  }
+
+  /* Attempts to dial all the addresses in the bootstrap list */
+  private async bootstrap(bootstrapAddrs: Multiaddr[]): Promise<HubResult<void>> {
+    if (bootstrapAddrs.length == 0) return ok(undefined);
+    const results = await Promise.all(bootstrapAddrs.map((addr) => this.connectAddress(addr)));
+
+    const finalResults = Result.combineWithAllErrors(results) as Result<void[], HubError[]>;
+    if (finalResults.isErr() && finalResults.error.length == bootstrapAddrs.length) {
+      // only fail if all connections failed
+      return err(new HubError('unavailable', 'could not connect to any bootstrap nodes'));
+    }
+
+    return ok(undefined);
+  }
+
+  /**
+   * Creates a Libp2p node with GossipSub
+   */
+  private async createNode(options: NodeOptions): Promise<HubResult<Libp2p>> {
+    const listenIPMultiAddr = options.ipMultiAddr ?? MultiaddrLocalHost;
+    const listenPort = options.gossipPort ?? 0;
+    const listenMultiAddrStr = `${listenIPMultiAddr}/tcp/${listenPort}`;
+
+    const checkResult = checkNodeAddrs(listenIPMultiAddr, listenMultiAddrStr);
+    if (checkResult.isErr()) return err(new HubError('unavailable', checkResult.error));
+
+    const gossip = new GossipSub({
+      emitSelf: false,
+      allowPublishToZeroPeers: true,
+      globalSignaturePolicy: 'StrictSign',
+    });
+
+    if (options.allowedPeerIdStrs) {
+      log.info(
+        { identity: this.identity, function: 'createNode', allowedPeerIds: options.allowedPeerIdStrs },
+        `!!! PEER-ID RESTRICTIONS ENABLED !!!`
+      );
+    }
+    const connectionGater = new ConnectionFilter(options.allowedPeerIdStrs);
+
+    return ResultAsync.fromPromise(
+      createLibp2p({
+        // setting these optional fields to `undefined` throws an error, only set them if they're defined
+        ...(options.peerId && { peerId: options.peerId }),
+        connectionGater,
+        addresses: {
+          listen: [listenMultiAddrStr],
+        },
+        transports: [new TCP()],
+        streamMuxers: [new Mplex()],
+        connectionEncryption: [new Noise()],
+        pubsub: gossip,
+        peerDiscovery: [new PubSubPeerDiscovery()],
+      }),
+      (e) => new HubError('unavailable', { message: 'failed to create libp2p node', cause: e as Error })
+    );
+  }
+}

--- a/src/network/rpc/flatbuffers/castService.test.ts
+++ b/src/network/rpc/flatbuffers/castService.test.ts
@@ -11,6 +11,7 @@ import IdRegistryEventModel from '~/storage/flatbuffers/idRegistryEventModel';
 import { KeyPair } from '~/types';
 import { CastId, UserId } from '~/utils/generated/message_generated';
 import { HubError } from '~/utils/hubErrors';
+import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestBinaryRocksDB('flatbuffers.rpc.castService.test');
 const engine = new Engine(db);
@@ -21,7 +22,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(engine);
   const port = await server.start();
-  client = new Client(port);
+  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });
 
 afterAll(async () => {

--- a/src/network/rpc/flatbuffers/eventService.test.ts
+++ b/src/network/rpc/flatbuffers/eventService.test.ts
@@ -11,6 +11,7 @@ import IdRegistryEventModel from '~/storage/flatbuffers/idRegistryEventModel';
 import { KeyPair } from '~/types';
 import { EventResponse, EventType } from '~/utils/generated/rpc_generated';
 import { ClientReadableStream } from '@grpc/grpc-js';
+import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestBinaryRocksDB('flatbuffers.rpc.eventService.test');
 const engine = new Engine(db);
@@ -21,7 +22,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(engine);
   const port = await server.start();
-  client = new Client(port);
+  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });
 
 afterAll(async () => {

--- a/src/network/rpc/flatbuffers/followService.test.ts
+++ b/src/network/rpc/flatbuffers/followService.test.ts
@@ -11,6 +11,7 @@ import IdRegistryEventModel from '~/storage/flatbuffers/idRegistryEventModel';
 import { KeyPair } from '~/types';
 import { UserId } from '~/utils/generated/message_generated';
 import { HubError } from '~/utils/hubErrors';
+import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestBinaryRocksDB('flatbuffers.rpc.followService.test');
 const engine = new Engine(db);
@@ -21,7 +22,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(engine);
   const port = await server.start();
-  client = new Client(port);
+  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });
 
 afterAll(async () => {

--- a/src/network/rpc/flatbuffers/reactionService.test.ts
+++ b/src/network/rpc/flatbuffers/reactionService.test.ts
@@ -11,6 +11,7 @@ import IdRegistryEventModel from '~/storage/flatbuffers/idRegistryEventModel';
 import { KeyPair } from '~/types';
 import { CastId, ReactionType } from '~/utils/generated/message_generated';
 import { HubError } from '~/utils/hubErrors';
+import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestBinaryRocksDB('flatbuffers.rpc.reactionService.test');
 const engine = new Engine(db);
@@ -21,7 +22,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(engine);
   const port = await server.start();
-  client = new Client(port);
+  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });
 
 afterAll(async () => {

--- a/src/network/rpc/flatbuffers/server.ts
+++ b/src/network/rpc/flatbuffers/server.ts
@@ -88,8 +88,8 @@ export const defaultMethod = {
 };
 
 class Server {
-  server: grpc.Server;
-  port: number;
+  private server: grpc.Server;
+  private port: number;
 
   constructor(engine: Engine, rpcHandler?: RPCHandler) {
     this.port = 0;

--- a/src/network/rpc/flatbuffers/signerService.test.ts
+++ b/src/network/rpc/flatbuffers/signerService.test.ts
@@ -10,6 +10,7 @@ import { generateEd25519KeyPair } from '~/utils/crypto';
 import IdRegistryEventModel from '~/storage/flatbuffers/idRegistryEventModel';
 import { KeyPair } from '~/types';
 import { HubError } from '~/utils/hubErrors';
+import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestBinaryRocksDB('flatbuffers.rpc.signerService.test');
 const engine = new Engine(db);
@@ -20,7 +21,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(engine);
   const port = await server.start();
-  client = new Client(port);
+  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });
 
 afterAll(async () => {

--- a/src/network/rpc/flatbuffers/submitService.test.ts
+++ b/src/network/rpc/flatbuffers/submitService.test.ts
@@ -13,6 +13,7 @@ import { HubError } from '~/utils/hubErrors';
 import NameRegistryEventModel from '~/storage/flatbuffers/nameRegistryEventModel';
 import { NameRegistryEventType } from '~/utils/generated/name_registry_event_generated';
 import { IdRegistryEventType } from '~/utils/generated/id_registry_event_generated';
+import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestBinaryRocksDB('flatbuffers.rpc.submitService.test');
 const engine = new Engine(db);
@@ -23,7 +24,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(engine);
   const port = await server.start();
-  client = new Client(port);
+  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });
 
 afterAll(async () => {

--- a/src/network/rpc/flatbuffers/syncService.test.ts
+++ b/src/network/rpc/flatbuffers/syncService.test.ts
@@ -22,6 +22,7 @@ import { generateEd25519KeyPair } from '~/utils/crypto';
 import IdRegistryEventModel from '~/storage/flatbuffers/idRegistryEventModel';
 import { KeyPair } from '~/types';
 import { HubResult } from '~/utils/hubErrors';
+import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestBinaryRocksDB('flatbuffers.rpc.syncService.test');
 const engine = new Engine(db);
@@ -32,7 +33,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(engine);
   const port = await server.start();
-  client = new Client(port);
+  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });
 
 afterAll(async () => {

--- a/src/network/rpc/flatbuffers/userDataService.test.ts
+++ b/src/network/rpc/flatbuffers/userDataService.test.ts
@@ -13,6 +13,7 @@ import { UserDataType } from '~/utils/generated/message_generated';
 import { HubError } from '~/utils/hubErrors';
 import NameRegistryEventModel from '~/storage/flatbuffers/nameRegistryEventModel';
 import { ok } from 'neverthrow';
+import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestBinaryRocksDB('flatbuffers.rpc.userDataService.test');
 const engine = new Engine(db);
@@ -23,7 +24,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(engine);
   const port = await server.start();
-  client = new Client(port);
+  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });
 
 afterAll(async () => {

--- a/src/network/rpc/flatbuffers/verificationService.test.ts
+++ b/src/network/rpc/flatbuffers/verificationService.test.ts
@@ -10,6 +10,7 @@ import { generateEd25519KeyPair } from '~/utils/crypto';
 import IdRegistryEventModel from '~/storage/flatbuffers/idRegistryEventModel';
 import { KeyPair } from '~/types';
 import { HubError } from '~/utils/hubErrors';
+import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestBinaryRocksDB('flatbuffers.rpc.verificationService.test');
 const engine = new Engine(db);
@@ -20,7 +21,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(engine);
   const port = await server.start();
-  client = new Client(port);
+  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });
 
 afterAll(async () => {

--- a/src/test/factories/flatbuffer.test.ts
+++ b/src/test/factories/flatbuffer.test.ts
@@ -28,6 +28,15 @@ describe('FidFactory', () => {
     const fid = Factories.FID.build();
     expect(fid.byteLength).toBeLessThan(32);
   });
+
+  test('accepts number input', async () => {
+    const fid = Factories.FID.build({}, { transient: { fid: 24 } });
+    expect(fid.byteLength).toBeLessThan(32);
+
+    const buffer = Buffer.from(fid);
+    const result = buffer.readUIntLE(0, fid.length);
+    expect(result).toBe(24);
+  });
 });
 
 describe('TsHashFactory', () => {

--- a/src/test/factories/flatbuffer.ts
+++ b/src/test/factories/flatbuffer.ts
@@ -73,9 +73,9 @@ const BytesFactory = Factory.define<Uint8Array, { length?: number }>(({ transien
   return bytes;
 });
 
-const FIDFactory = Factory.define<Uint8Array>(() => {
+const FIDFactory = Factory.define<Uint8Array, { fid: number }>(({ transientParams }) => {
   const builder = new Builder(4);
-  builder.addInt32(faker.datatype.number({ max: 2 ** 32 - 1 }));
+  builder.addInt32(transientParams.fid ?? faker.datatype.number({ max: 2 ** 32 - 1 }));
   return builder.asUint8Array();
 });
 


### PR DESCRIPTION
Note - No tests for the new gossip implementation yet. Will add those in a follow-up
## Change Summary

- Added gossip support for Hub 
- Updated RPC Client to bind to any address
- Added number support to fid factory

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] Changes to the protocol specification have been merged
