### PR TITLE
Fix: Tests need to teardown properly.

### DIFF
--- a/src/flatbuffers/hub.ts
+++ b/src/flatbuffers/hub.ts
@@ -124,6 +124,7 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
   /** Stop the GossipNode and RPC Server */
   async stop() {
     clearInterval(this.contactTimer);
+    await this.ethRegistryProvider.stop();
     await this.rpcServer.stop();
     await this.rocksDB.close();
   }

--- a/src/storage/engine/flatbuffers/providers/ethEventsProvider.test.ts
+++ b/src/storage/engine/flatbuffers/providers/ethEventsProvider.test.ts
@@ -84,8 +84,9 @@ describe('process events', () => {
     ethEventsProvider.start();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     mockRPCProvider.polling = false;
+    await ethEventsProvider.stop();
   });
 
   const waitForBlock = async (blockNumber: number) => {

--- a/src/storage/engine/flatbuffers/providers/ethEventsProvider.ts
+++ b/src/storage/engine/flatbuffers/providers/ethEventsProvider.ts
@@ -130,6 +130,15 @@ export class EthEventsProvider {
     this._idRegistryContract.removeAllListeners();
     this._nameRegistryContract.removeAllListeners();
     this._jsonRpcProvider.removeAllListeners();
+
+    // Clear all polling, including the bootstrap polling. We need to reach inside the provider to do this,
+    // because the provider does not expose a way to stop the bootstrap polling.
+    // This can happen if the test runs quickly, where the bootstrap polling is still running when the test ends.
+    clearTimeout(this._jsonRpcProvider._bootstrapPoll);
+    this._jsonRpcProvider.polling = false;
+
+    // Wait for all async promises to resolve
+    await new Promise((resolve) => setTimeout(resolve, 0));
   }
 
   /* -------------------------------------------------------------------------- */

--- a/src/test/e2e/hub.test.ts
+++ b/src/test/e2e/hub.test.ts
@@ -211,6 +211,8 @@ describe('Hub negative tests', () => {
     expect(() => {
       hub.identity;
     }).toThrow(HubError);
+
+    tearDownHub(hub);
   });
 
   test('Fail to sync from invalid peers', async () => {


### PR DESCRIPTION
Fixes #297

## Motivation

Properly teardown the `EthEventsProvider` when finishing the tests.

## Change Summary

- Remove bootstrap poll and the regular poll in the JSONRpc Provider

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged
