### PR TITLE
docs: README for starting the Hub correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,16 @@ First, ensure that the following are installed globally on your machine:
 - [Node.js 18+](https://github.com/nvm-sh/nvm)
 - [Yarn](https://classic.yarnpkg.com/lang/en/docs/install)
 
+Next ensure that you have a Goerli Ethereum node that can you can connect to over HTTP. You can set one up using [Alchemy](https://www.alchemy.com/) or [Infura](https://www.infura.io/).
+
 Then, run:
 
 - `yarn install` to install dependencies
 - `yarn test` to ensure that the test suite runs correctly
 - `yarn identity create` to create a network identity for your Hub
-- `yarn start` to boot up the Hub
+- `yarn start -n <network-url>` to boot up the Hub, where `network-url` points to the Goerli node's RPC
 
-This will start an instance of the Hub that you can send messages to. Hubs do not (yet) peer automatically, this will be added closer to the v2 release in Q4 2022.
+This will start an instance of the Hub that you can send messages to.
 
 ## Architecture
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,8 +29,8 @@ app
 app
   .command('start')
   .description('Start a Hub')
+  .requiredOption('-n --network-url <url>', 'RPC URL of a Goerli Ethereum Node')
   .option('-c, --config <filepath>', 'Path to a config file with options', DEFAULT_CONFIG_FILE)
-  .option('-n --network-url <url>', 'ETH Node RPC URL to connect to')
   .option('-f, --fir-address <address>', 'The address of the FIR contract')
   .option('-b, --bootstrap <peer-multiaddrs...>', 'A list of peer multiaddrs to bootstrap libp2p')
   .option('-a, --allowed-peers <peerIds...>', 'An allow-list of peer ids permitted to connect to the hub')


### PR DESCRIPTION
## Motivation

The README for starting a Hub no longer works.

## Change Summary

- Updated the README with instructions on getting and plugging in the Eth node url
- Updated the cli to throw an error if the node url is not provided

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)