### PR TITLE
perf: speed up gossip node tests

### DIFF
--- a/src/network/p2p/node.test.ts
+++ b/src/network/p2p/node.test.ts
@@ -16,7 +16,6 @@ let messages: Map<string, Map<string, GossipMessage[] | undefined>>;
 
 /** Create a sequence of connections between all the nodes */
 const connectAll = async (nodes: Node[]) => {
-  // TODO: isn't this always guaranteed to be a single promise?
   const connectionResults = await Promise.all(
     nodes.slice(1).map((n) => {
       return n.connect(nodes[0] as Node);

--- a/src/network/p2p/node.test.ts
+++ b/src/network/p2p/node.test.ts
@@ -5,6 +5,7 @@ import { GossipMessage, NETWORK_TOPIC_PRIMARY } from '~/network/p2p/protocol';
 import { sleep } from '~/utils/crypto';
 
 const NUM_NODES = 10;
+const PROPAGATION_DELAY = 2 * 1000; // between 1 and 2 full heartbeat ticks
 
 const TEST_TIMEOUT_LONG = 60 * 1000;
 const TEST_TIMEOUT_SHORT = 10 * 1000;
@@ -27,8 +28,7 @@ const connectAll = async (nodes: Node[]) => {
 
   // subscribes every node to the test topic
   nodes.forEach((n) => n.gossip?.subscribe(NETWORK_TOPIC_PRIMARY));
-  // sleeps 1 heartbeat to let the network form
-  await sleep(1_000);
+  await sleep(PROPAGATION_DELAY);
 };
 
 const trackMessages = () => {
@@ -166,7 +166,7 @@ describe('gossip network', () => {
 
       const randomNode = nodes[Math.floor(Math.random() * nodes.length)] as Node;
       expect(randomNode.publish(message)).resolves.toBeUndefined();
-      await sleep(1_000); // sleep for at least one heartbeat tick
+      await sleep(PROPAGATION_DELAY);
 
       // check that every node has the message
       nodes.map((n) => {


### PR DESCRIPTION
## Motivation

Speed up node tests locally from 22s -> 10s by eliminating unnecessary waits and re-initializations. 

## Change Summary

- Two tests were combined to eliminate unnecessary double initialization
- Sleep times were reduced from 5s to2s since the network formed quickly
- `forEach` was replaced with `map` where iteration was not necessary

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
