### PR TITLE
perf: replace all calls to Wallet.createRandom() to speed up tests

### DIFF
--- a/src/network/rpc/flatbuffers/castService.test.ts
+++ b/src/network/rpc/flatbuffers/castService.test.ts
@@ -30,7 +30,7 @@ afterAll(async () => {
 });
 
 const fid = Factories.FID.build();
-const wallet = Wallet.createRandom();
+const wallet = new Wallet(utils.randomBytes(32));
 let custodyEvent: IdRegistryEventModel;
 let signer: KeyPair;
 let signerAdd: SignerAddModel;

--- a/src/network/rpc/flatbuffers/eventService.test.ts
+++ b/src/network/rpc/flatbuffers/eventService.test.ts
@@ -30,7 +30,7 @@ afterAll(async () => {
 });
 
 const fid = Factories.FID.build();
-const wallet = Wallet.createRandom();
+const wallet = new Wallet(utils.randomBytes(32));
 let custodyEvent: IdRegistryEventModel;
 let signer: KeyPair;
 let signerAdd: SignerAddModel;

--- a/src/network/rpc/flatbuffers/followService.test.ts
+++ b/src/network/rpc/flatbuffers/followService.test.ts
@@ -30,7 +30,7 @@ afterAll(async () => {
 });
 
 const fid = Factories.FID.build();
-const wallet = Wallet.createRandom();
+const wallet = new Wallet(utils.randomBytes(32));
 let custodyEvent: IdRegistryEventModel;
 let signer: KeyPair;
 let signerAdd: SignerAddModel;

--- a/src/network/rpc/flatbuffers/reactionService.test.ts
+++ b/src/network/rpc/flatbuffers/reactionService.test.ts
@@ -30,7 +30,7 @@ afterAll(async () => {
 });
 
 const fid = Factories.FID.build();
-const wallet = Wallet.createRandom();
+const wallet = new Wallet(utils.randomBytes(32));
 let custodyEvent: IdRegistryEventModel;
 let signer: KeyPair;
 let signerAdd: SignerAddModel;

--- a/src/network/rpc/flatbuffers/signerService.test.ts
+++ b/src/network/rpc/flatbuffers/signerService.test.ts
@@ -29,7 +29,7 @@ afterAll(async () => {
 });
 
 const fid = Factories.FID.build();
-const wallet = Wallet.createRandom();
+const wallet = new Wallet(utils.randomBytes(32));
 let custodyEvent: IdRegistryEventModel;
 let signer: KeyPair;
 let signerAdd: SignerAddModel;

--- a/src/network/rpc/flatbuffers/submitService.test.ts
+++ b/src/network/rpc/flatbuffers/submitService.test.ts
@@ -32,7 +32,7 @@ afterAll(async () => {
 });
 
 const fid = Factories.FID.build();
-const wallet = Wallet.createRandom();
+const wallet = new Wallet(utils.randomBytes(32));
 let custodyEvent: IdRegistryEventModel;
 let signer: KeyPair;
 let signerAdd: SignerAddModel;

--- a/src/network/rpc/flatbuffers/syncService.test.ts
+++ b/src/network/rpc/flatbuffers/syncService.test.ts
@@ -41,7 +41,7 @@ afterAll(async () => {
 });
 
 const fid = Factories.FID.build();
-const wallet = Wallet.createRandom();
+const wallet = new Wallet(utils.randomBytes(32));
 let custodyEvent: IdRegistryEventModel;
 let signer: KeyPair;
 let signerAdd: SignerAddModel;

--- a/src/network/rpc/flatbuffers/userDataService.test.ts
+++ b/src/network/rpc/flatbuffers/userDataService.test.ts
@@ -33,7 +33,7 @@ afterAll(async () => {
 
 const fid = Factories.FID.build();
 const fname = Factories.Fname.build();
-const wallet = Wallet.createRandom();
+const wallet = new Wallet(utils.randomBytes(32));
 let custodyEvent: IdRegistryEventModel;
 let signer: KeyPair;
 let signerAdd: SignerAddModel;

--- a/src/network/rpc/flatbuffers/verificationService.test.ts
+++ b/src/network/rpc/flatbuffers/verificationService.test.ts
@@ -29,7 +29,7 @@ afterAll(async () => {
 });
 
 const fid = Factories.FID.build();
-const wallet = Wallet.createRandom();
+const wallet = new Wallet(utils.randomBytes(32));
 let custodyEvent: IdRegistryEventModel;
 let signer: KeyPair;
 let signerAdd: SignerAddModel;

--- a/src/storage/engine/engine.verification.test.ts
+++ b/src/storage/engine/engine.verification.test.ts
@@ -14,7 +14,7 @@ import {
   CastRecast,
 } from '~/types';
 import { faker } from '@faker-js/faker';
-import { Wallet } from 'ethers';
+import { utils, Wallet } from 'ethers';
 import { hashFCObject, generateEd25519Signer, generateEthereumSigner } from '~/utils/crypto';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import CastDB from '~/storage/db/cast';
@@ -66,7 +66,7 @@ describe('mergeVerification', () => {
       { data: { fid: aliceFid, body: { delegate: aliceSigner.signerKey } } },
       { transient: { signer: aliceCustody } }
     );
-    aliceEthWallet = Wallet.createRandom();
+    aliceEthWallet = new Wallet(utils.randomBytes(32));
     transientParams = { transient: { signer: aliceSigner, ethWallet: aliceEthWallet } };
     aliceBlockHash = faker.datatype.hexadecimal({ length: 64 }).toLowerCase();
 
@@ -238,7 +238,7 @@ describe('mergeVerification', () => {
   });
 
   test('fails with externalSignature from unknown address', async () => {
-    const randomEthWallet = Wallet.createRandom();
+    const randomEthWallet = new Wallet(utils.randomBytes(32));
     const verificationAddMessage = await Factories.VerificationEthereumAddress.create(
       {
         data: {

--- a/src/storage/engine/flatbuffers/index.test.ts
+++ b/src/storage/engine/flatbuffers/index.test.ts
@@ -54,7 +54,7 @@ let verificationAdd: VerificationAddEthAddressModel;
 let userDataAdd: UserDataAddModel;
 
 beforeAll(async () => {
-  custodyWallet = Wallet.createRandom();
+  custodyWallet = new Wallet(utils.randomBytes(32));
   custodyAddress = utils.arrayify(custodyWallet.address);
   custodyEvent = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create({ fid: Array.from(fid), to: Array.from(custodyAddress) })

--- a/src/storage/flatbuffers/validations.test.ts
+++ b/src/storage/flatbuffers/validations.test.ts
@@ -60,7 +60,7 @@ let wallet: Wallet;
 let signer: KeyPair;
 
 beforeAll(async () => {
-  wallet = Wallet.createRandom();
+  wallet = new Wallet(utils.randomBytes(32));
   signer = await generateEd25519KeyPair();
 });
 
@@ -238,7 +238,7 @@ describe('validateEthAddress', () => {
   let address: Uint8Array;
 
   beforeAll(async () => {
-    const wallet = Wallet.createRandom();
+    const wallet = new Wallet(utils.randomBytes(32));
     address = utils.arrayify(wallet.address);
   });
 

--- a/src/storage/sets/flatbuffers/userDataStore.test.ts
+++ b/src/storage/sets/flatbuffers/userDataStore.test.ts
@@ -14,12 +14,12 @@ import NameRegistryEventModel from '~/storage/flatbuffers/nameRegistryEventModel
 import SignerStore from './signerStore';
 import UserDataStore from '~/storage/sets/flatbuffers/userDataStore';
 import Engine from '~/storage/engine/flatbuffers';
-import { Wallet } from 'ethers';
+import { utils, Wallet } from 'ethers';
 import { NameRegistryEventType } from '~/utils/generated/name_registry_event_generated';
 
 const db = jestBinaryRocksDB('flatbuffers.userDataSet.test');
 
-const wallet = Wallet.createRandom();
+const wallet = new Wallet(utils.randomBytes(32));
 
 const eventHandler = new StoreEventHandler();
 const signerSet = new SignerStore(db, eventHandler);

--- a/src/test/factories/flatbuffer.ts
+++ b/src/test/factories/flatbuffer.ts
@@ -39,7 +39,7 @@ import { blake3 } from '@noble/hashes/blake3';
 import { generateEd25519KeyPair } from '~/utils/crypto';
 import * as ed from '@noble/ed25519';
 import { arrayify } from 'ethers/lib/utils';
-import { ethers, Wallet } from 'ethers';
+import { ethers, utils, Wallet } from 'ethers';
 import { signMessageHash, signVerificationEthAddressClaim } from '~/utils/eip712';
 import { VerificationEthAddressClaim } from '~/storage/flatbuffers/types';
 import { IdRegistryEvent, IdRegistryEventT, IdRegistryEventType } from '~/utils/generated/id_registry_event_generated';
@@ -256,7 +256,7 @@ const VerificationAddEthAddressBodyFactory = Factory.define<
 >(({ onCreate, transientParams }) => {
   onCreate(async (params) => {
     // Generate address and signature
-    const wallet = transientParams.wallet ?? Wallet.createRandom();
+    const wallet = transientParams.wallet ?? new Wallet(utils.randomBytes(32));
     params.address = Array.from(arrayify(wallet.address));
 
     const fid = transientParams.fid ?? FIDFactory.build();

--- a/src/utils/eip712.test.ts
+++ b/src/utils/eip712.test.ts
@@ -11,7 +11,7 @@ import {
 } from '~/utils/eip712';
 import { blake3 } from '@noble/hashes/blake3';
 
-const wallet = Wallet.createRandom();
+const wallet = new Wallet(utils.randomBytes(32));
 
 describe('signVerificationEthAddressClaim', () => {
   let claim: VerificationEthAddressClaim;


### PR DESCRIPTION
## Motivation

See https://github.com/farcasterxyz/hub/pull/295

## Change Summary

Replaced all instances of `Wallet.createRandom()` with faster method to speed up tests

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)