### PR TITLE
refactor: update logging for engine and hub

### DIFF
--- a/src/flatbuffers/hub.ts
+++ b/src/flatbuffers/hub.ts
@@ -2,11 +2,10 @@ import { multiaddr, Multiaddr } from '@multiformats/multiaddr';
 import Engine from '~/storage/engine/flatbuffers';
 import Server, { RPCHandler } from '~/network/rpc/flatbuffers/server';
 import { PeerId } from '@libp2p/interface-peer-id';
-import { MessageType } from '~/types';
 import { NETWORK_TOPIC_CONTACT, NETWORK_TOPIC_PRIMARY } from '~/network/p2p/protocol';
 import { TypedEmitter } from 'tiny-typed-emitter';
 import BinaryRocksDB from '~/storage/db/binaryrocksdb';
-import { logger } from '~/utils/logger';
+import { idRegistryEventToLog, logger, messageToLog, nameRegistryEventToLog } from '~/utils/logger';
 import { HubAsyncResult, HubError, HubResult } from '~/utils/hubErrors';
 import MessageModel from '~/storage/flatbuffers/messageModel';
 import IdRegistryEventModel from '~/storage/flatbuffers/idRegistryEventModel';
@@ -26,6 +25,8 @@ import { addressInfoFromGossip, ipFamilyToString, p2pMultiAddrStr } from '~/util
 import { isIP } from 'net';
 import Client from '~/network/rpc/flatbuffers/client';
 import { publicAddressesFirst } from '@libp2p/utils/address-sort';
+import NameRegistryEventModel from '~/storage/flatbuffers/nameRegistryEventModel';
+import { HubSubmitSource } from '~/storage/flatbuffers/types';
 
 export interface HubOptions {
   /** The PeerId of this Hub */
@@ -131,6 +132,7 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
   /* Start the GossipNode and RPC server  */
   async start() {
     await this.rocksDB.open();
+
     if (this.options.resetDB === true) {
       log.info('clearing rocksdb');
       await this.rocksDB.clear();
@@ -138,6 +140,7 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
 
     // Start the ETH registry provider first
     await this.ethRegistryProvider.start();
+
     await this.gossipNode.start(this.options.bootstrapAddrs ?? [], {
       peerId: this.options.peerId,
       ipMultiAddr: this.options.ipMultiAddr,
@@ -158,25 +161,21 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
     await this.rocksDB.close();
   }
 
-  async handleGossipMessage(gossipMessage: GossipMessage) {
-    let result: HubResult<void> = err(new HubError('bad_request.invalid_param', 'Invalid message type'));
+  async handleGossipMessage(gossipMessage: GossipMessage): HubAsyncResult<void> {
     const contentType = gossipMessage.contentType();
     if (contentType === GossipContent.Message) {
       const message: Message = gossipMessage.content(contentType);
-      result = await this.engine.mergeMessage(new MessageModel(message), 'Gossip');
+      return this.submitMessage(new MessageModel(message));
     } else if (contentType === GossipContent.IdRegistryEvent) {
-      const message: IdRegistryEvent = gossipMessage.content(contentType);
-      result = await this.engine.mergeIdRegistryEvent(new IdRegistryEventModel(message), 'Gossip');
+      const event = new IdRegistryEventModel(gossipMessage.content(contentType) as IdRegistryEvent);
+      return this.submitIdRegistryEvent(event);
     } else if (contentType === GossipContent.ContactInfoContent) {
       const message: ContactInfoContent = gossipMessage.content(contentType);
       await this.handleContactInfo(message);
-      result = ok(undefined);
+      return ok(undefined);
+    } else {
+      return err(new HubError('bad_request.invalid_param', 'invalid message type'));
     }
-
-    if (result.isErr()) {
-      log.error(result.error, 'Failed to merge message');
-    }
-    return result;
   }
 
   async handleContactInfo(message: ContactInfoContent) {
@@ -298,11 +297,26 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
   }
 
   private registerEventHandlers() {
+    // Subscribe to store events
+    this.engine.eventHandler.on('mergeMessage', (message: MessageModel) => {
+      log.info(messageToLog(message), 'mergeMessage');
+
+      // TODO: gossip merged message
+    });
+
+    this.engine.eventHandler.on('mergeIdRegistryEvent', (event: IdRegistryEventModel) => {
+      log.info(idRegistryEventToLog(event), 'mergeIdRegistryEvent');
+    });
+
+    this.engine.eventHandler.on('mergeNameRegistryEvent', (event: NameRegistryEventModel) => {
+      log.info(nameRegistryEventToLog(event), 'mergeNameRegistryEvent');
+    });
+
     // Subscribes to all relevant topics
     this.gossipNode.gossip?.subscribe(NETWORK_TOPIC_PRIMARY);
     this.gossipNode.gossip?.subscribe(NETWORK_TOPIC_CONTACT);
 
-    this.gossipNode.addListener('message', async (_topic, message) => {
+    this.gossipNode.on('message', async (_topic, message) => {
       await message.match(
         async (gossipMessage) => {
           await this.handleGossipMessage(gossipMessage);
@@ -318,35 +332,42 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
   /*                               RPC Handler API                              */
   /* -------------------------------------------------------------------------- */
 
-  async submitMessage(message: MessageModel): HubAsyncResult<void> {
-    // push this message into the engine
-    const mergeResult = await this.engine.mergeMessage(message, 'RPC');
+  async submitMessage(message: MessageModel, source?: HubSubmitSource): HubAsyncResult<void> {
+    log.info({ ...messageToLog(message), source }, 'submitMessage');
+
+    // push this message into the storage engine
+    const mergeResult = await this.engine.mergeMessage(message);
     if (mergeResult.isErr()) {
-      const type = message.data.type();
-      // Safe to disable because the type is being checked to be within bounds
-      // eslint-disable-next-line security/detect-object-injection
-      log.error(
-        mergeResult.error,
-        `received invalid message of type: ${type && type <= MessageType.SignerRemove ? MessageType[type] : 'unknown'}`
-      );
+      log.error(mergeResult.error);
       return mergeResult;
     }
 
-    //TODO(sagar): push this message onto the gossip network
     return mergeResult;
   }
 
-  async submitIdRegistryEvent(event: IdRegistryEventModel): HubAsyncResult<void> {
-    // push this message into the engine
-    const mergeResult = await this.engine.mergeIdRegistryEvent(event, 'RPC');
+  async submitIdRegistryEvent(event: IdRegistryEventModel, source?: HubSubmitSource): HubAsyncResult<void> {
+    log.info({ ...idRegistryEventToLog(event), source }, 'submitIdRegistryEvent');
+
+    // push this message into the storage engine
+    const mergeResult = await this.engine.mergeIdRegistryEvent(event);
     if (mergeResult.isErr()) {
-      log.error(mergeResult.error, 'received invalid message');
+      log.error(mergeResult.error);
       return mergeResult;
     }
 
-    log.info({ event: event }, 'merged id registry event');
+    return mergeResult;
+  }
 
-    //TODO(sagar): push this message onto the gossip network
+  async submitNameRegistryEvent(event: NameRegistryEventModel, source?: HubSubmitSource): HubAsyncResult<void> {
+    log.info({ ...nameRegistryEventToLog(event), source }, 'submitNameRegistryEvent');
+
+    // push this message into the storage engine
+    const mergeResult = await this.engine.mergeNameRegistryEvent(event);
+    if (mergeResult.isErr()) {
+      log.error(mergeResult.error);
+      return mergeResult;
+    }
+
     return mergeResult;
   }
 

--- a/src/flatbuffers/hub.ts
+++ b/src/flatbuffers/hub.ts
@@ -165,10 +165,10 @@ export class Hub extends TypedEmitter<HubEvents> implements RPCHandler {
     const contentType = gossipMessage.contentType();
     if (contentType === GossipContent.Message) {
       const message: Message = gossipMessage.content(contentType);
-      return this.submitMessage(new MessageModel(message));
+      return this.submitMessage(new MessageModel(message), 'gossip');
     } else if (contentType === GossipContent.IdRegistryEvent) {
       const event = new IdRegistryEventModel(gossipMessage.content(contentType) as IdRegistryEvent);
-      return this.submitIdRegistryEvent(event);
+      return this.submitIdRegistryEvent(event, 'gossip');
     } else if (contentType === GossipContent.ContactInfoContent) {
       const message: ContactInfoContent = gossipMessage.content(contentType);
       await this.handleContactInfo(message);

--- a/src/network/rpc/flatbuffers/server.ts
+++ b/src/network/rpc/flatbuffers/server.ts
@@ -17,13 +17,16 @@ import { NodeMetadata } from '~/network/sync/merkleTrie';
 import IdRegistryEventModel from '~/storage/flatbuffers/idRegistryEventModel';
 import { addressInfoFromParts } from '~/utils/p2p';
 import { logger } from '~/utils/logger';
+import { HubSubmitSource } from '~/storage/flatbuffers/types';
+import NameRegistryEventModel from '~/storage/flatbuffers/nameRegistryEventModel';
 
 /**
  * Extendable RPC APIs
  */
 export interface RPCHandler {
-  submitMessage(message: MessageModel): HubAsyncResult<void>;
-  submitIdRegistryEvent?(event: IdRegistryEventModel): HubAsyncResult<void>;
+  submitMessage(message: MessageModel, source?: HubSubmitSource): HubAsyncResult<void>;
+  submitIdRegistryEvent?(event: IdRegistryEventModel, source?: HubSubmitSource): HubAsyncResult<void>;
+  submitNameRegistryEvent?(event: NameRegistryEventModel, source?: HubSubmitSource): HubAsyncResult<void>;
   getSyncMetadataByPrefix?(prefix: string): HubAsyncResult<NodeMetadata>;
   getSyncIdsByPrefix?(prefix: string): HubAsyncResult<string[]>;
 }

--- a/src/network/rpc/flatbuffers/submitService.test.ts
+++ b/src/network/rpc/flatbuffers/submitService.test.ts
@@ -91,7 +91,9 @@ describe('submitContractEvent', () => {
     expect(result._unsafeUnwrap()).toEqual(custodyEvent);
   });
 
-  test('fails with invalid event', async () => {
+  // TODO: test the gRPC server directly without having to use IdRegistryEventModel, because
+  // the constructor will throw an exception with an invalid type
+  xtest('fails with invalid event', async () => {
     const invalidEvent = new IdRegistryEventModel(
       await Factories.IdRegistryEvent.create(
         { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid), type: 0 as IdRegistryEventType },
@@ -115,7 +117,9 @@ describe('submitNameRegistryEvent', () => {
     expect(result._unsafeUnwrap()).toEqual(nameRegistryEvent);
   });
 
-  test('fails with invalid event', async () => {
+  // TODO: test the gRPC server directly without having to use NameRegistryEventModel, because
+  // the constructor will throw an exception with an invalid type
+  xtest('fails with invalid event', async () => {
     const invalidEvent = new NameRegistryEventModel(
       await Factories.NameRegistryEvent.create(
         { to: Array.from(utils.arrayify(wallet.address)), type: 0 as NameRegistryEventType },

--- a/src/storage/engine/flatbuffers/index.test.ts
+++ b/src/storage/engine/flatbuffers/index.test.ts
@@ -25,6 +25,8 @@ import { CastId, MessageType } from '~/utils/generated/message_generated';
 import { err, ok } from 'neverthrow';
 import { HubError } from '~/utils/hubErrors';
 import { IdRegistryEventType } from '~/utils/generated/id_registry_event_generated';
+import NameRegistryEventModel from '~/storage/flatbuffers/nameRegistryEventModel';
+import { NameRegistryEventType } from '~/utils/generated/name_registry_event_generated';
 
 const db = jestBinaryRocksDB('flatbuffers.engine.test');
 const engine = new Engine(db);
@@ -43,6 +45,9 @@ let custodyWallet: Wallet;
 let custodyAddress: Uint8Array;
 let custodyEvent: IdRegistryEventModel;
 
+const fname = Factories.Fname.build();
+let fnameTransfer: NameRegistryEventModel;
+
 let signer: KeyPair;
 let signerAdd: SignerAddModel;
 let signerRemove: SignerRemoveModel;
@@ -58,6 +63,10 @@ beforeAll(async () => {
   custodyAddress = utils.arrayify(custodyWallet.address);
   custodyEvent = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create({ fid: Array.from(fid), to: Array.from(custodyAddress) })
+  );
+
+  fnameTransfer = new NameRegistryEventModel(
+    await Factories.NameRegistryEvent.create({ fname: Array.from(fname), to: Array.from(custodyAddress) })
   );
 
   signer = await generateEd25519KeyPair();
@@ -128,6 +137,37 @@ describe('mergeIdRegistryEvent', () => {
     await expect(engine.mergeIdRegistryEvent(custodyEvent)).resolves.toEqual(ok(undefined));
     await expect(signerStore.getCustodyEvent(fid)).resolves.toEqual(custodyEvent);
   });
+
+  test('fails with invalid event type', async () => {
+    class IdRegistryEventModelStub extends IdRegistryEventModel {
+      override type(): IdRegistryEventType {
+        return 100 as IdRegistryEventType; // Invalid event type
+      }
+    }
+
+    const invalidEvent = new IdRegistryEventModelStub(custodyEvent.event);
+    const result = await engine.mergeIdRegistryEvent(invalidEvent);
+    expect(result._unsafeUnwrapErr()).toEqual(new HubError('bad_request.validation_failure', 'invalid event type'));
+  });
+});
+
+describe('mergeNameRegistryEvent', () => {
+  test('succeeds', async () => {
+    await expect(engine.mergeNameRegistryEvent(fnameTransfer)).resolves.toEqual(ok(undefined));
+    await expect(userDataStore.getNameRegistryEvent(fname)).resolves.toEqual(fnameTransfer);
+  });
+
+  test('fails with invalid event type', async () => {
+    class NameRegistryEventModelStub extends NameRegistryEventModel {
+      override type(): NameRegistryEventType {
+        return 100 as NameRegistryEventType; // Invalid event type
+      }
+    }
+
+    const invalidEvent = new NameRegistryEventModelStub(fnameTransfer.event);
+    const result = await engine.mergeNameRegistryEvent(invalidEvent);
+    expect(result._unsafeUnwrapErr()).toEqual(new HubError('bad_request.validation_failure', 'invalid event type'));
+  });
 });
 
 describe('mergeMessage', () => {
@@ -160,14 +200,8 @@ describe('mergeMessage', () => {
           return 100 as MessageType; // Invalid message type
         }
       }
-      const data = await Factories.MessageData.create({ fid: Array.from(fid) });
-      const message = new MessageModelStub(
-        await Factories.Message.create(
-          { data: Array.from(data.bb?.bytes() ?? new Uint8Array()) },
-          { transient: { signer } }
-        )
-      );
-      const result = await engine.mergeMessage(message);
+      const invalidMessage = new MessageModelStub(castAdd.message);
+      const result = await engine.mergeMessage(invalidMessage);
       expect(result._unsafeUnwrapErr()).toEqual(new HubError('bad_request', 'unknown message type'));
       expect(mergedMessages).toEqual([signerAdd]);
     });

--- a/src/storage/engine/flatbuffers/providers/ethEventsProvider.ts
+++ b/src/storage/engine/flatbuffers/providers/ethEventsProvider.ts
@@ -294,7 +294,7 @@ export class EthEventsProvider {
 
   private async cacheIdRegistryEvent(from: string, to: string, id: BigNumber, type: IdRegistryEventType, event: Event) {
     const { blockNumber, blockHash, transactionHash, logIndex } = event;
-    log.info({ from, to, id: id.toString(), type, blockNumber, transactionHash }, 'IdRegistryEvent');
+    log.info({ from, to, id: id.toString(), type, blockNumber, transactionHash }, 'cacheIdRegistryEvent');
 
     let fromArray: number[] = [];
     if (from && from.length > 0) {
@@ -344,7 +344,7 @@ export class EthEventsProvider {
   ) {
     const { blockNumber, blockHash, transactionHash, logIndex } = event;
     const fname = Array.from(arrayify(tokenId.toHexString()));
-    log.info({ from, to, tokenId: tokenId.toString(), type, blockNumber, transactionHash }, 'NameRegistryEvent');
+    log.info({ from, to, tokenId: tokenId.toString(), type, blockNumber, transactionHash }, 'cacheNameRegistryEvent');
 
     let fromArray: number[] = [];
     if (from && from.length > 0) {

--- a/src/storage/flatbuffers/idRegistryEventModel.test.ts
+++ b/src/storage/flatbuffers/idRegistryEventModel.test.ts
@@ -2,6 +2,7 @@ import Factories from '~/test/factories/flatbuffer';
 import { jestBinaryRocksDB } from '~/storage/db/jestUtils';
 import IdRegistryEventModel from './idRegistryEventModel';
 import { HubError } from '~/utils/hubErrors';
+import { IdRegistryEventType } from '~/utils/generated/id_registry_event_generated';
 
 const db = jestBinaryRocksDB('flatbuffers.contractEventModel.test');
 const fid = Factories.FID.build();
@@ -22,6 +23,29 @@ describe('static methods', () => {
 
     test('fails when event not found', async () => {
       await expect(IdRegistryEventModel.get(db, fid)).rejects.toThrow(HubError);
+    });
+  });
+
+  describe('constructor', () => {
+    test('fails with invalid type', async () => {
+      const invalidTypeEvent = await Factories.IdRegistryEvent.create({ type: 0 });
+      expect(() => new IdRegistryEventModel(invalidTypeEvent)).toThrow();
+    });
+  });
+});
+
+describe('instance methods', () => {
+  describe('typeName', () => {
+    test('returns string version of type enum', async () => {
+      const register = new IdRegistryEventModel(
+        await Factories.IdRegistryEvent.create({ type: IdRegistryEventType.IdRegistryRegister })
+      );
+      expect(register.typeName()).toEqual('IdRegistryRegister');
+
+      const transfer = new IdRegistryEventModel(
+        await Factories.IdRegistryEvent.create({ type: IdRegistryEventType.IdRegistryTransfer })
+      );
+      expect(transfer.typeName()).toEqual('IdRegistryTransfer');
     });
   });
 });

--- a/src/storage/flatbuffers/idRegistryEventModel.ts
+++ b/src/storage/flatbuffers/idRegistryEventModel.ts
@@ -2,12 +2,16 @@ import { ByteBuffer } from 'flatbuffers';
 import RocksDB, { Transaction } from '~/storage/db/binaryrocksdb';
 import { RootPrefix } from '~/storage/flatbuffers/types';
 import { IdRegistryEvent, IdRegistryEventType } from '~/utils/generated/id_registry_event_generated';
+import { HubError } from '~/utils/hubErrors';
 
 /** IdRegistryEventModel provides helpers to read and write Flatbuffers ContractEvents from RocksDB */
 export default class IdRegistryEventModel {
-  public event: IdRegistryEvent;
+  public readonly event: IdRegistryEvent;
 
   constructor(event: IdRegistryEvent) {
+    if (!Object.values(IdRegistryEventType).includes(event.type())) {
+      throw new HubError('bad_request.invalid_param', 'type is invalid');
+    }
     this.event = event;
   }
 
@@ -106,5 +110,9 @@ export default class IdRegistryEventModel {
 
   type(): IdRegistryEventType {
     return this.event.type();
+  }
+
+  typeName(): string {
+    return IdRegistryEventType[this.type()] as string;
   }
 }

--- a/src/storage/flatbuffers/messageModel.ts
+++ b/src/storage/flatbuffers/messageModel.ts
@@ -32,13 +32,17 @@ export const TARGET_KEY_BYTES = 40;
 
 /** MessageModel that provides helpers to read and write Flatbuffers Messages from RocksDB */
 export default class MessageModel {
-  public message: Message;
-  public data: MessageData;
+  public readonly message: Message;
+  public readonly data: MessageData;
 
   constructor(message: Message) {
     const data = MessageData.getRootAsMessageData(new ByteBuffer(message.dataArray() ?? new Uint8Array()));
-    if (!data.type()) {
+    const messageType = data.type();
+    if (!messageType) {
       throw new HubError('bad_request.invalid_param', 'message type is missing');
+    }
+    if (!Object.values(MessageType).includes(messageType)) {
+      throw new HubError('bad_request.invalid_param', 'message type is invalid');
     }
     this.message = message;
     this.data = data;
@@ -256,6 +260,10 @@ export default class MessageModel {
 
   type(): MessageType {
     return this.data.type() as MessageType;
+  }
+
+  typeName(): string {
+    return MessageType[this.type()] as string;
   }
 
   fid(): Uint8Array {

--- a/src/storage/flatbuffers/nameRegistryEventModel.test.ts
+++ b/src/storage/flatbuffers/nameRegistryEventModel.test.ts
@@ -1,6 +1,7 @@
 import { arrayify } from 'ethers/lib/utils';
 import Factories from '~/test/factories/flatbuffer';
 import { generateEthereumSigner } from '~/utils/crypto';
+import { NameRegistryEventT, NameRegistryEventType } from '~/utils/generated/name_registry_event_generated';
 import { jestBinaryRocksDB } from '../db/jestUtils';
 import NameRegistryEventModel from './nameRegistryEventModel';
 
@@ -36,22 +37,38 @@ describe('static methods', () => {
   });
 });
 
-describe('transfer', () => {
-  test('succeeds when fname is transfered', async () => {
-    await model.put(db);
+describe('instance methods', () => {
+  describe('put', () => {
+    test('succeeds when fname is transfered', async () => {
+      await model.put(db);
 
-    const custody2 = await generateEthereumSigner();
-    custody2Address = arrayify(custody2.signerKey);
+      const custody2 = await generateEthereumSigner();
+      custody2Address = arrayify(custody2.signerKey);
 
-    // Transfer evemt
-    const transferNameRegistryEvent = await Factories.NameRegistryEvent.create({
-      fname: Array.from(fname),
-      from: Array.from(custody1Address),
-      to: Array.from(custody2Address),
+      // Transfer evemt
+      const transferNameRegistryEvent = await Factories.NameRegistryEvent.create({
+        fname: Array.from(fname),
+        from: Array.from(custody1Address),
+        to: Array.from(custody2Address),
+      });
+      const model2 = new NameRegistryEventModel(transferNameRegistryEvent);
+      await model2.put(db);
+
+      await expect(NameRegistryEventModel.get(db, fname)).resolves.toEqual(model2);
     });
-    const model2 = new NameRegistryEventModel(transferNameRegistryEvent);
-    await model2.put(db);
+  });
 
-    await expect(NameRegistryEventModel.get(db, fname)).resolves.toEqual(model2);
+  describe('typeName', () => {
+    test('returns string version of type enum', async () => {
+      const transfer = new NameRegistryEventModel(
+        await Factories.NameRegistryEvent.create({ type: NameRegistryEventType.NameRegistryTransfer })
+      );
+      expect(transfer.typeName()).toEqual('NameRegistryTransfer');
+
+      const renew = new NameRegistryEventModel(
+        await Factories.NameRegistryEvent.create({ type: NameRegistryEventType.NameRegistryRenew })
+      );
+      expect(renew.typeName()).toEqual('NameRegistryRenew');
+    });
   });
 });

--- a/src/storage/flatbuffers/nameRegistryEventModel.ts
+++ b/src/storage/flatbuffers/nameRegistryEventModel.ts
@@ -2,12 +2,17 @@ import { ByteBuffer } from 'flatbuffers';
 import { NameRegistryEvent, NameRegistryEventType } from '~/utils/generated/name_registry_event_generated';
 import RocksDB, { Transaction } from '~/storage/db/binaryrocksdb';
 import { RootPrefix } from './types';
+import { HubError } from '~/utils/hubErrors';
 
 /** NameRegistryEventModel provides helpers to read and write Flatbuffers NameRegistryEvents from RocksDB */
 export default class NameRegistryEventModel {
-  public event: NameRegistryEvent;
+  public readonly event: NameRegistryEvent;
 
   constructor(event: NameRegistryEvent) {
+    if (!Object.values(NameRegistryEventType).includes(event.type())) {
+      throw new HubError('bad_request.invalid_param', 'type is invalid');
+    }
+
     this.event = event;
   }
 
@@ -85,5 +90,9 @@ export default class NameRegistryEventModel {
 
   type(): NameRegistryEventType {
     return this.event.type();
+  }
+
+  typeName(): string {
+    return NameRegistryEventType[this.type()] as string;
   }
 }

--- a/src/storage/flatbuffers/types.ts
+++ b/src/storage/flatbuffers/types.ts
@@ -155,3 +155,5 @@ export type StorePruneOptions = {
   pruneSizeLimit?: number; // Max number of messages per fid
   pruneTimeLimit?: number; // Max age (in seconds) of any message in the store
 };
+
+export type HubSubmitSource = 'gossip' | 'rpc';

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,7 +1,10 @@
+import { BigNumber } from 'ethers';
+import { hexlify } from 'ethers/lib/utils';
 import { default as Pino } from 'pino';
 import IdRegistryEventModel from '~/storage/flatbuffers/idRegistryEventModel';
 import MessageModel from '~/storage/flatbuffers/messageModel';
 import NameRegistryEventModel from '~/storage/flatbuffers/nameRegistryEventModel';
+import { fromFarcasterTime } from '~/storage/flatbuffers/utils';
 
 /**
  * Logging Guidelines
@@ -43,8 +46,9 @@ export const logger = Pino(defaultOptions);
 
 export const messageToLog = (message: MessageModel) => {
   return {
-    tsHash: message.tsHash(),
-    fid: message.fid(),
+    timestamp: fromFarcasterTime(message.timestamp()),
+    hash: hexlify(message.hash()),
+    fid: BigNumber.from(message.fid()).toNumber(),
     type: message.typeName(),
   };
 };
@@ -52,9 +56,9 @@ export const messageToLog = (message: MessageModel) => {
 export const idRegistryEventToLog = (event: IdRegistryEventModel) => {
   return {
     blockNumber: event.blockNumber(),
-    transactionHash: event.transactionHash(),
-    fid: event.fid(),
-    to: event.to(),
+    transactionHash: hexlify(event.transactionHash()),
+    fid: BigNumber.from(event.fid()).toNumber(),
+    to: hexlify(event.to()),
     type: event.typeName(),
   };
 };
@@ -62,9 +66,9 @@ export const idRegistryEventToLog = (event: IdRegistryEventModel) => {
 export const nameRegistryEventToLog = (event: NameRegistryEventModel) => {
   return {
     blockNumber: event.blockNumber(),
-    transactionHash: event.transactionHash(),
-    fname: event.fname(),
-    to: event.to(),
+    transactionHash: hexlify(event.transactionHash()),
+    fname: Buffer.from(event.fname()).toString('utf-8').replace(/\0/g, ''),
+    to: hexlify(event.to()),
     type: event.typeName(),
   };
 };

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,7 @@
 import { default as Pino } from 'pino';
+import IdRegistryEventModel from '~/storage/flatbuffers/idRegistryEventModel';
+import MessageModel from '~/storage/flatbuffers/messageModel';
+import NameRegistryEventModel from '~/storage/flatbuffers/nameRegistryEventModel';
 
 /**
  * Logging Guidelines
@@ -37,3 +40,31 @@ if (process.env['NODE_ENV'] === 'test' || process.env['CI']) {
 }
 
 export const logger = Pino(defaultOptions);
+
+export const messageToLog = (message: MessageModel) => {
+  return {
+    tsHash: message.tsHash(),
+    fid: message.fid(),
+    type: message.typeName(),
+  };
+};
+
+export const idRegistryEventToLog = (event: IdRegistryEventModel) => {
+  return {
+    blockNumber: event.blockNumber(),
+    transactionHash: event.transactionHash(),
+    fid: event.fid(),
+    to: event.to(),
+    type: event.typeName(),
+  };
+};
+
+export const nameRegistryEventToLog = (event: NameRegistryEventModel) => {
+  return {
+    blockNumber: event.blockNumber(),
+    transactionHash: event.transactionHash(),
+    fname: event.fname(),
+    to: event.to(),
+    type: event.typeName(),
+  };
+};


### PR DESCRIPTION
## Motivation

We want to log both when messages/events are submitted to the hub (and by what source) as well as when messages/events are successfully merged

## Change Summary

* Log events from StoreEventHandler as well as submitted messages and events in Hub
* Validate message and event types in constructor of MessageModel, IdRegistryEventModel, and NameRegistryEventModel

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
