### PR TITLE
test: upgrade gh actions to resolve warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,15 @@ jobs:
         shard: [1/2, 2/2]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '18'
 
       - name: Restore cached dependencies for Node modules.
         id: module-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/node_modules
           key: ${{ runner.os }}--node--${{ hashFiles('**/yarn.lock') }}
@@ -51,4 +51,4 @@ jobs:
         run: yarn test:ci --shard=${{ matrix.shard }}
 
       - name: Upload coverage results
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Motivation

Resolves these warnings:

<img width="1353" alt="Screen Shot 2022-12-19 at 2 48 07 PM" src="https://user-images.githubusercontent.com/528882/208541557-ea0fd81b-868f-44f3-9513-7edd502a827f.png">

## Change Summary

Upgrade all the GH actions to the latest versions

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
