### PR TITLE
refactor: minimize external dependencies in RPC client

### DIFF
--- a/app/src/hubRpcClient.ts
+++ b/app/src/hubRpcClient.ts
@@ -1,0 +1,26 @@
+import { AddressInfo } from 'net';
+import { Client } from 'undici';
+import { logger } from '~/utils/logger';
+import { addressInfoToString, ipMultiAddrStrFromAddressInfo } from '~/utils/p2p';
+
+class HubRPCClient extends Client {
+  private serverAddr: string;
+
+  constructor(addressInfo: AddressInfo) {
+    const multiAddrResult = ipMultiAddrStrFromAddressInfo(addressInfo);
+    if (multiAddrResult.isErr()) {
+      logger.warn({ component: 'gRPC Client', address: addressInfo }, 'Failed to parse address as multiaddr');
+    }
+
+    const addressString = addressInfoToString(addressInfo);
+    super(addressString);
+
+    this.serverAddr = `${multiAddrResult.unwrapOr('localhost')}/tcp/${addressInfo.port}`;
+  }
+
+  get serverMultiaddr() {
+    return this.serverAddr;
+  }
+}
+
+export default HubRPCClient;

--- a/app/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/app/src/network/sync/multiPeerSyncEngine.test.ts
@@ -10,7 +10,6 @@ import { jestRocksDB } from '~/storage/db/jestUtils';
 import Engine from '~/storage/engine';
 import { MockHub } from '~/test/mocks';
 import { generateEd25519KeyPair } from '~/utils/crypto';
-import { addressInfoFromParts } from '~/utils/p2p';
 import SyncEngine from './syncEngine';
 import { SyncId } from './syncId';
 
@@ -77,7 +76,7 @@ describe('Multi peer sync engine', () => {
     syncEngine1 = new SyncEngine(engine1);
     server1 = new Server(hub1, engine1, syncEngine1);
     port1 = await server1.start();
-    clientForServer1 = new Client(addressInfoFromParts('127.0.0.1', port1)._unsafeUnwrap());
+    clientForServer1 = new Client(`127.0.0.1:${port1}`);
   });
 
   afterEach(async () => {
@@ -186,7 +185,7 @@ describe('Multi peer sync engine', () => {
     {
       const server2 = new Server(new MockHub(testDb2, engine2), engine2, syncEngine2);
       const port2 = await server2.start();
-      const clientForServer2 = new Client(addressInfoFromParts('127.0.0.1', port2)._unsafeUnwrap());
+      const clientForServer2 = new Client(`127.0.0.1:${port2}`);
       const engine1RootHashBefore = syncEngine1.trie.rootHash;
 
       await syncEngine1.performSync(syncEngine2.snapshot.excludedHashes, clientForServer2);

--- a/app/src/rpc/client/serviceRequests/syncRequests.ts
+++ b/app/src/rpc/client/serviceRequests/syncRequests.ts
@@ -1,9 +1,37 @@
-import { GetAllMessagesByFidRequest, GetAllMessagesByFidRequestT } from '@hub/flatbuffers';
+import {
+  GetAllMessagesByFidRequest,
+  GetAllMessagesByFidRequestT,
+  GetAllMessagesBySyncIdsRequest,
+  GetAllMessagesBySyncIdsRequestT,
+  GetTrieNodesByPrefixRequest,
+  GetTrieNodesByPrefixRequestT,
+  SyncIdHashT,
+} from '@hub/flatbuffers';
 import { Builder, ByteBuffer } from 'flatbuffers';
 
-export const createSyncRequest = (fid: Uint8Array): GetAllMessagesByFidRequest => {
-  const builder = new Builder(1);
-  const requestT = new GetAllMessagesByFidRequestT(Array.from(fid));
-  builder.finish(requestT.pack(builder));
-  return GetAllMessagesByFidRequest.getRootAsGetAllMessagesByFidRequest(new ByteBuffer(builder.asUint8Array()));
+export const syncRequests = {
+  createSyncRequest: (fid: Uint8Array): GetAllMessagesByFidRequest => {
+    const builder = new Builder(1);
+    const requestT = new GetAllMessagesByFidRequestT(Array.from(fid));
+    builder.finish(requestT.pack(builder));
+    return GetAllMessagesByFidRequest.getRootAsGetAllMessagesByFidRequest(new ByteBuffer(builder.asUint8Array()));
+  },
+
+  createByPrefixRequest: (prefix: Uint8Array): GetTrieNodesByPrefixRequest => {
+    const builder = new Builder(1);
+    const requestT = new GetTrieNodesByPrefixRequestT(Array.from(prefix));
+    builder.finish(requestT.pack(builder));
+    return GetTrieNodesByPrefixRequest.getRootAsGetTrieNodesByPrefixRequest(new ByteBuffer(builder.asUint8Array()));
+  },
+
+  getAllMessagesByHashesRequest: (hashes: Uint8Array[]): GetAllMessagesBySyncIdsRequest => {
+    const hashes_list = hashes.map((hash) => new SyncIdHashT(Array.from(hash)));
+
+    const builder = new Builder(1);
+    const hashesT = new GetAllMessagesBySyncIdsRequestT(hashes_list);
+    builder.finish(hashesT.pack(builder));
+    return GetAllMessagesBySyncIdsRequest.getRootAsGetAllMessagesBySyncIdsRequest(
+      new ByteBuffer(builder.asUint8Array())
+    );
+  },
 };

--- a/app/src/rpc/server/index.ts
+++ b/app/src/rpc/server/index.ts
@@ -95,38 +95,6 @@ export const toTrieNodeMetadataResponse = (metadata: NodeMetadata): flatbuffers.
   return response;
 };
 
-export const fromNodeMetadataResponse = (response: flatbuffers.TrieNodeMetadataResponse): NodeMetadata => {
-  const children = new Map<string, NodeMetadata>();
-  for (let i = 0; i < response.childrenLength(); i++) {
-    const child = response.children(i);
-
-    const prefix = new TextDecoder().decode(child?.prefixArray() ?? new Uint8Array());
-    // Char is the last char of prefix
-    const char = prefix[prefix.length - 1] ?? '';
-
-    children.set(char, {
-      numMessages: Number(child?.numMessages()),
-      prefix,
-      hash: new TextDecoder().decode(child?.hashArray() ?? new Uint8Array()),
-    });
-  }
-
-  return {
-    prefix: new TextDecoder().decode(response.prefixArray() ?? new Uint8Array()),
-    numMessages: Number(response.numMessages()),
-    hash: new TextDecoder().decode(response.hashArray() ?? new Uint8Array()),
-    children,
-  };
-};
-
-export const fromSyncIdsByPrefixResponse = (response: flatbuffers.GetAllSyncIdsByPrefixResponse): string[] => {
-  const ids = [];
-  for (let i = 0; i < response.idsLength(); i++) {
-    ids.push(response.ids(i));
-  }
-  return ids;
-};
-
 interface GenericFlatbuffer {
   bb: ByteBuffer | null;
 }

--- a/app/src/rpc/server/serviceImplementations/syncImplementation.ts
+++ b/app/src/rpc/server/serviceImplementations/syncImplementation.ts
@@ -154,23 +154,3 @@ export const createSyncServiceRequest = (fid: Uint8Array): flatbuffers.GetAllMes
     new ByteBuffer(builder.asUint8Array())
   );
 };
-
-export const createByPrefixRequest = (prefix: Uint8Array): flatbuffers.GetTrieNodesByPrefixRequest => {
-  const builder = new Builder(1);
-  const requestT = new flatbuffers.GetTrieNodesByPrefixRequestT(Array.from(prefix));
-  builder.finish(requestT.pack(builder));
-  return flatbuffers.GetTrieNodesByPrefixRequest.getRootAsGetTrieNodesByPrefixRequest(
-    new ByteBuffer(builder.asUint8Array())
-  );
-};
-
-export const createAllMessagesByHashesRequest = (hashes: Uint8Array[]): flatbuffers.GetAllMessagesBySyncIdsRequest => {
-  const hashes_list = hashes.map((hash) => new flatbuffers.SyncIdHashT(Array.from(hash)));
-
-  const builder = new Builder(1);
-  const hashesT = new flatbuffers.GetAllMessagesBySyncIdsRequestT(hashes_list);
-  builder.finish(hashesT.pack(builder));
-  return flatbuffers.GetAllMessagesBySyncIdsRequest.getRootAsGetAllMessagesBySyncIdsRequest(
-    new ByteBuffer(builder.asUint8Array())
-  );
-};

--- a/app/src/rpc/test/ampService.test.ts
+++ b/app/src/rpc/test/ampService.test.ts
@@ -12,7 +12,6 @@ import Engine from '~/storage/engine';
 import { MockHub } from '~/test/mocks';
 import { generateEd25519KeyPair } from '~/utils/crypto';
 import { HubError } from '~/utils/hubErrors';
-import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.ampService.test');
 const engine = new Engine(db);
@@ -24,7 +23,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
-  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
+  client = new Client(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/app/src/rpc/test/castService.test.ts
+++ b/app/src/rpc/test/castService.test.ts
@@ -12,7 +12,6 @@ import Engine from '~/storage/engine';
 import { MockHub } from '~/test/mocks';
 import { generateEd25519KeyPair } from '~/utils/crypto';
 import { HubError } from '~/utils/hubErrors';
-import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.castService.test');
 const engine = new Engine(db);
@@ -24,7 +23,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
-  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
+  client = new Client(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/app/src/rpc/test/eventService.test.ts
+++ b/app/src/rpc/test/eventService.test.ts
@@ -13,7 +13,6 @@ import { jestRocksDB } from '~/storage/db/jestUtils';
 import Engine from '~/storage/engine';
 import { MockHub } from '~/test/mocks';
 import { generateEd25519KeyPair, sleep } from '~/utils/crypto';
-import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.eventService.test');
 const engine = new Engine(db);
@@ -25,7 +24,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
-  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
+  client = new Client(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/app/src/rpc/test/reactionService.test.ts
+++ b/app/src/rpc/test/reactionService.test.ts
@@ -12,7 +12,6 @@ import Engine from '~/storage/engine';
 import { MockHub } from '~/test/mocks';
 import { generateEd25519KeyPair } from '~/utils/crypto';
 import { HubError } from '~/utils/hubErrors';
-import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.reactionService.test');
 const engine = new Engine(db);
@@ -24,7 +23,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
-  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
+  client = new Client(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/app/src/rpc/test/signerService.test.ts
+++ b/app/src/rpc/test/signerService.test.ts
@@ -11,7 +11,6 @@ import Engine from '~/storage/engine';
 import { MockHub } from '~/test/mocks';
 import { generateEd25519KeyPair } from '~/utils/crypto';
 import { HubError } from '~/utils/hubErrors';
-import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.signerService.test');
 const engine = new Engine(db);
@@ -23,7 +22,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
-  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
+  client = new Client(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/app/src/rpc/test/submitService.test.ts
+++ b/app/src/rpc/test/submitService.test.ts
@@ -13,7 +13,6 @@ import Engine from '~/storage/engine';
 import { MockHub } from '~/test/mocks';
 import { generateEd25519KeyPair } from '~/utils/crypto';
 import { HubError } from '~/utils/hubErrors';
-import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.submitService.test');
 const engine = new Engine(db);
@@ -25,7 +24,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
-  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
+  client = new Client(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/app/src/rpc/test/syncService.test.ts
+++ b/app/src/rpc/test/syncService.test.ts
@@ -24,7 +24,6 @@ import Engine from '~/storage/engine';
 import { MockHub } from '~/test/mocks';
 import { generateEd25519KeyPair } from '~/utils/crypto';
 import { HubResult } from '~/utils/hubErrors';
-import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.syncService.test');
 const engine = new Engine(db);
@@ -36,7 +35,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
-  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
+  client = new Client(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/app/src/rpc/test/userDataService.test.ts
+++ b/app/src/rpc/test/userDataService.test.ts
@@ -14,7 +14,6 @@ import Engine from '~/storage/engine';
 import { MockHub } from '~/test/mocks';
 import { generateEd25519KeyPair } from '~/utils/crypto';
 import { HubError } from '~/utils/hubErrors';
-import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.userDataService.test');
 const engine = new Engine(db);
@@ -26,7 +25,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
-  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
+  client = new Client(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/app/src/rpc/test/verificationService.test.ts
+++ b/app/src/rpc/test/verificationService.test.ts
@@ -11,7 +11,6 @@ import Engine from '~/storage/engine';
 import { MockHub } from '~/test/mocks';
 import { generateEd25519KeyPair } from '~/utils/crypto';
 import { HubError } from '~/utils/hubErrors';
-import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.verificationService.test');
 const engine = new Engine(db);
@@ -23,7 +22,7 @@ let client: Client;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
-  client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
+  client = new Client(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {


### PR DESCRIPTION
## Motivation

Client is a folder that will be shared between consumers of the Hub and the Hub itself. It is important that this has as few external dependencies as possible so that it can be easily extracted into a package in the future. Closes #312 

## Change Summary

The 'net', 'logger', 'utils/p2p' dependencies are removed from Client by refactoring hub specific logic into HubRPCClient and introducing ClientError.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)