### PR TITLE
fix: clean up contract event handlers when stopping hub

### DIFF
--- a/src/hub.ts
+++ b/src/hub.ts
@@ -216,6 +216,7 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
   /** Stop the GossipNode and RPC Server */
   async stop() {
     clearInterval(this.contactTimer);
+    await this.ethRegistryProvider.stop();
     await this.gossipNode.stop();
     await this.rpcServer.stop();
     await this.rocksDB.close();

--- a/src/storage/engine/flatbuffers/providers/ethEventsProvider.ts
+++ b/src/storage/engine/flatbuffers/providers/ethEventsProvider.ts
@@ -117,10 +117,24 @@ export class EthEventsProvider {
     return provider;
   }
 
+  public getLatestBlockNumber(): number {
+    return this._lastBlockNumber;
+  }
+
   public async start() {
     // Connect to Ethereum RPC
     await this.connectAndSyncHistoricalEvents();
   }
+
+  public async stop() {
+    this._idRegistryContract.removeAllListeners();
+    this._nameRegistryContract.removeAllListeners();
+    this._jsonRpcProvider.removeAllListeners();
+  }
+
+  /* -------------------------------------------------------------------------- */
+  /*                               Private Methods                              */
+  /* -------------------------------------------------------------------------- */
 
   /** Connect to Ethereum RPC */
   private async connectAndSyncHistoricalEvents() {
@@ -365,9 +379,5 @@ export class EthEventsProvider {
     if (r.isErr()) {
       log.error({ err: r._unsafeUnwrap() }, 'NameRegistryEvent failed to merge');
     }
-  }
-
-  public getLatestBlockNumber(): number {
-    return this._lastBlockNumber;
   }
 }

--- a/src/test/e2e/hub.test.ts
+++ b/src/test/e2e/hub.test.ts
@@ -236,8 +236,7 @@ describe('Hub negative tests', () => {
 
     expect(syncHandler).toBeCalledTimes(2);
 
-    await hub.stop();
-    await hub.destroyDB();
+    tearDownHub(hub);
   });
 
   test(


### PR DESCRIPTION
## Motivation

The original goal was to solve #297, but this change did not resolve the issue entirely. However, it is does clean up 9 event handlers that were not terminated, so it's worth merging anyway. 

## Change Summary

EthEventListener implements a stop method which clears all listeners and the hub calls stop when it is stopped.

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
