### PR TITLE
Feat: Hub Sync

### DIFF
--- a/src/flatbuffers/generated/rpc_generated.ts
+++ b/src/flatbuffers/generated/rpc_generated.ts
@@ -12,6 +12,98 @@ export enum EventType {
   MergeContractEvent = 3
 }
 
+export class MessageBytes implements flatbuffers.IUnpackableObject<MessageBytesT> {
+  bb: flatbuffers.ByteBuffer|null = null;
+  bb_pos = 0;
+  __init(i:number, bb:flatbuffers.ByteBuffer):MessageBytes {
+  this.bb_pos = i;
+  this.bb = bb;
+  return this;
+}
+
+static getRootAsMessageBytes(bb:flatbuffers.ByteBuffer, obj?:MessageBytes):MessageBytes {
+  return (obj || new MessageBytes()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+static getSizePrefixedRootAsMessageBytes(bb:flatbuffers.ByteBuffer, obj?:MessageBytes):MessageBytes {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new MessageBytes()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+messageBytes(index: number):number|null {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.readUint8(this.bb!.__vector(this.bb_pos + offset) + index) : 0;
+}
+
+messageBytesLength():number {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
+}
+
+messageBytesArray():Uint8Array|null {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? new Uint8Array(this.bb!.bytes().buffer, this.bb!.bytes().byteOffset + this.bb!.__vector(this.bb_pos + offset), this.bb!.__vector_len(this.bb_pos + offset)) : null;
+}
+
+static startMessageBytes(builder:flatbuffers.Builder) {
+  builder.startObject(1);
+}
+
+static addMessageBytes(builder:flatbuffers.Builder, messageBytesOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(0, messageBytesOffset, 0);
+}
+
+static createMessageBytesVector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset {
+  builder.startVector(1, data.length, 1);
+  for (let i = data.length - 1; i >= 0; i--) {
+    builder.addInt8(data[i]!);
+  }
+  return builder.endVector();
+}
+
+static startMessageBytesVector(builder:flatbuffers.Builder, numElems:number) {
+  builder.startVector(1, numElems, 1);
+}
+
+static endMessageBytes(builder:flatbuffers.Builder):flatbuffers.Offset {
+  const offset = builder.endObject();
+  builder.requiredField(offset, 4) // message_bytes
+  return offset;
+}
+
+static createMessageBytes(builder:flatbuffers.Builder, messageBytesOffset:flatbuffers.Offset):flatbuffers.Offset {
+  MessageBytes.startMessageBytes(builder);
+  MessageBytes.addMessageBytes(builder, messageBytesOffset);
+  return MessageBytes.endMessageBytes(builder);
+}
+
+unpack(): MessageBytesT {
+  return new MessageBytesT(
+    this.bb!.createScalarList<number>(this.messageBytes.bind(this), this.messageBytesLength())
+  );
+}
+
+
+unpackTo(_o: MessageBytesT): void {
+  _o.messageBytes = this.bb!.createScalarList<number>(this.messageBytes.bind(this), this.messageBytesLength());
+}
+}
+
+export class MessageBytesT implements flatbuffers.IGeneratedObject {
+constructor(
+  public messageBytes: (number)[] = []
+){}
+
+
+pack(builder:flatbuffers.Builder): flatbuffers.Offset {
+  const messageBytes = MessageBytes.createMessageBytesVector(builder, this.messageBytes);
+
+  return MessageBytes.createMessageBytes(builder,
+    messageBytes
+  );
+}
+}
+
 export class MessagesResponse implements flatbuffers.IUnpackableObject<MessagesResponseT> {
   bb: flatbuffers.ByteBuffer|null = null;
   bb_pos = 0;
@@ -30,9 +122,9 @@ static getSizePrefixedRootAsMessagesResponse(bb:flatbuffers.ByteBuffer, obj?:Mes
   return (obj || new MessagesResponse()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 }
 
-messages(index: number, obj?:Message):Message|null {
+messages(index: number, obj?:MessageBytes):MessageBytes|null {
   const offset = this.bb!.__offset(this.bb_pos, 4);
-  return offset ? (obj || new Message()).__init(this.bb!.__indirect(this.bb!.__vector(this.bb_pos + offset) + index * 4), this.bb!) : null;
+  return offset ? (obj || new MessageBytes()).__init(this.bb!.__indirect(this.bb!.__vector(this.bb_pos + offset) + index * 4), this.bb!) : null;
 }
 
 messagesLength():number {
@@ -73,19 +165,19 @@ static createMessagesResponse(builder:flatbuffers.Builder, messagesOffset:flatbu
 
 unpack(): MessagesResponseT {
   return new MessagesResponseT(
-    this.bb!.createObjList<Message, MessageT>(this.messages.bind(this), this.messagesLength())
+    this.bb!.createObjList<MessageBytes, MessageBytesT>(this.messages.bind(this), this.messagesLength())
   );
 }
 
 
 unpackTo(_o: MessagesResponseT): void {
-  _o.messages = this.bb!.createObjList<Message, MessageT>(this.messages.bind(this), this.messagesLength());
+  _o.messages = this.bb!.createObjList<MessageBytes, MessageBytesT>(this.messages.bind(this), this.messagesLength());
 }
 }
 
 export class MessagesResponseT implements flatbuffers.IGeneratedObject {
 constructor(
-  public messages: (MessageT)[] = []
+  public messages: (MessageBytesT)[] = []
 ){}
 
 
@@ -273,6 +365,180 @@ pack(builder:flatbuffers.Builder): flatbuffers.Offset {
   EventResponse.addContractEvent(builder, contractEvent);
 
   return EventResponse.endEventResponse(builder);
+}
+}
+
+export class TrieNodeMetadataResponse implements flatbuffers.IUnpackableObject<TrieNodeMetadataResponseT> {
+  bb: flatbuffers.ByteBuffer|null = null;
+  bb_pos = 0;
+  __init(i:number, bb:flatbuffers.ByteBuffer):TrieNodeMetadataResponse {
+  this.bb_pos = i;
+  this.bb = bb;
+  return this;
+}
+
+static getRootAsTrieNodeMetadataResponse(bb:flatbuffers.ByteBuffer, obj?:TrieNodeMetadataResponse):TrieNodeMetadataResponse {
+  return (obj || new TrieNodeMetadataResponse()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+static getSizePrefixedRootAsTrieNodeMetadataResponse(bb:flatbuffers.ByteBuffer, obj?:TrieNodeMetadataResponse):TrieNodeMetadataResponse {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new TrieNodeMetadataResponse()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+prefix(index: number):number|null {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.readUint8(this.bb!.__vector(this.bb_pos + offset) + index) : 0;
+}
+
+prefixLength():number {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
+}
+
+prefixArray():Uint8Array|null {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? new Uint8Array(this.bb!.bytes().buffer, this.bb!.bytes().byteOffset + this.bb!.__vector(this.bb_pos + offset), this.bb!.__vector_len(this.bb_pos + offset)) : null;
+}
+
+numMessages():bigint {
+  const offset = this.bb!.__offset(this.bb_pos, 6);
+  return offset ? this.bb!.readUint64(this.bb_pos + offset) : BigInt('0');
+}
+
+hash(index: number):number|null {
+  const offset = this.bb!.__offset(this.bb_pos, 8);
+  return offset ? this.bb!.readUint8(this.bb!.__vector(this.bb_pos + offset) + index) : 0;
+}
+
+hashLength():number {
+  const offset = this.bb!.__offset(this.bb_pos, 8);
+  return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
+}
+
+hashArray():Uint8Array|null {
+  const offset = this.bb!.__offset(this.bb_pos, 8);
+  return offset ? new Uint8Array(this.bb!.bytes().buffer, this.bb!.bytes().byteOffset + this.bb!.__vector(this.bb_pos + offset), this.bb!.__vector_len(this.bb_pos + offset)) : null;
+}
+
+children(index: number, obj?:TrieNodeMetadataResponse):TrieNodeMetadataResponse|null {
+  const offset = this.bb!.__offset(this.bb_pos, 10);
+  return offset ? (obj || new TrieNodeMetadataResponse()).__init(this.bb!.__indirect(this.bb!.__vector(this.bb_pos + offset) + index * 4), this.bb!) : null;
+}
+
+childrenLength():number {
+  const offset = this.bb!.__offset(this.bb_pos, 10);
+  return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
+}
+
+static startTrieNodeMetadataResponse(builder:flatbuffers.Builder) {
+  builder.startObject(4);
+}
+
+static addPrefix(builder:flatbuffers.Builder, prefixOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(0, prefixOffset, 0);
+}
+
+static createPrefixVector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset {
+  builder.startVector(1, data.length, 1);
+  for (let i = data.length - 1; i >= 0; i--) {
+    builder.addInt8(data[i]!);
+  }
+  return builder.endVector();
+}
+
+static startPrefixVector(builder:flatbuffers.Builder, numElems:number) {
+  builder.startVector(1, numElems, 1);
+}
+
+static addNumMessages(builder:flatbuffers.Builder, numMessages:bigint) {
+  builder.addFieldInt64(1, numMessages, BigInt('0'));
+}
+
+static addHash(builder:flatbuffers.Builder, hashOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(2, hashOffset, 0);
+}
+
+static createHashVector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset {
+  builder.startVector(1, data.length, 1);
+  for (let i = data.length - 1; i >= 0; i--) {
+    builder.addInt8(data[i]!);
+  }
+  return builder.endVector();
+}
+
+static startHashVector(builder:flatbuffers.Builder, numElems:number) {
+  builder.startVector(1, numElems, 1);
+}
+
+static addChildren(builder:flatbuffers.Builder, childrenOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(3, childrenOffset, 0);
+}
+
+static createChildrenVector(builder:flatbuffers.Builder, data:flatbuffers.Offset[]):flatbuffers.Offset {
+  builder.startVector(4, data.length, 4);
+  for (let i = data.length - 1; i >= 0; i--) {
+    builder.addOffset(data[i]!);
+  }
+  return builder.endVector();
+}
+
+static startChildrenVector(builder:flatbuffers.Builder, numElems:number) {
+  builder.startVector(4, numElems, 4);
+}
+
+static endTrieNodeMetadataResponse(builder:flatbuffers.Builder):flatbuffers.Offset {
+  const offset = builder.endObject();
+  return offset;
+}
+
+static createTrieNodeMetadataResponse(builder:flatbuffers.Builder, prefixOffset:flatbuffers.Offset, numMessages:bigint, hashOffset:flatbuffers.Offset, childrenOffset:flatbuffers.Offset):flatbuffers.Offset {
+  TrieNodeMetadataResponse.startTrieNodeMetadataResponse(builder);
+  TrieNodeMetadataResponse.addPrefix(builder, prefixOffset);
+  TrieNodeMetadataResponse.addNumMessages(builder, numMessages);
+  TrieNodeMetadataResponse.addHash(builder, hashOffset);
+  TrieNodeMetadataResponse.addChildren(builder, childrenOffset);
+  return TrieNodeMetadataResponse.endTrieNodeMetadataResponse(builder);
+}
+
+unpack(): TrieNodeMetadataResponseT {
+  return new TrieNodeMetadataResponseT(
+    this.bb!.createScalarList<number>(this.prefix.bind(this), this.prefixLength()),
+    this.numMessages(),
+    this.bb!.createScalarList<number>(this.hash.bind(this), this.hashLength()),
+    this.bb!.createObjList<TrieNodeMetadataResponse, TrieNodeMetadataResponseT>(this.children.bind(this), this.childrenLength())
+  );
+}
+
+
+unpackTo(_o: TrieNodeMetadataResponseT): void {
+  _o.prefix = this.bb!.createScalarList<number>(this.prefix.bind(this), this.prefixLength());
+  _o.numMessages = this.numMessages();
+  _o.hash = this.bb!.createScalarList<number>(this.hash.bind(this), this.hashLength());
+  _o.children = this.bb!.createObjList<TrieNodeMetadataResponse, TrieNodeMetadataResponseT>(this.children.bind(this), this.childrenLength());
+}
+}
+
+export class TrieNodeMetadataResponseT implements flatbuffers.IGeneratedObject {
+constructor(
+  public prefix: (number)[] = [],
+  public numMessages: bigint = BigInt('0'),
+  public hash: (number)[] = [],
+  public children: (TrieNodeMetadataResponseT)[] = []
+){}
+
+
+pack(builder:flatbuffers.Builder): flatbuffers.Offset {
+  const prefix = TrieNodeMetadataResponse.createPrefixVector(builder, this.prefix);
+  const hash = TrieNodeMetadataResponse.createHashVector(builder, this.hash);
+  const children = TrieNodeMetadataResponse.createChildrenVector(builder, builder.createObjectOffsetList(this.children));
+
+  return TrieNodeMetadataResponse.createTrieNodeMetadataResponse(builder,
+    prefix,
+    this.numMessages,
+    hash,
+    children
+  );
 }
 }
 
@@ -2086,6 +2352,274 @@ pack(builder:flatbuffers.Builder): flatbuffers.Offset {
 }
 }
 
+export class SyncIdHash implements flatbuffers.IUnpackableObject<SyncIdHashT> {
+  bb: flatbuffers.ByteBuffer|null = null;
+  bb_pos = 0;
+  __init(i:number, bb:flatbuffers.ByteBuffer):SyncIdHash {
+  this.bb_pos = i;
+  this.bb = bb;
+  return this;
+}
+
+static getRootAsSyncIdHash(bb:flatbuffers.ByteBuffer, obj?:SyncIdHash):SyncIdHash {
+  return (obj || new SyncIdHash()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+static getSizePrefixedRootAsSyncIdHash(bb:flatbuffers.ByteBuffer, obj?:SyncIdHash):SyncIdHash {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new SyncIdHash()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+syncIdHash(index: number):number|null {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.readUint8(this.bb!.__vector(this.bb_pos + offset) + index) : 0;
+}
+
+syncIdHashLength():number {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
+}
+
+syncIdHashArray():Uint8Array|null {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? new Uint8Array(this.bb!.bytes().buffer, this.bb!.bytes().byteOffset + this.bb!.__vector(this.bb_pos + offset), this.bb!.__vector_len(this.bb_pos + offset)) : null;
+}
+
+static startSyncIdHash(builder:flatbuffers.Builder) {
+  builder.startObject(1);
+}
+
+static addSyncIdHash(builder:flatbuffers.Builder, syncIdHashOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(0, syncIdHashOffset, 0);
+}
+
+static createSyncIdHashVector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset {
+  builder.startVector(1, data.length, 1);
+  for (let i = data.length - 1; i >= 0; i--) {
+    builder.addInt8(data[i]!);
+  }
+  return builder.endVector();
+}
+
+static startSyncIdHashVector(builder:flatbuffers.Builder, numElems:number) {
+  builder.startVector(1, numElems, 1);
+}
+
+static endSyncIdHash(builder:flatbuffers.Builder):flatbuffers.Offset {
+  const offset = builder.endObject();
+  builder.requiredField(offset, 4) // sync_id_hash
+  return offset;
+}
+
+static createSyncIdHash(builder:flatbuffers.Builder, syncIdHashOffset:flatbuffers.Offset):flatbuffers.Offset {
+  SyncIdHash.startSyncIdHash(builder);
+  SyncIdHash.addSyncIdHash(builder, syncIdHashOffset);
+  return SyncIdHash.endSyncIdHash(builder);
+}
+
+unpack(): SyncIdHashT {
+  return new SyncIdHashT(
+    this.bb!.createScalarList<number>(this.syncIdHash.bind(this), this.syncIdHashLength())
+  );
+}
+
+
+unpackTo(_o: SyncIdHashT): void {
+  _o.syncIdHash = this.bb!.createScalarList<number>(this.syncIdHash.bind(this), this.syncIdHashLength());
+}
+}
+
+export class SyncIdHashT implements flatbuffers.IGeneratedObject {
+constructor(
+  public syncIdHash: (number)[] = []
+){}
+
+
+pack(builder:flatbuffers.Builder): flatbuffers.Offset {
+  const syncIdHash = SyncIdHash.createSyncIdHashVector(builder, this.syncIdHash);
+
+  return SyncIdHash.createSyncIdHash(builder,
+    syncIdHash
+  );
+}
+}
+
+export class GetAllMessagesBySyncIdsRequest implements flatbuffers.IUnpackableObject<GetAllMessagesBySyncIdsRequestT> {
+  bb: flatbuffers.ByteBuffer|null = null;
+  bb_pos = 0;
+  __init(i:number, bb:flatbuffers.ByteBuffer):GetAllMessagesBySyncIdsRequest {
+  this.bb_pos = i;
+  this.bb = bb;
+  return this;
+}
+
+static getRootAsGetAllMessagesBySyncIdsRequest(bb:flatbuffers.ByteBuffer, obj?:GetAllMessagesBySyncIdsRequest):GetAllMessagesBySyncIdsRequest {
+  return (obj || new GetAllMessagesBySyncIdsRequest()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+static getSizePrefixedRootAsGetAllMessagesBySyncIdsRequest(bb:flatbuffers.ByteBuffer, obj?:GetAllMessagesBySyncIdsRequest):GetAllMessagesBySyncIdsRequest {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new GetAllMessagesBySyncIdsRequest()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+syncIds(index: number, obj?:SyncIdHash):SyncIdHash|null {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? (obj || new SyncIdHash()).__init(this.bb!.__indirect(this.bb!.__vector(this.bb_pos + offset) + index * 4), this.bb!) : null;
+}
+
+syncIdsLength():number {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
+}
+
+static startGetAllMessagesBySyncIdsRequest(builder:flatbuffers.Builder) {
+  builder.startObject(1);
+}
+
+static addSyncIds(builder:flatbuffers.Builder, syncIdsOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(0, syncIdsOffset, 0);
+}
+
+static createSyncIdsVector(builder:flatbuffers.Builder, data:flatbuffers.Offset[]):flatbuffers.Offset {
+  builder.startVector(4, data.length, 4);
+  for (let i = data.length - 1; i >= 0; i--) {
+    builder.addOffset(data[i]!);
+  }
+  return builder.endVector();
+}
+
+static startSyncIdsVector(builder:flatbuffers.Builder, numElems:number) {
+  builder.startVector(4, numElems, 4);
+}
+
+static endGetAllMessagesBySyncIdsRequest(builder:flatbuffers.Builder):flatbuffers.Offset {
+  const offset = builder.endObject();
+  builder.requiredField(offset, 4) // sync_ids
+  return offset;
+}
+
+static createGetAllMessagesBySyncIdsRequest(builder:flatbuffers.Builder, syncIdsOffset:flatbuffers.Offset):flatbuffers.Offset {
+  GetAllMessagesBySyncIdsRequest.startGetAllMessagesBySyncIdsRequest(builder);
+  GetAllMessagesBySyncIdsRequest.addSyncIds(builder, syncIdsOffset);
+  return GetAllMessagesBySyncIdsRequest.endGetAllMessagesBySyncIdsRequest(builder);
+}
+
+unpack(): GetAllMessagesBySyncIdsRequestT {
+  return new GetAllMessagesBySyncIdsRequestT(
+    this.bb!.createObjList<SyncIdHash, SyncIdHashT>(this.syncIds.bind(this), this.syncIdsLength())
+  );
+}
+
+
+unpackTo(_o: GetAllMessagesBySyncIdsRequestT): void {
+  _o.syncIds = this.bb!.createObjList<SyncIdHash, SyncIdHashT>(this.syncIds.bind(this), this.syncIdsLength());
+}
+}
+
+export class GetAllMessagesBySyncIdsRequestT implements flatbuffers.IGeneratedObject {
+constructor(
+  public syncIds: (SyncIdHashT)[] = []
+){}
+
+
+pack(builder:flatbuffers.Builder): flatbuffers.Offset {
+  const syncIds = GetAllMessagesBySyncIdsRequest.createSyncIdsVector(builder, builder.createObjectOffsetList(this.syncIds));
+
+  return GetAllMessagesBySyncIdsRequest.createGetAllMessagesBySyncIdsRequest(builder,
+    syncIds
+  );
+}
+}
+
+export class GetAllSyncIdsByPrefixResponse implements flatbuffers.IUnpackableObject<GetAllSyncIdsByPrefixResponseT> {
+  bb: flatbuffers.ByteBuffer|null = null;
+  bb_pos = 0;
+  __init(i:number, bb:flatbuffers.ByteBuffer):GetAllSyncIdsByPrefixResponse {
+  this.bb_pos = i;
+  this.bb = bb;
+  return this;
+}
+
+static getRootAsGetAllSyncIdsByPrefixResponse(bb:flatbuffers.ByteBuffer, obj?:GetAllSyncIdsByPrefixResponse):GetAllSyncIdsByPrefixResponse {
+  return (obj || new GetAllSyncIdsByPrefixResponse()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+static getSizePrefixedRootAsGetAllSyncIdsByPrefixResponse(bb:flatbuffers.ByteBuffer, obj?:GetAllSyncIdsByPrefixResponse):GetAllSyncIdsByPrefixResponse {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new GetAllSyncIdsByPrefixResponse()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+ids(index: number):string
+ids(index: number,optionalEncoding:flatbuffers.Encoding):string|Uint8Array
+ids(index: number,optionalEncoding?:any):string|Uint8Array|null {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.__string(this.bb!.__vector(this.bb_pos + offset) + index * 4, optionalEncoding) : null;
+}
+
+idsLength():number {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
+}
+
+static startGetAllSyncIdsByPrefixResponse(builder:flatbuffers.Builder) {
+  builder.startObject(1);
+}
+
+static addIds(builder:flatbuffers.Builder, idsOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(0, idsOffset, 0);
+}
+
+static createIdsVector(builder:flatbuffers.Builder, data:flatbuffers.Offset[]):flatbuffers.Offset {
+  builder.startVector(4, data.length, 4);
+  for (let i = data.length - 1; i >= 0; i--) {
+    builder.addOffset(data[i]!);
+  }
+  return builder.endVector();
+}
+
+static startIdsVector(builder:flatbuffers.Builder, numElems:number) {
+  builder.startVector(4, numElems, 4);
+}
+
+static endGetAllSyncIdsByPrefixResponse(builder:flatbuffers.Builder):flatbuffers.Offset {
+  const offset = builder.endObject();
+  builder.requiredField(offset, 4) // ids
+  return offset;
+}
+
+static createGetAllSyncIdsByPrefixResponse(builder:flatbuffers.Builder, idsOffset:flatbuffers.Offset):flatbuffers.Offset {
+  GetAllSyncIdsByPrefixResponse.startGetAllSyncIdsByPrefixResponse(builder);
+  GetAllSyncIdsByPrefixResponse.addIds(builder, idsOffset);
+  return GetAllSyncIdsByPrefixResponse.endGetAllSyncIdsByPrefixResponse(builder);
+}
+
+unpack(): GetAllSyncIdsByPrefixResponseT {
+  return new GetAllSyncIdsByPrefixResponseT(
+    this.bb!.createScalarList<string>(this.ids.bind(this), this.idsLength())
+  );
+}
+
+
+unpackTo(_o: GetAllSyncIdsByPrefixResponseT): void {
+  _o.ids = this.bb!.createScalarList<string>(this.ids.bind(this), this.idsLength());
+}
+}
+
+export class GetAllSyncIdsByPrefixResponseT implements flatbuffers.IGeneratedObject {
+constructor(
+  public ids: (string)[] = []
+){}
+
+
+pack(builder:flatbuffers.Builder): flatbuffers.Offset {
+  const ids = GetAllSyncIdsByPrefixResponse.createIdsVector(builder, builder.createObjectOffsetList(this.ids));
+
+  return GetAllSyncIdsByPrefixResponse.createGetAllSyncIdsByPrefixResponse(builder,
+    ids
+  );
+}
+}
+
 export class GetAllMessagesByFidRequest implements flatbuffers.IUnpackableObject<GetAllMessagesByFidRequestT> {
   bb: flatbuffers.ByteBuffer|null = null;
   bb_pos = 0;
@@ -2174,6 +2708,98 @@ pack(builder:flatbuffers.Builder): flatbuffers.Offset {
 
   return GetAllMessagesByFidRequest.createGetAllMessagesByFidRequest(builder,
     fid
+  );
+}
+}
+
+export class GetTrieNodesByPrefixRequest implements flatbuffers.IUnpackableObject<GetTrieNodesByPrefixRequestT> {
+  bb: flatbuffers.ByteBuffer|null = null;
+  bb_pos = 0;
+  __init(i:number, bb:flatbuffers.ByteBuffer):GetTrieNodesByPrefixRequest {
+  this.bb_pos = i;
+  this.bb = bb;
+  return this;
+}
+
+static getRootAsGetTrieNodesByPrefixRequest(bb:flatbuffers.ByteBuffer, obj?:GetTrieNodesByPrefixRequest):GetTrieNodesByPrefixRequest {
+  return (obj || new GetTrieNodesByPrefixRequest()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+static getSizePrefixedRootAsGetTrieNodesByPrefixRequest(bb:flatbuffers.ByteBuffer, obj?:GetTrieNodesByPrefixRequest):GetTrieNodesByPrefixRequest {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new GetTrieNodesByPrefixRequest()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+prefix(index: number):number|null {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.readUint8(this.bb!.__vector(this.bb_pos + offset) + index) : 0;
+}
+
+prefixLength():number {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
+}
+
+prefixArray():Uint8Array|null {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? new Uint8Array(this.bb!.bytes().buffer, this.bb!.bytes().byteOffset + this.bb!.__vector(this.bb_pos + offset), this.bb!.__vector_len(this.bb_pos + offset)) : null;
+}
+
+static startGetTrieNodesByPrefixRequest(builder:flatbuffers.Builder) {
+  builder.startObject(1);
+}
+
+static addPrefix(builder:flatbuffers.Builder, prefixOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(0, prefixOffset, 0);
+}
+
+static createPrefixVector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset {
+  builder.startVector(1, data.length, 1);
+  for (let i = data.length - 1; i >= 0; i--) {
+    builder.addInt8(data[i]!);
+  }
+  return builder.endVector();
+}
+
+static startPrefixVector(builder:flatbuffers.Builder, numElems:number) {
+  builder.startVector(1, numElems, 1);
+}
+
+static endGetTrieNodesByPrefixRequest(builder:flatbuffers.Builder):flatbuffers.Offset {
+  const offset = builder.endObject();
+  builder.requiredField(offset, 4) // prefix
+  return offset;
+}
+
+static createGetTrieNodesByPrefixRequest(builder:flatbuffers.Builder, prefixOffset:flatbuffers.Offset):flatbuffers.Offset {
+  GetTrieNodesByPrefixRequest.startGetTrieNodesByPrefixRequest(builder);
+  GetTrieNodesByPrefixRequest.addPrefix(builder, prefixOffset);
+  return GetTrieNodesByPrefixRequest.endGetTrieNodesByPrefixRequest(builder);
+}
+
+unpack(): GetTrieNodesByPrefixRequestT {
+  return new GetTrieNodesByPrefixRequestT(
+    this.bb!.createScalarList<number>(this.prefix.bind(this), this.prefixLength())
+  );
+}
+
+
+unpackTo(_o: GetTrieNodesByPrefixRequestT): void {
+  _o.prefix = this.bb!.createScalarList<number>(this.prefix.bind(this), this.prefixLength());
+}
+}
+
+export class GetTrieNodesByPrefixRequestT implements flatbuffers.IGeneratedObject {
+constructor(
+  public prefix: (number)[] = []
+){}
+
+
+pack(builder:flatbuffers.Builder): flatbuffers.Offset {
+  const prefix = GetTrieNodesByPrefixRequest.createPrefixVector(builder, this.prefix);
+
+  return GetTrieNodesByPrefixRequest.createGetTrieNodesByPrefixRequest(builder,
+    prefix
   );
 }
 }

--- a/src/flatbuffers/models/hubStateModel.ts
+++ b/src/flatbuffers/models/hubStateModel.ts
@@ -1,4 +1,4 @@
-import { Builder, ByteBuffer } from 'flatbuffers';
+import { ByteBuffer } from 'flatbuffers';
 import { HubState } from '~/flatbuffers/generated/hub_state_generated';
 import { RootPrefix } from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
@@ -38,10 +38,7 @@ export default class HubStateModel {
   }
 
   toBytes(): Uint8Array {
-    const builder = new Builder(1);
-    const stateT = this.state.unpack();
-    builder.finish(stateT.pack(builder));
-    return builder.asUint8Array();
+    return this.state.bb?.bytes() || new Uint8Array();
   }
 
   lastEthBlock(): bigint {

--- a/src/flatbuffers/models/idRegistryEventModel.ts
+++ b/src/flatbuffers/models/idRegistryEventModel.ts
@@ -1,4 +1,4 @@
-import { Builder, ByteBuffer } from 'flatbuffers';
+import { ByteBuffer } from 'flatbuffers';
 import { IdRegistryEvent, IdRegistryEventType } from '~/flatbuffers/generated/id_registry_event_generated';
 import { RootPrefix } from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
@@ -77,10 +77,7 @@ export default class IdRegistryEventModel {
   }
 
   toBytes(): Uint8Array {
-    const builder = new Builder(1);
-    const eventT = this.event.unpack();
-    builder.finish(eventT.pack(builder));
-    return builder.asUint8Array();
+    return this.event.bb?.bytes() || new Uint8Array();
   }
 
   blockNumber(): number {

--- a/src/flatbuffers/models/messageModel.ts
+++ b/src/flatbuffers/models/messageModel.ts
@@ -1,4 +1,4 @@
-import { Builder, ByteBuffer } from 'flatbuffers';
+import { ByteBuffer } from 'flatbuffers';
 import AbstractRocksDB from 'rocksdb';
 import * as message_generated from '~/flatbuffers/generated/message_generated';
 import { RootPrefix, UserMessagePostfix, UserPostfix } from '~/flatbuffers/models/types';
@@ -222,10 +222,7 @@ export default class MessageModel {
   }
 
   dataBytes(): Uint8Array {
-    const builder = new Builder(1);
-    const dataT = this.data.unpack();
-    builder.finish(dataT.pack(builder));
-    return builder.asUint8Array();
+    return this.data.bb?.bytes() ?? new Uint8Array();
   }
 
   primaryKey(): Buffer {
@@ -241,10 +238,7 @@ export default class MessageModel {
   }
 
   toBytes(): Uint8Array {
-    const builder = new Builder(1);
-    const messageT = this.message.unpack();
-    builder.finish(messageT.pack(builder));
-    return builder.asUint8Array();
+    return this.message.bb?.bytes() ?? new Uint8Array();
   }
 
   tsHash(): Uint8Array {

--- a/src/flatbuffers/models/nameRegistryEventModel.ts
+++ b/src/flatbuffers/models/nameRegistryEventModel.ts
@@ -1,4 +1,4 @@
-import { Builder, ByteBuffer } from 'flatbuffers';
+import { ByteBuffer } from 'flatbuffers';
 import { NameRegistryEvent, NameRegistryEventType } from '~/flatbuffers/generated/name_registry_event_generated';
 import { RootPrefix } from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
@@ -57,10 +57,7 @@ export default class NameRegistryEventModel {
   }
 
   toBytes(): Uint8Array {
-    const builder = new Builder(1);
-    const eventT = this.event.unpack();
-    builder.finish(eventT.pack(builder));
-    return builder.asUint8Array();
+    return this.event.bb?.bytes() || new Uint8Array();
   }
 
   blockNumber(): number {

--- a/src/flatbuffers/schemas/rpc.fbs
+++ b/src/flatbuffers/schemas/rpc.fbs
@@ -13,9 +13,12 @@ enum EventType: uint8 {
 }
 
 // Responses
+table MessageBytes {
+  message_bytes: [ubyte] (nested_flatbuffer: "Farcaster.Message", required);
+}
 
 table MessagesResponse {
-  messages: [Message];
+  messages: [MessageBytes];
 }
 
 table FidsResponse {
@@ -26,6 +29,14 @@ table EventResponse {
   type: EventType;
   message: Message;
   contract_event: IdRegistryEvent;
+}
+
+// A partial trie node response
+table TrieNodeMetadataResponse {
+  prefix: [ubyte];
+  num_messages: uint64;
+  hash: [ubyte];
+  children: [TrieNodeMetadataResponse]; 
 }
 
 // Cast Requests
@@ -124,9 +135,24 @@ table GetUserNameRequest {
 }
 
 // Sync Requests
+table SyncIdHash {
+  sync_id_hash: [ubyte] (required);
+}
+
+table GetAllMessagesBySyncIdsRequest {
+  sync_ids: [SyncIdHash] (required);
+}
+
+table GetAllSyncIdsByPrefixResponse {
+  ids: [string] (required);
+}
 
 table GetAllMessagesByFidRequest {
   fid: [ubyte] (required);
+}
+
+table GetTrieNodesByPrefixRequest {
+  prefix: [ubyte] (required);
 }
 
 // Events Requests

--- a/src/network/sync/merkleTrie.test.ts
+++ b/src/network/sync/merkleTrie.test.ts
@@ -1,0 +1,297 @@
+import { createHash } from 'crypto';
+import Factories from '~/flatbuffers/factories';
+import { MerkleTrie } from '~/network/sync/merkleTrie';
+
+const emptyHash = createHash('sha256').digest('hex');
+
+describe('MerkleTrie', () => {
+  const trieWithIds = async (timestamps: number[]) => {
+    const syncIds = await Promise.all(
+      timestamps.map(async (t) => {
+        return await Factories.SyncId.create(undefined, { transient: { date: new Date(t * 1000) } });
+      })
+    );
+    const trie = new MerkleTrie();
+    syncIds.forEach((id) => trie.insert(id));
+    return trie;
+  };
+
+  describe('insert', () => {
+    test('succeeds inserting a single item', async () => {
+      const trie = new MerkleTrie();
+      const syncId = await Factories.SyncId.create();
+
+      expect(trie.items).toEqual(0);
+      expect(trie.rootHash).toEqual('');
+
+      trie.insert(syncId);
+
+      expect(trie.items).toEqual(1);
+      expect(trie.rootHash).toBeTruthy();
+    });
+
+    test('inserts are idempotent', async () => {
+      const syncId1 = await Factories.SyncId.create();
+      const syncId2 = await Factories.SyncId.create();
+
+      const firstTrie = new MerkleTrie();
+      firstTrie.insert(syncId1);
+      firstTrie.insert(syncId2);
+
+      const secondTrie = new MerkleTrie();
+      secondTrie.insert(syncId2);
+      secondTrie.insert(syncId1);
+
+      // Order does not matter
+      expect(firstTrie.rootHash).toEqual(secondTrie.rootHash);
+      expect(firstTrie.items).toEqual(secondTrie.items);
+      expect(firstTrie.rootHash).toBeTruthy();
+
+      firstTrie.insert(syncId2);
+      secondTrie.insert(syncId1);
+
+      // Re-adding same item does not change the hash
+      expect(firstTrie.rootHash).toEqual(secondTrie.rootHash);
+      expect(firstTrie.items).toEqual(secondTrie.items);
+      expect(firstTrie.items).toEqual(2);
+    });
+
+    test('insert multiple items out of order results in the same root hash', async () => {
+      const syncIds = await Factories.SyncId.createList(25);
+
+      const firstTrie = new MerkleTrie();
+      const secondTrie = new MerkleTrie();
+
+      syncIds.forEach((syncId) => firstTrie.insert(syncId));
+      const shuffledIds = syncIds.sort(() => 0.5 - Math.random());
+      shuffledIds.forEach((syncId) => secondTrie.insert(syncId));
+
+      expect(firstTrie.rootHash).toEqual(secondTrie.rootHash);
+      expect(firstTrie.rootHash).toBeTruthy();
+      expect(firstTrie.items).toEqual(secondTrie.items);
+      expect(firstTrie.items).toEqual(25);
+    });
+  });
+
+  describe('delete', () => {
+    test('deletes an item', async () => {
+      const syncId = await Factories.SyncId.create();
+
+      const trie = new MerkleTrie();
+      trie.insert(syncId);
+      expect(trie.items).toEqual(1);
+      expect(trie.rootHash).toBeTruthy();
+      expect(trie.get(syncId)).toBeTruthy();
+
+      trie.delete(syncId);
+      expect(trie.items).toEqual(0);
+      expect(trie.rootHash).toEqual(emptyHash);
+      expect(trie.get(syncId)).toBeFalsy();
+    });
+
+    test('deleting an item that does not exist does not change the trie', async () => {
+      const syncId = await Factories.SyncId.create();
+      const trie = new MerkleTrie();
+      trie.insert(syncId);
+
+      const rootHashBeforeDelete = trie.rootHash;
+      const syncId2 = await Factories.SyncId.create();
+      trie.delete(syncId2);
+
+      const rootHashAfterDelete = trie.rootHash;
+      expect(rootHashAfterDelete).toEqual(rootHashBeforeDelete);
+      expect(trie.items).toEqual(1);
+    });
+
+    test('delete is an exact inverse of insert', async () => {
+      const syncId1 = await Factories.SyncId.create();
+      const syncId2 = await Factories.SyncId.create();
+
+      const trie = new MerkleTrie();
+      trie.insert(syncId1);
+      const rootHashBeforeDelete = trie.rootHash;
+      trie.insert(syncId2);
+
+      trie.delete(syncId2);
+      expect(trie.rootHash).toEqual(rootHashBeforeDelete);
+    });
+
+    test('trie with a deleted item is the same as a trie with the item never added', async () => {
+      const syncId1 = await Factories.SyncId.create();
+      const syncId2 = await Factories.SyncId.create();
+
+      const firstTrie = new MerkleTrie();
+      firstTrie.insert(syncId1);
+      firstTrie.insert(syncId2);
+
+      firstTrie.delete(syncId1);
+
+      const secondTrie = new MerkleTrie();
+      secondTrie.insert(syncId2);
+
+      expect(firstTrie.rootHash).toEqual(secondTrie.rootHash);
+      expect(firstTrie.rootHash).toBeTruthy();
+      expect(firstTrie.items).toEqual(secondTrie.items);
+      expect(firstTrie.items).toEqual(1);
+    });
+  });
+
+  test('succeeds getting single item', async () => {
+    const trie = new MerkleTrie();
+    const syncId = await Factories.SyncId.create();
+
+    expect(trie.get(syncId)).toBeFalsy();
+
+    trie.insert(syncId);
+
+    expect(trie.get(syncId)).toEqual(syncId.idString());
+
+    const nonExistingSyncId = await Factories.SyncId.create();
+    expect(trie.get(nonExistingSyncId)).toBeFalsy();
+  });
+
+  test('value is always undefined for non-leaf nodes', async () => {
+    const trie = new MerkleTrie();
+    const syncId = await Factories.SyncId.create();
+
+    trie.insert(syncId);
+
+    expect(trie.root.value).toBeFalsy();
+  });
+
+  describe('getNodeMetadata', () => {
+    test('returns undefined if prefix is not present', async () => {
+      const syncId = await Factories.SyncId.create(undefined, { transient: { date: new Date(1665182332000) } });
+      const trie = new MerkleTrie();
+      trie.insert(syncId);
+
+      expect(trie.getTrieNodeMetadata('166518234')).toBeUndefined();
+    });
+
+    test('returns the root metadata if the prefix is empty', async () => {
+      const syncId = await Factories.SyncId.create(undefined, { transient: { date: new Date(1665182332000) } });
+      const trie = new MerkleTrie();
+      trie.insert(syncId);
+
+      const nodeMetadata = trie.getTrieNodeMetadata('');
+      expect(nodeMetadata).toBeDefined();
+      expect(nodeMetadata?.numMessages).toEqual(1);
+      expect(nodeMetadata?.prefix).toEqual('');
+      expect(nodeMetadata?.children?.size).toEqual(1);
+      expect(nodeMetadata?.children?.get('1')).toBeDefined();
+    });
+
+    test('returns the correct metadata if prefix is present', async () => {
+      const trie = await trieWithIds([1665182332, 1665182343]);
+      const nodeMetadata = trie.getTrieNodeMetadata('16651823');
+
+      expect(nodeMetadata).toBeDefined();
+      expect(nodeMetadata?.numMessages).toEqual(2);
+      expect(nodeMetadata?.prefix).toEqual('16651823');
+      expect(nodeMetadata?.children?.size).toEqual(2);
+      expect(nodeMetadata?.children?.get('3')).toBeDefined();
+      expect(nodeMetadata?.children?.get('4')).toBeDefined();
+    });
+  });
+
+  describe('getSnapshot', () => {
+    test('returns basic information', async () => {
+      const trie = await trieWithIds([1665182332, 1665182343]);
+
+      const snapshot = trie.getSnapshot('1665182343');
+      expect(snapshot.prefix).toEqual('1665182343');
+      expect(snapshot.numMessages).toEqual(1);
+      expect(snapshot.excludedHashes.length).toEqual('1665182343'.length);
+    });
+
+    test('returns early when prefix is only partially present', async () => {
+      const trie = await trieWithIds([1665182332, 1665182343]);
+
+      const snapshot = trie.getSnapshot('1677123');
+      expect(snapshot.prefix).toEqual('167');
+      expect(snapshot.numMessages).toEqual(2);
+      expect(snapshot.excludedHashes.length).toEqual('167'.length);
+    });
+
+    test('excluded hashes excludes the prefix char at every level', async () => {
+      const trie = await trieWithIds([1665182332, 1665182343, 1665182345, 1665182351]);
+      let snapshot = trie.getSnapshot('1665182351');
+      let node = trie.getTrieNodeMetadata('16651823');
+      // We expect the excluded hash to be the hash of the 3 and 4 child nodes, and excludes the 5 child node
+      const expectedHash = createHash('sha256')
+        .update(node?.children?.get('3')?.hash || '')
+        .update(node?.children?.get('4')?.hash || '')
+        .digest('hex');
+      expect(snapshot.excludedHashes).toEqual([
+        emptyHash, // 1, these are empty because there are no other children at this level
+        emptyHash, // 6
+        emptyHash, // 6
+        emptyHash, // 5
+        emptyHash, // 1
+        emptyHash, // 8
+        emptyHash, // 2
+        emptyHash, // 3
+        expectedHash, // 5 (hash of the 3 and 4 child node hashes)
+        emptyHash, // 1
+      ]);
+
+      snapshot = trie.getSnapshot('1665182343');
+      node = trie.getTrieNodeMetadata('166518234');
+      const expectedLastHash = createHash('sha256')
+        .update(node?.children?.get('5')?.hash || '')
+        .digest('hex');
+      node = trie.getTrieNodeMetadata('16651823');
+      const expectedPenultimateHash = createHash('sha256')
+        .update(node?.children?.get('3')?.hash || '')
+        .update(node?.children?.get('5')?.hash || '')
+        .digest('hex');
+      expect(snapshot.excludedHashes).toEqual([
+        emptyHash, // 1
+        emptyHash, // 6
+        emptyHash, // 6
+        emptyHash, // 5
+        emptyHash, // 1
+        emptyHash, // 8
+        emptyHash, // 2
+        emptyHash, // 3
+        expectedPenultimateHash, // 4 (hash of the 3 and 5 child node hashes)
+        expectedLastHash, // 3 (hash of the 5 child node hash)
+      ]);
+    });
+  });
+
+  test('getAllValues returns all values for child nodes', async () => {
+    const trie = await trieWithIds([1665182332, 1665182343, 1665182345]);
+
+    let values = trie.root.getNode('16651823')?.getAllValues();
+    expect(values?.length).toEqual(3);
+    values = trie.root.getNode('166518233')?.getAllValues();
+    expect(values?.length).toEqual(1);
+  });
+
+  describe('getDivergencePrefix', () => {
+    test('returns the prefix with the most common excluded hashes', async () => {
+      const trie = await trieWithIds([1665182332, 1665182343, 1665182345]);
+      const prefixToTest = '1665182343';
+      const oldSnapshot = trie.getSnapshot(prefixToTest);
+      trie.insert(await Factories.SyncId.create(undefined, { transient: { date: new Date(1665182353000) } }));
+
+      // Since message above was added at 1665182353, the two tries diverged at 16651823 for our prefix
+      let divergencePrefix = trie.getDivergencePrefix(prefixToTest, oldSnapshot.excludedHashes);
+      expect(divergencePrefix).toEqual('16651823');
+
+      // divergence prefix should be the full prefix, if snapshots are the same
+      const currentSnapshot = trie.getSnapshot(prefixToTest);
+      divergencePrefix = trie.getDivergencePrefix(prefixToTest, currentSnapshot.excludedHashes);
+      expect(divergencePrefix).toEqual(prefixToTest);
+
+      // divergence prefix should empty if excluded hashes are empty
+      divergencePrefix = trie.getDivergencePrefix(prefixToTest, []);
+      expect(divergencePrefix).toEqual('');
+
+      // divergence prefix should be our prefix if provided hashes are longer
+      divergencePrefix = trie.getDivergencePrefix(prefixToTest + '5', [...currentSnapshot.excludedHashes, 'different']);
+      expect(divergencePrefix).toEqual(prefixToTest);
+    });
+  });
+});

--- a/src/network/sync/merkleTrie.ts
+++ b/src/network/sync/merkleTrie.ts
@@ -1,0 +1,105 @@
+import { SyncId } from '~/network/sync/syncId';
+import { TrieNode, TrieSnapshot } from './trieNode';
+
+/**
+ * Represents a node in the trie, and it's immediate children
+ *
+ * @prefix - The prefix of the node, uniquely describes its position in the trie
+ * @numMessages - The number of messages under this node
+ * @hash - The merkle hash of the node
+ * @children - The immediate children of this node
+ */
+export type NodeMetadata = {
+  prefix: string;
+  numMessages: number;
+  hash: string;
+  children?: Map<string, NodeMetadata>;
+};
+
+/**
+ * Represents a MerkleTrie. It's conceptually very similar to a Merkle Patricia Tree (see
+ * https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/).
+ * We don't have extension nodes currently, so this is essentially a Merkle Radix Trie as
+ * defined in the link above.
+ *
+ * The first 10 levels of the trie are used to represent the timestamp of the messages (see SyncID).
+ * The "prefix" refers to a subset of the timestamp string. This is used to determine the state of the trie
+ * (and therefore the hub's messages) at a particular point in time.
+ *
+ * Comparing the state of two tries (represented by the snapshot) for the same prefix allows us to determine
+ * whether two hubs are in sync, and the earliest point of divergence if not.
+ *
+ * Note about concurrency: This class and TrieNode are not thread-safe. This is fine because there are no async
+ * methods, which means the operations won't be interrupted. DO NOT add async methods without considering
+ * impact on concurrency-safety.
+ */
+class MerkleTrie {
+  private readonly _root: TrieNode;
+
+  constructor() {
+    this._root = new TrieNode();
+  }
+
+  public insert(id: SyncId): boolean {
+    // TODO(aditya): Why should key and value be the same? Just remove the value
+    // TODO(aditya): We should insert Uint8Array instead of string
+    return this._root.insert(id.toString(), id.toString());
+  }
+
+  public delete(id: SyncId): boolean {
+    return this._root.delete(id.toString());
+  }
+
+  public get(id: SyncId): string | undefined {
+    return this._root.get(id.toString());
+  }
+
+  // A snapshot captures the state of the trie excluding the nodes
+  // specified in the prefix. See TrieSnapshot for more
+  public getSnapshot(prefix: string): TrieSnapshot {
+    return this._root.getSnapshot(prefix);
+  }
+
+  // Compares excluded hashes of another trie with this trie to determine at which prefix the
+  // states differ. Returns the subset of prefix that's common to both tries.
+  public getDivergencePrefix(prefix: string, excludedHashes: string[]): string {
+    const ourExcludedHashes = this.getSnapshot(prefix).excludedHashes;
+    for (let i = 0; i < prefix.length; i++) {
+      if (ourExcludedHashes[i] !== excludedHashes[i]) {
+        return prefix.slice(0, i);
+      }
+    }
+    return prefix;
+  }
+
+  public getTrieNodeMetadata(prefix: string): NodeMetadata | undefined {
+    const node = this._root.getNode(prefix);
+    if (node === undefined) {
+      return undefined;
+    }
+    const children = node?.children || new Map();
+    const result = new Map<string, NodeMetadata>();
+    for (const [char, child] of children) {
+      result.set(char, {
+        numMessages: child.items,
+        prefix: prefix + char,
+        hash: child.hash,
+      });
+    }
+    return { prefix, children: result, numMessages: node.items, hash: node.hash };
+  }
+
+  public get root(): TrieNode {
+    return this._root;
+  }
+
+  public get items(): number {
+    return this._root.items;
+  }
+
+  public get rootHash(): string {
+    return this._root.hash;
+  }
+}
+
+export { MerkleTrie };

--- a/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/src/network/sync/multiPeerSyncEngine.test.ts
@@ -1,0 +1,193 @@
+import { KeyPair } from '@chainsafe/libp2p-noise/dist/src/@types/libp2p';
+import { utils, Wallet } from 'ethers';
+import Factories from '~/flatbuffers/factories';
+import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
+import MessageModel from '~/flatbuffers/models/messageModel';
+import { SignerAddModel } from '~/flatbuffers/models/types';
+import Client from '~/rpc/client';
+import Server from '~/rpc/server';
+import { jestRocksDB } from '~/storage/db/jestUtils';
+import Engine from '~/storage/engine';
+import { MockHub } from '~/test/mocks';
+import { generateEd25519KeyPair } from '~/utils/crypto';
+import { addressInfoFromParts } from '~/utils/p2p';
+import SyncEngine from './syncEngine';
+
+const TEST_TIMEOUT_LONG = 60 * 1000;
+
+const testDb1 = jestRocksDB(`engine1.peersyncEngine.test`);
+const testDb2 = jestRocksDB(`engine2.peersyncEngine.test`);
+
+const fid = Factories.FID.build();
+const wallet = new Wallet(utils.randomBytes(32));
+
+let custodyEvent: IdRegistryEventModel;
+let signer: KeyPair;
+let signerAdd: SignerAddModel;
+
+beforeAll(async () => {
+  custodyEvent = new IdRegistryEventModel(
+    await Factories.IdRegistryEvent.create(
+      { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid) },
+      { transient: { wallet } }
+    )
+  );
+
+  signer = await generateEd25519KeyPair();
+  const signerAddData = await Factories.SignerAddData.create({
+    body: Factories.SignerBody.build({ signer: Array.from(signer.publicKey) }),
+    fid: Array.from(fid),
+  });
+  signerAdd = new MessageModel(
+    await Factories.Message.create({ data: Array.from(signerAddData.bb?.bytes() ?? []) }, { transient: { wallet } })
+  ) as SignerAddModel;
+});
+
+describe('Multi peer sync engine', () => {
+  const addMessagesWithTimestamps = async (engine: Engine, timestamps: number[]) => {
+    return await Promise.all(
+      timestamps.map(async (t) => {
+        const addData = await Factories.CastAddData.create({ fid: Array.from(fid), timestamp: t });
+        const addMessage = await Factories.Message.create(
+          { data: Array.from(addData.bb?.bytes() ?? []) },
+          { transient: { signer } }
+        );
+        const addMessageModel = new MessageModel(addMessage);
+
+        const result = await engine.mergeMessage(addMessageModel);
+        expect(result.isOk()).toBeTruthy();
+        return Promise.resolve(addMessageModel);
+      })
+    );
+  };
+
+  // Engine 1 is where we add events, and see if engine 2 will sync them
+  let engine1: Engine;
+  let hub1;
+  let syncEngine1: SyncEngine;
+  let server1: Server;
+  let port1;
+  let clientForServer1: Client;
+
+  beforeEach(async () => {
+    // Engine 1 is where we add events, and see if engine 2 will sync them
+    engine1 = new Engine(testDb1);
+    hub1 = new MockHub(testDb1, engine1);
+    syncEngine1 = new SyncEngine(engine1);
+    server1 = new Server(hub1, engine1, syncEngine1);
+    port1 = await server1.start();
+    clientForServer1 = new Client(addressInfoFromParts('127.0.0.1', port1)._unsafeUnwrap());
+  });
+
+  afterEach(async () => {
+    // Cleanup
+    clientForServer1.close();
+    await server1.stop();
+  });
+
+  test('toBytes test', async () => {
+    // Add signer custody event to engine 1
+    await engine1.mergeIdRegistryEvent(custodyEvent);
+    await engine1.mergeMessage(signerAdd);
+
+    // Fetch the signerAdd message from engine 1
+    const rpcResult = await clientForServer1.getAllSignerMessagesByFid(fid);
+    expect(rpcResult.isOk()).toBeTruthy();
+    expect(rpcResult._unsafeUnwrap().length).toEqual(1);
+    const rpcSignerAdd = rpcResult._unsafeUnwrap()[0];
+
+    // Construct the message model from the rpc message bytes.
+    const mm = MessageModel.from(rpcSignerAdd!.toBuffer());
+
+    expect(signerAdd?.toBuffer().toString('hex')).toEqual(rpcSignerAdd?.toBuffer().toString('hex'));
+    expect(mm.fid()).toEqual(signerAdd.fid());
+  });
+
+  test(
+    'two peers should sync',
+    async () => {
+      // Add signer custody event to engine 1
+      await engine1.mergeIdRegistryEvent(custodyEvent);
+      await engine1.mergeMessage(signerAdd);
+
+      // Add messages to engine 1
+      await addMessagesWithTimestamps(engine1, [30662167, 30662169, 30662172]);
+
+      const engine2 = new Engine(testDb2);
+      const syncEngine2 = new SyncEngine(engine2);
+
+      // Engine 2 should sync with no excluded hashes
+      expect(syncEngine2.shouldSync([])).toBeTruthy();
+
+      // Sync engine 2 with engine 1
+      await syncEngine2.performSync([], clientForServer1);
+
+      // Make sure snapshots match
+      expect(syncEngine1.snapshot.excludedHashes).toEqual(syncEngine2.snapshot.excludedHashes);
+      expect(syncEngine1.snapshot.numMessages).toEqual(syncEngine2.snapshot.numMessages);
+
+      // Should sync should now be false with the new excluded hashes
+      expect(syncEngine2.shouldSync(syncEngine1.snapshot.excludedHashes)).toBeFalsy();
+
+      // Add more messages
+      await addMessagesWithTimestamps(engine1, [30663167, 30663169, 30663172]);
+
+      // Should sync should now be true
+      const newSnapshot = syncEngine1.snapshot.excludedHashes;
+      expect(syncEngine2.shouldSync(newSnapshot)).toBeTruthy();
+
+      // Do the sync again
+      await syncEngine2.performSync(newSnapshot, clientForServer1);
+
+      // Make sure snapshots match
+      expect(syncEngine1.snapshot.excludedHashes).toEqual(syncEngine2.snapshot.excludedHashes);
+      expect(syncEngine1.snapshot.numMessages).toEqual(syncEngine2.snapshot.numMessages);
+    },
+    TEST_TIMEOUT_LONG
+  );
+
+  xtest(
+    'loads of messages',
+    async () => {
+      // Add signer custody event to engine 1
+      await engine1.mergeIdRegistryEvent(custodyEvent);
+      await engine1.mergeMessage(signerAdd);
+
+      // Add loads of messages to engine 1
+      let startTime = 30662167;
+      const batchSize = 100;
+      const numBatches = 20;
+      for (let i = 0; i < numBatches; i++) {
+        const timestamps = [];
+        for (let j = 0; j < batchSize; j++) {
+          timestamps.push(startTime + i * batchSize + j);
+        }
+        // console.log('adding batch', i, ' of ', numBatches);
+        await addMessagesWithTimestamps(engine1, timestamps);
+        startTime += batchSize;
+      }
+
+      const engine2 = new Engine(testDb2);
+      const syncEngine2 = new SyncEngine(engine2);
+
+      // Engine 2 should sync with no excluded hashes
+      expect(syncEngine2.shouldSync([])).toBeTruthy();
+
+      await engine2.mergeIdRegistryEvent(custodyEvent);
+      await engine2.mergeMessage(signerAdd);
+
+      // Sync engine 2 with engine 1, and measure the time taken
+      const start = Date.now();
+      await syncEngine2.performSync([], clientForServer1);
+      const end = Date.now();
+
+      const totalTime = (end - start) / 1000;
+      expect(totalTime).toBeGreaterThan(0);
+      // console.log('total time', totalTime, 'seconds. Casts per second:', (numBatches * batchSize) / totalTime);
+
+      expect(syncEngine1.snapshot.excludedHashes).toEqual(syncEngine2.snapshot.excludedHashes);
+      expect(syncEngine1.snapshot.numMessages).toEqual(syncEngine2.snapshot.numMessages);
+    },
+    TEST_TIMEOUT_LONG
+  );
+});

--- a/src/network/sync/syncEngine.test.ts
+++ b/src/network/sync/syncEngine.test.ts
@@ -1,0 +1,198 @@
+import { utils, Wallet } from 'ethers';
+import { ok } from 'neverthrow';
+import { anyString, instance, mock, when } from 'ts-mockito';
+import Factories from '~/flatbuffers/factories';
+import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
+import MessageModel from '~/flatbuffers/models/messageModel';
+import { CastAddModel, KeyPair, SignerAddModel } from '~/flatbuffers/models/types';
+import SyncEngine from '~/network/sync/syncEngine';
+import { SyncId } from '~/network/sync/syncId';
+import Client from '~/rpc/client';
+import { jestRocksDB } from '~/storage/db/jestUtils';
+import Engine from '~/storage/engine';
+import { generateEd25519KeyPair } from '~/utils/crypto';
+
+const testDb = jestRocksDB(`engine.syncEngine.test`);
+const fid = Factories.FID.build();
+const wallet = new Wallet(utils.randomBytes(32));
+
+let custodyEvent: IdRegistryEventModel;
+let signer: KeyPair;
+let signerAdd: SignerAddModel;
+let castAdd: CastAddModel;
+
+beforeAll(async () => {
+  custodyEvent = new IdRegistryEventModel(
+    await Factories.IdRegistryEvent.create(
+      { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid) },
+      { transient: { wallet } }
+    )
+  );
+
+  signer = await generateEd25519KeyPair();
+  const signerAddData = await Factories.SignerAddData.create({
+    body: Factories.SignerBody.build({ signer: Array.from(signer.publicKey) }),
+    fid: Array.from(fid),
+  });
+  signerAdd = new MessageModel(
+    await Factories.Message.create({ data: Array.from(signerAddData.bb?.bytes() ?? []) }, { transient: { wallet } })
+  ) as SignerAddModel;
+
+  const castAddData = await Factories.CastAddData.create({
+    fid: Array.from(fid),
+  });
+  castAdd = new MessageModel(
+    await Factories.Message.create({ data: Array.from(castAddData.bb?.bytes() ?? []) }, { transient: { signer } })
+  ) as CastAddModel;
+});
+
+describe('SyncEngine', () => {
+  let syncEngine: SyncEngine;
+  let engine: Engine;
+
+  beforeEach(async () => {
+    await testDb.clear();
+    engine = new Engine(testDb);
+    syncEngine = new SyncEngine(engine);
+  });
+
+  const addMessagesWithTimestamps = async (timestamps: number[]) => {
+    return await Promise.all(
+      timestamps.map(async (t) => {
+        const addData = await Factories.CastAddData.create({ fid: Array.from(fid), timestamp: t });
+        const addMessage = await Factories.Message.create(
+          { data: Array.from(addData.bb?.bytes() ?? []) },
+          { transient: { signer } }
+        );
+        const addMessageModel = new MessageModel(addMessage);
+
+        const result = await engine.mergeMessage(addMessageModel);
+        expect(result.isOk()).toBeTruthy();
+        return Promise.resolve(addMessageModel);
+      })
+    );
+  };
+
+  test('trie is updated on successful merge', async () => {
+    const existingItems = syncEngine.trie.items;
+
+    await engine.mergeIdRegistryEvent(custodyEvent);
+    await engine.mergeMessage(signerAdd);
+    const result = await engine.mergeMessage(castAdd);
+
+    expect(result.isOk()).toBeTruthy();
+
+    // Two messages (signerAdd + castAdd) was added to the trie
+    expect(syncEngine.trie.items - existingItems).toEqual(2);
+    expect(syncEngine.trie.get(new SyncId(castAdd))).toEqual(new SyncId(castAdd).idString());
+  });
+
+  test('trie is not updated on merge failure', async () => {
+    expect(syncEngine.trie.items).toEqual(0);
+
+    // Merging a message without the custody event should fail
+    const result = await engine.mergeMessage(castAdd);
+
+    expect(result.isErr()).toBeTruthy();
+    expect(syncEngine.trie.items).toEqual(0);
+    expect(syncEngine.trie.get(new SyncId(castAdd))).toBeFalsy();
+  });
+
+  // test('trie is updated when a message is removed', async () => {
+  //   await engine.mergeIdRegistryEvent(custodyEvent);
+  //   await engine.mergeMessage(signerAdd);
+  //   let result = await engine.mergeMessage(castAdd);
+  //   expect(result.isOk()).toBeTruthy();
+
+  //   // Remove this cast.
+  //   const castRemoveBody = await Factories.CastRemoveBody.create({ targetTsHash: Array.from(castAdd.tsHash()) });
+  //   const castRemoveData = await Factories.CastRemoveData.create({
+  //     fid: Array.from(fid),
+  //     body: castRemoveBody.unpack(),
+  //   });
+  //   const castRemove = new MessageModel(
+  //     await Factories.Message.create({ data: Array.from(castRemoveData.bb?.bytes() ?? []) }, { transient: { signer } })
+  //   ) as CastRemoveModel;
+
+  //   // Merging the cast remove deletes the cast add in the db, and it should be reflected in the trie
+  //   result = await engine.mergeMessage(castRemove);
+  //   expect(result.isOk()).toBeTruthy();
+
+  //   const id = new SyncId(castRemove);
+  //   expect(syncEngine.trie.get(id)).toEqual(id.idString());
+
+  //   const allMessages = await engine.getAllMessagesBySyncIds([Buffer.from(castRemove.primaryKey()).toString('hex')]);
+  //   expect(allMessages).toEqual([]);
+  //   expect(syncEngine.trie.get(id)).toBeFalsy();
+  // });
+
+  test('snapshotTimestampPrefix trims the seconds', async () => {
+    const nowInSeconds = Date.now() / 1000;
+    const snapshotTimestamp = syncEngine.snapshotTimestamp;
+    expect(snapshotTimestamp).toBeLessThanOrEqual(nowInSeconds);
+    expect(snapshotTimestamp).toEqual(Math.floor(nowInSeconds / 10) * 10);
+  });
+
+  test('shouldSync returns false when already syncing', async () => {
+    const mockRPCClient = mock(Client);
+    const rpcClient = instance(mockRPCClient);
+    let called = false;
+    when(mockRPCClient.getSyncMetadataByPrefix(anyString())).thenCall(() => {
+      expect(syncEngine.shouldSync([])).toBeFalsy();
+      called = true;
+      // Return an empty child map so sync will finish with a noop
+      return Promise.resolve(ok({ prefix: '', numMessages: 1000, hash: '', children: new Map() }));
+    });
+    await syncEngine.performSync(['some-divergence'], rpcClient);
+    expect(called).toBeTruthy();
+  });
+
+  test('shouldSync returns false when excludedHashes match', async () => {
+    await engine.mergeIdRegistryEvent(custodyEvent);
+    await engine.mergeMessage(signerAdd);
+
+    await addMessagesWithTimestamps([30662167, 30662169, 30662172]);
+    expect(syncEngine.shouldSync(syncEngine.snapshot.excludedHashes)).toBeFalsy();
+  });
+
+  test('shouldSync returns true when hashes dont match', async () => {
+    await engine.mergeIdRegistryEvent(custodyEvent);
+    await engine.mergeMessage(signerAdd);
+
+    await addMessagesWithTimestamps([30662167, 30662169, 30662172]);
+    const oldSnapshot = syncEngine.snapshot;
+    await addMessagesWithTimestamps([30662372]);
+    expect(oldSnapshot.excludedHashes).not.toEqual(syncEngine.snapshot.excludedHashes);
+    expect(syncEngine.shouldSync(oldSnapshot.excludedHashes)).toBeTruthy();
+  });
+
+  // xtest('should not sync if messages were added within the sync threshold', async () => {
+  //   const user = await mockFid(engine, faker.datatype.number());
+  //   const snapshotTimestamp = syncEngine.snapshotTimestamp;
+  //   await addMessagesWithTimestamps(user, [snapshotTimestamp - 3, snapshotTimestamp - 2, snapshotTimestamp - 1]);
+
+  //   const snapshot = syncEngine.snapshot;
+  //   // Add a message after the snapshot, within the sync threshold
+  //   await addMessagesWithTimestamps(user, [snapshotTimestamp + 1]);
+  //   expect(syncEngine.shouldSync(snapshot.excludedHashes)).toBeFalsy();
+  // });
+
+  test('initialize populates the trie with all existing messages', async () => {
+    await engine.mergeIdRegistryEvent(custodyEvent);
+    await engine.mergeMessage(signerAdd);
+
+    const messages = await addMessagesWithTimestamps([30662167, 30662169, 30662172]);
+
+    const syncEngine = new SyncEngine(engine);
+    expect(syncEngine.trie.items).toEqual(0);
+
+    await syncEngine.initialize();
+
+    // There might be more messages related to user creation, but it's sufficient to check for casts
+    expect(syncEngine.trie.items).toBeGreaterThanOrEqual(3);
+    expect(syncEngine.trie.rootHash).toBeTruthy();
+    expect(syncEngine.trie.get(new SyncId(messages[0] as MessageModel))).toBeTruthy();
+    expect(syncEngine.trie.get(new SyncId(messages[1] as MessageModel))).toBeTruthy();
+    expect(syncEngine.trie.get(new SyncId(messages[2] as MessageModel))).toBeTruthy();
+  });
+});

--- a/src/network/sync/syncEngine.ts
+++ b/src/network/sync/syncEngine.ts
@@ -1,0 +1,257 @@
+import { arrayify } from 'ethers/lib/utils';
+import { err } from 'neverthrow';
+import MessageModel from '~/flatbuffers/models/messageModel';
+import Client from '~/rpc/client';
+import Engine from '~/storage/engine';
+import { HubError, HubResult } from '~/utils/hubErrors';
+import { logger } from '~/utils/logger';
+import { MerkleTrie, NodeMetadata } from './merkleTrie';
+import { SyncId } from './syncId';
+import { TrieSnapshot } from './trieNode';
+
+// Number of seconds to wait for the network to "settle" before syncing. We will only
+// attempt to sync messages that are older than this time.
+const SYNC_THRESHOLD_IN_SECONDS = 10;
+const HASHES_PER_FETCH = 50;
+
+const log = logger.child({
+  component: 'SyncEngine',
+});
+
+class SyncEngine {
+  private readonly _trie: MerkleTrie;
+  private readonly engine: Engine;
+  private _isSyncing = false;
+
+  constructor(engine: Engine) {
+    this._trie = new MerkleTrie();
+    this.engine = engine;
+
+    this.engine.eventHandler.on('mergeMessage', async (message) => {
+      this.addMessage(message);
+    });
+
+    // Note: There's no guarantee that the message is actually deleted, because the transaction could fail.
+    // This is fine, because we'll just end up syncing the message again. It's much worse to miss a removal and cause
+    // the trie to diverge in a way that's not recoverable without reconstructing it from the db.
+    // Order of events does not matter. The trie will always converge to the same state.
+    this.engine.eventHandler.on('pruneMessage', async (message) => {
+      this.removeMessage(message);
+    });
+    this.engine.eventHandler.on('revokeMessage', async (message) => {
+      this.removeMessage(message);
+    });
+  }
+
+  public async initialize() {
+    // TODO: cache the trie to disk, and use this only when the cache doesn't exist
+    let processedMessages = 0;
+    await this.engine.forEachMessage((message) => {
+      this.addMessage(message);
+      processedMessages += 1;
+      if (processedMessages % 10_000 === 0) {
+        log.info({ processedMessages }, 'Initializing sync engine');
+      }
+    });
+    log.info({ processedMessages }, 'Sync engine initialized');
+  }
+
+  /** ---------------------------------------------------------------------------------- */
+  /**                                      Sync Methods                                  */
+  /** ---------------------------------------------------------------------------------- */
+
+  public shouldSync(excludedHashes: string[]): boolean {
+    if (this._isSyncing) {
+      log.debug('shouldSync: already syncing');
+      return false;
+    }
+
+    const ourSnapshot = this.snapshot;
+    const excludedHashesMatch =
+      ourSnapshot.excludedHashes.length === excludedHashes.length &&
+      ourSnapshot.excludedHashes.every((value, index) => value === excludedHashes[index]);
+
+    log.debug(`shouldSync: excluded hashes check: ${excludedHashes}`);
+    return !excludedHashesMatch;
+  }
+
+  async performSync(excludedHashes: string[], rpcClient: Client) {
+    try {
+      this._isSyncing = true;
+      const ourSnapshot = this.snapshot;
+
+      const divergencePrefix = this._trie.getDivergencePrefix(ourSnapshot.prefix, excludedHashes);
+      log.info({ divergencePrefix, prefix: ourSnapshot.prefix }, 'Divergence prefix');
+      const missingIds = await this.fetchMissingHashesByPrefix(divergencePrefix, rpcClient);
+      log.info({ missingCount: missingIds.length }, 'Fetched missing hashes');
+
+      // TODO: sort missingIds by timestamp and fetch messages in batches
+      await this.fetchAndMergeMessages(missingIds, rpcClient);
+      log.info(`Sync complete`);
+    } catch (e) {
+      log.warn(e, `Error performing sync`);
+    } finally {
+      this._isSyncing = false;
+    }
+  }
+
+  public async fetchAndMergeMessages(syncIDs: string[], rpcClient: Client): Promise<boolean> {
+    let result = true;
+    if (syncIDs.length === 0) {
+      return false;
+    }
+
+    const messages = await rpcClient.getAllMessagesBySyncIds(
+      syncIDs.map((syncIdhash) => arrayify(Buffer.from(syncIdhash)))
+    );
+    await messages.match(
+      async (msgs) => {
+        const mergeResults = [];
+        // Merge messages sequentially, so we can handle missing users.
+        // TODO: Optimize by collecting all failures and retrying them in a batch
+        for (const msg of msgs) {
+          const result = await this.engine.mergeMessage(msg);
+          // Unknown user error
+          if (
+            result.isErr() &&
+            result.error.errCode === 'bad_request.validation_failure' &&
+            (result.error.message === 'invalid signer' || result.error.message.startsWith('unknown fid'))
+          ) {
+            log.warn({ fid: msg.data.fid }, 'Unknown user, fetching custody event');
+            const result = await this.syncUserAndRetryMessage(msg, rpcClient);
+            mergeResults.push(result);
+          } else {
+            mergeResults.push(result);
+          }
+        }
+        log.info(
+          { messages: mergeResults.length, success: mergeResults.filter((r) => r.isOk()).length },
+          'Merged messages'
+        );
+      },
+      async (err) => {
+        // e.g. Node goes down while we're performing the sync. No need to handle it, the next round of sync will retry.
+        log.warn(err, `Error fetching messages for sync`);
+        result = false;
+      }
+    );
+    return result;
+  }
+
+  async fetchMissingHashesByNode(
+    theirNode: NodeMetadata,
+    ourNode: NodeMetadata | undefined,
+    rpcClient: Client
+  ): Promise<string[]> {
+    const missingHashes: string[] = [];
+    // If the node has fewer than HASHES_PER_FETCH, just fetch them all in go, otherwise,
+    // iterate through the node's children and fetch them in batches.
+    if (theirNode.numMessages <= HASHES_PER_FETCH) {
+      const result = await rpcClient.getSyncIdsByPrefix(theirNode.prefix);
+      result.match(
+        (ids) => {
+          missingHashes.push(...ids);
+        },
+        (err) => {
+          log.warn(err, `Error fetching ids for prefix ${theirNode.prefix}`);
+        }
+      );
+    } else if (theirNode.children) {
+      for (const [theirChildChar, theirChild] of theirNode.children.entries()) {
+        // recursively fetch hashes for every node where the hashes don't match
+        if (ourNode?.children?.get(theirChildChar)?.hash !== theirChild.hash) {
+          missingHashes.push(...(await this.fetchMissingHashesByPrefix(theirChild.prefix, rpcClient)));
+        }
+      }
+    }
+    return missingHashes;
+  }
+
+  async fetchMissingHashesByPrefix(prefix: string, rpcClient: Client): Promise<string[]> {
+    const ourNode = this._trie.getTrieNodeMetadata(prefix);
+    const theirNodeResult = await rpcClient.getSyncMetadataByPrefix(prefix);
+
+    const missingHashes: string[] = [];
+    await theirNodeResult.match(
+      async (theirNode) => {
+        missingHashes.push(...(await this.fetchMissingHashesByNode(theirNode, ourNode, rpcClient)));
+      },
+      async (err) => {
+        log.warn(err, `Error fetching metadata for prefix ${prefix}`);
+      }
+    );
+    return missingHashes;
+  }
+
+  /** ---------------------------------------------------------------------------------- */
+  /**                                      Trie Methods                                  */
+  /** ---------------------------------------------------------------------------------- */
+  public addMessage(message: MessageModel): void {
+    this._trie.insert(new SyncId(message));
+  }
+
+  public removeMessage(message: MessageModel): void {
+    this._trie.delete(new SyncId(message));
+  }
+
+  public getTrieNodeMetadata(prefix: string): NodeMetadata | undefined {
+    return this._trie.getTrieNodeMetadata(prefix);
+  }
+
+  public getIdsByPrefix(prefix: string): string[] {
+    return this._trie.root.getNode(prefix)?.getAllValues() ?? [];
+  }
+
+  public get trie(): MerkleTrie {
+    return this._trie;
+  }
+
+  public get snapshot(): TrieSnapshot {
+    // Ignore the least significant digit when fetching the snapshot timestamp because
+    // second resolution is too fine grained, and fall outside sync threshold anyway
+    return this._trie.getSnapshot((this.snapshotTimestamp / 10).toString());
+  }
+
+  // Returns the most recent timestamp in seconds that's within the sync threshold
+  // (i.e. highest timestamp that's < current time and timestamp % sync_threshold == 0)
+  public get snapshotTimestamp(): number {
+    const currentTimeInSeconds = Math.floor(Date.now() / 1000);
+    return Math.floor(currentTimeInSeconds / SYNC_THRESHOLD_IN_SECONDS) * SYNC_THRESHOLD_IN_SECONDS;
+  }
+
+  private async syncUserAndRetryMessage(message: MessageModel, rpcClient: Client): Promise<HubResult<void>> {
+    const fid = message.data.fidArray();
+    if (!fid) {
+      return err(new HubError('bad_request.invalid_param', 'Invalid fid'));
+    }
+
+    const custodyEventResult = await rpcClient.getCustodyEvent(fid);
+    if (custodyEventResult.isErr()) {
+      return err(new HubError('unavailable.network_failure', 'Failed to fetch custody event'));
+    }
+    const custodyResult = await this.engine.mergeIdRegistryEvent(custodyEventResult.value);
+    if (custodyResult.isErr()) {
+      return err(new HubError('unavailable.storage_failure', 'Failed to merge custody event'));
+    }
+
+    // Probably not required to fetch the signer messages, but doing it here means
+    //  sync will complete in one round (prevents messages failing to merge due to missed or out of order signer message)
+    const signerMessagesResult = await rpcClient.getAllSignerMessagesByFid(fid);
+    if (signerMessagesResult.isErr()) {
+      return err(new HubError('unavailable.network_failure', 'Failed to fetch signer messages'));
+    }
+
+    const results = await this.engine.mergeMessages(signerMessagesResult.value);
+    if (results.every((r) => r.isErr())) {
+      return err(new HubError('unavailable.storage_failure', 'Failed to merge signer messages'));
+    } else {
+      // if at least one signer message was merged, retry the original message
+      return (await this.engine.mergeMessage(message)).mapErr((e) => {
+        log.warn(e, `Failed to merge message type ${message.type()}`);
+        return new HubError('unavailable.storage_failure', e);
+      });
+    }
+  }
+}
+
+export default SyncEngine;

--- a/src/network/sync/syncId.ts
+++ b/src/network/sync/syncId.ts
@@ -1,0 +1,50 @@
+import MessageModel from '~/flatbuffers/models/messageModel';
+
+const TIMESTAMP_LENGTH = 10; // 10 bytes for timestamp in decimal
+const HASH_LENGTH = 128; // We're using 64 byte blake2b hashes
+
+/**
+ * SyncId allows for a stable, time ordered lexicographic sorting of messages across hubs
+ * It is a combination of the message's timestamp and hash. This id string is used as the key in
+ * the MerkleTrie.
+ */
+class SyncId {
+  private readonly _fid: Uint8Array;
+  private readonly _tsHash: Uint8Array;
+  private readonly _timestamp: number;
+  private readonly _type: number;
+
+  constructor(message: MessageModel) {
+    this._fid = message.fid();
+    this._tsHash = message.tsHash();
+    this._timestamp = message.timestamp();
+    this._type = message.type();
+
+    // if (this._tsHash.length !== ID_LENGTH) {
+    //   throw new HubError('bad_request.parse_failure', `Invalid hash: ${this._tsHash}`);
+    // }
+  }
+
+  public idString(): string {
+    // For our MerkleTrie, seconds is a good enough resolution
+    // We also want to normalize the length to 10 characters, so that the MerkleTrie
+    // will always have the same depth for any timestamp (even 0).
+    const timestampString = Math.floor(this._timestamp).toString().padStart(TIMESTAMP_LENGTH, '0');
+
+    const buf = MessageModel.primaryKey(this._fid, MessageModel.typeToSetPostfix(this._type), this._tsHash);
+    return timestampString + buf.toString('hex');
+  }
+
+  public toString(): string {
+    return this.idString();
+  }
+
+  static pkFromIdString(idString: string): Buffer {
+    // The first 10 bytes are the timestamp, so we skip them
+    const pk = idString.slice(TIMESTAMP_LENGTH);
+
+    return Buffer.from(pk, 'hex');
+  }
+}
+
+export { SyncId, TIMESTAMP_LENGTH, HASH_LENGTH };

--- a/src/network/sync/trieNode.test.ts
+++ b/src/network/sync/trieNode.test.ts
@@ -1,0 +1,217 @@
+import { createHash } from 'crypto';
+import Factories from '~/flatbuffers/factories';
+import { TIMESTAMP_LENGTH } from '~/network/sync/syncId';
+import { TrieNode } from '~/network/sync/trieNode';
+
+const fid = Factories.FID.build();
+const emptyHash = createHash('sha256').digest('hex');
+const sharedDate = new Date(1665182332000);
+const sharedPrefixHashA =
+  '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86a4321';
+const sharedPrefixHashB =
+  '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86b1234';
+
+describe('TrieNode', () => {
+  // Traverse the node until we find a leaf or path splits into multiple choices
+  const traverse = (node: TrieNode): TrieNode => {
+    if (node.isLeaf) {
+      return node;
+    }
+    const children = Array.from(node.children);
+    if (children.length > 1) {
+      return node;
+    }
+    return traverse((children[0] as [string, TrieNode])[1]);
+  };
+
+  describe('insert', () => {
+    test('succeeds inserting a single item', async () => {
+      const root = new TrieNode();
+      const id = await Factories.SyncId.create();
+
+      expect(root.items).toEqual(0);
+      expect(root.hash).toEqual('');
+
+      root.insert(id.toString(), id.idString());
+
+      expect(root.items).toEqual(1);
+      expect(root.hash).toBeTruthy();
+    });
+
+    test('inserting the same item twice is idempotent', async () => {
+      const root = new TrieNode();
+      const id = await Factories.SyncId.create();
+
+      root.insert(id.toString(), id.idString());
+      expect(root.items).toEqual(1);
+      const previousHash = root.hash;
+      root.insert(id.toString(), id.idString());
+
+      expect(root.hash).toEqual(previousHash);
+      expect(root.items).toEqual(1);
+    });
+
+    test('inserting the same key with a different value does nothing', async () => {
+      const root = new TrieNode();
+      const id = await Factories.SyncId.create();
+      const id2 = await Factories.SyncId.create();
+
+      root.insert(id.toString(), id.idString());
+      expect(root.items).toEqual(1);
+      expect(root.get(id.toString())).toEqual(id.idString());
+      const previousHash = root.hash;
+      root.insert(id.toString(), id2.idString());
+
+      expect(root.hash).toEqual(previousHash);
+      expect(root.items).toEqual(1);
+      expect(root.get(id.toString())).toEqual(id.idString());
+    });
+
+    test('insert compacts hashstring component of syncid to single node for efficiency', async () => {
+      const root = new TrieNode();
+      const id = await Factories.SyncId.create();
+
+      root.insert(id.toString(), id.idString());
+      let node = root;
+      // Timestamp portion of the key is not collapsed, but the hash portion is
+      for (let i = 0; i < TIMESTAMP_LENGTH; i++) {
+        const children = Array.from(node.children);
+        const firstChild = children[0] as [string, TrieNode];
+        expect(children.length).toEqual(1);
+        node = firstChild[1];
+      }
+
+      expect(node.isLeaf).toEqual(true);
+      expect(node.value).toEqual(id.idString());
+    });
+
+    test('inserting another key with a common prefix splits the node', async () => {
+      // Generate two ids with the same timestamp and the same hash prefix. The trie should split the node
+      // where they diverge
+      const id1 = await Factories.SyncId.create(undefined, {
+        transient: { date: sharedDate, hash: sharedPrefixHashA, fid },
+      });
+      const hash1 = id1.toString();
+
+      const id2 = await Factories.SyncId.create(undefined, {
+        transient: { date: sharedDate, hash: sharedPrefixHashB, fid },
+      });
+      const hash2 = id2.toString();
+
+      // The node at which the trie splits should be the first character that differs between the two hashes
+      const firstDiffPos = hash1.split('').findIndex((c, i) => c !== hash2[i]);
+
+      const root = new TrieNode();
+      root.insert(id1.toString(), id1.idString());
+      root.insert(id2.toString(), id2.idString());
+
+      const splitNode = traverse(root);
+      expect(splitNode.items).toEqual(2);
+      const children = Array.from(splitNode.children);
+      const firstChild = children[0] as [string, TrieNode];
+      const secondChild = children[1] as [string, TrieNode];
+      expect(children.length).toEqual(2);
+      // hash1 node
+      expect(firstChild[0]).toEqual(hash1[firstDiffPos]);
+      expect(firstChild[1].isLeaf).toBeTruthy();
+      expect(firstChild[1].value).toEqual(id1.idString());
+      // hash2 node
+      expect(secondChild[0]).toEqual(hash2[firstDiffPos]);
+      expect(secondChild[1].isLeaf).toBeTruthy();
+      expect(secondChild[1].value).toEqual(id2.idString());
+    });
+  });
+
+  describe('delete', () => {
+    test('deleting a single item removes the node', async () => {
+      const root = new TrieNode();
+      const id = await Factories.SyncId.create();
+
+      root.insert(id.toString(), id.idString());
+      expect(root.items).toEqual(1);
+
+      root.delete(id.toString());
+      expect(root.items).toEqual(0);
+      expect(root.hash).toEqual(emptyHash);
+    });
+
+    test('deleting a single item from a node with multiple items removes the item', async () => {
+      const root = new TrieNode();
+      const id1 = await Factories.SyncId.create(undefined, { transient: { date: sharedDate } });
+      const id2 = await Factories.SyncId.create(undefined, { transient: { date: sharedDate } });
+
+      root.insert(id1.toString(), id1.idString());
+      const previousHash = root.hash;
+      root.insert(id2.toString(), id2.idString());
+      expect(root.items).toEqual(2);
+
+      root.delete(id2.toString());
+      expect(root.items).toEqual(1);
+      expect(root.get(id2.toString())).toBeUndefined();
+      expect(root.hash).toEqual(previousHash);
+    });
+
+    test('deleting a single item from a split node should preserve previous hash', async () => {
+      const id1 = await Factories.SyncId.create(undefined, {
+        transient: { date: sharedDate, hash: sharedPrefixHashA },
+      });
+      const id2 = await Factories.SyncId.create(undefined, {
+        transient: { date: sharedDate, hash: sharedPrefixHashB },
+      });
+
+      const root = new TrieNode();
+      root.insert(id1.toString(), id1.idString());
+      const previousRootHash = root.hash;
+      const leafNode = traverse(root);
+      root.insert(id2.toString(), id2.idString());
+
+      expect(root.hash).not.toEqual(previousRootHash);
+
+      root.delete(id2.toString());
+
+      const newLeafNode = traverse(root);
+      expect(newLeafNode).toEqual(leafNode);
+      expect(root.hash).toEqual(previousRootHash);
+    });
+  });
+
+  describe('get', () => {
+    test('getting a single item returns the value', async () => {
+      const root = new TrieNode();
+      const id = await Factories.SyncId.create();
+
+      root.insert(id.toString(), id.idString());
+      expect(root.items).toEqual(1);
+
+      const value = root.get(id.toString());
+      expect(value).toEqual(id.idString());
+    });
+
+    test('getting an item after deleting it returns undefined', async () => {
+      const root = new TrieNode();
+      const id = await Factories.SyncId.create();
+
+      root.insert(id.toString(), id.idString());
+      expect(root.items).toEqual(1);
+
+      root.delete(id.toString());
+      expect(root.get(id.toString())).toBeUndefined();
+      expect(root.items).toEqual(0);
+    });
+
+    test('getting an non-existent item that share the same prefix with an existing item returns undefined', async () => {
+      const id1 = await Factories.SyncId.create(undefined, {
+        transient: { date: sharedDate, hash: sharedPrefixHashA },
+      });
+      const id2 = await Factories.SyncId.create(undefined, {
+        transient: { date: sharedDate, hash: sharedPrefixHashB },
+      });
+
+      const root = new TrieNode();
+      root.insert(id1.toString(), id1.idString());
+
+      // id2 shares the same prefix, but doesn't exist, so it should return undefined
+      expect(root.get(id2.toString())).toBeUndefined();
+    });
+  });
+});

--- a/src/network/sync/trieNode.ts
+++ b/src/network/sync/trieNode.ts
@@ -1,0 +1,272 @@
+import { createHash } from 'crypto';
+import { TIMESTAMP_LENGTH } from '~/network/sync/syncId';
+import { HubError } from '~/utils/hubErrors';
+
+/**
+ * A snapshot of the trie at a particular timestamp which can be used to determine if two
+ * hubs are in sync
+ *
+ * @prefix - The prefix (timestamp string) used to generate the snapshot
+ * @excludedHashes - The hash of all the nodes excluding the prefix character at every index of the prefix
+ * @numMessages - The total number of messages captured in the snapshot (excludes the prefix nodes)
+ */
+export type TrieSnapshot = {
+  prefix: string;
+  excludedHashes: string[];
+  numMessages: number;
+};
+
+/**
+ * Represents a node in a MerkleTrie. Automatically updates the hashes when items are added,
+ * and keeps track of the number of items in the subtree.
+ */
+class TrieNode {
+  private _hash: string;
+  private _items: number;
+  private _children: Map<string, TrieNode>;
+  private _key: string | undefined;
+  private _value: string | undefined;
+
+  constructor() {
+    this._hash = '';
+    this._items = 0;
+    this._children = new Map();
+    this._key = undefined;
+    this._value = undefined;
+  }
+
+  /**
+   * Inserts a value into the trie. Returns true if the value was inserted, false if it already existed
+   * @param key - The key to insert
+   * @param value - The value to insert
+   * @param current_index - The index of the current character in the key (only used internally)
+   * @returns true if the value was inserted, false if it already existed
+   *
+   * Recursively traverses the trie by prefix and inserts the value at the end. Updates the hashes for
+   * every node that was traversed.
+   */
+  public insert(key: string, value: string, current_index = 0): boolean {
+    const char = key.charAt(current_index);
+
+    // Do not compact the timestamp portion of the trie, since it's used to compare snapshots
+    if (current_index >= TIMESTAMP_LENGTH && this.isLeaf && !this._value) {
+      // Reached a leaf node with no value, insert it
+      this._setKeyValue(key, value);
+      this._items += 1;
+      return true;
+    }
+
+    if (current_index >= TIMESTAMP_LENGTH && this.isLeaf) {
+      if (this._key == key) {
+        // If the same key exists, do nothing
+        return false;
+      }
+      // If the key is different, and a value exists, then split the node
+      this._splitLeafNode(current_index);
+    }
+
+    if (!this._children.has(char)) {
+      this._addChild(char);
+    }
+
+    // Recurse into a non-leaf node and instruct it to insert the value
+    const success = this._children.get(char)?.insert(key, value, current_index + 1);
+    if (success) {
+      this._items += 1;
+      this._updateHash();
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Deletes a value from the trie by key. Returns true if the value was deleted, false if it didn't exist
+   * @param key - The key to delete
+   * @param current_index - The index of the current character in the key (only used internally)
+   *
+   * Ensures that there are no empty nodes after deletion. This is important to make sure the hashes
+   * will match exactly with another trie that never had the value (e.g. in another hub).
+   */
+  public delete(key: string, current_index = 0): boolean {
+    if (this.isLeaf) {
+      if (this._key === key) {
+        this._items -= 1;
+        this._setKeyValue(undefined, undefined);
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    const char = key.charAt(current_index);
+    if (!this._children.has(char)) {
+      return false;
+    }
+
+    const success = this._children.get(char)?.delete(key, current_index + 1);
+    if (success) {
+      this._items -= 1;
+      // Delete the child if it's empty. This is required to make sure the hash will be the same
+      // as another trie that doesn't have this node in the first place.
+      if (this._children.get(char)?.items === 0) {
+        this._children.delete(char);
+      }
+
+      if (this._children.size === 1 && current_index >= TIMESTAMP_LENGTH) {
+        // Compact the node if it has only one child
+        const [char, child] = this._children.entries().next().value;
+        this._setKeyValue(child._key, child._value);
+        this._children.delete(char);
+      }
+
+      this._updateHash();
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Gets a value from the trie by key. Returns the value if it exists, undefined otherwise
+   * @param key - The key to delete
+   * @param current_index - The index of the current character in the key (only used internally)
+   */
+  public get(key: string, current_index = 0): string | undefined {
+    if (this.isLeaf && this._key === key) {
+      return this._value;
+    }
+
+    const char = key.charAt(current_index);
+    if (!this._children.has(char)) {
+      return undefined;
+    }
+
+    return this._children.get(char)?.get(key, current_index + 1);
+  }
+
+  // Generates a snapshot for the current node and below. current_index is the index of the prefix the method is operating on
+  public getSnapshot(prefix: string, current_index = 0): TrieSnapshot {
+    const char = prefix.charAt(current_index);
+    if (current_index === prefix.length - 1) {
+      const excludedHash = this._excludedHash(char);
+      return {
+        prefix: prefix,
+        excludedHashes: [excludedHash.hash],
+        numMessages: excludedHash.items,
+      };
+    }
+
+    const innerSnapshot = this._children.get(char)?.getSnapshot(prefix, current_index + 1);
+    const excludedHash = this._excludedHash(char);
+    return {
+      prefix: innerSnapshot?.prefix || prefix.slice(0, current_index + 1),
+      excludedHashes: [excludedHash.hash, ...(innerSnapshot?.excludedHashes || [])],
+      numMessages: excludedHash.items + (innerSnapshot?.numMessages || 0),
+    };
+  }
+
+  public get items(): number {
+    return this._items;
+  }
+
+  public get hash(): string {
+    return this._hash;
+  }
+
+  public get isLeaf(): boolean {
+    return this._children.size === 0;
+  }
+
+  // Only available on leaf nodes
+  public get value(): string | undefined {
+    if (this.isLeaf) {
+      return this._value;
+    }
+    return undefined;
+  }
+
+  public getNode(prefix: string): TrieNode | undefined {
+    if (prefix.length === 0) {
+      return this;
+    }
+    const char = prefix.charAt(0);
+    if (!this._children.has(char)) {
+      return undefined;
+    }
+    return this._children.get(char)?.getNode(prefix.slice(1));
+  }
+
+  public get children(): IterableIterator<[string, TrieNode]> {
+    return this._children.entries();
+  }
+
+  public getAllValues(): string[] {
+    if (this.isLeaf) {
+      return this._value ? [this._value] : [];
+    }
+    const values: string[] = [];
+    this._children.forEach((child) => {
+      values.push(...child.getAllValues());
+    });
+    return values;
+  }
+
+  /* Private methods */
+
+  private _excludedHash(char: string): { items: number; hash: string } {
+    // TODO: Cache this for performance
+    const hash = createHash('sha256');
+    let excludedItems = 0;
+    this._children.forEach((child, key) => {
+      if (key !== char) {
+        hash.update(child.hash);
+        excludedItems += child.items;
+      }
+    });
+    return { hash: hash.digest('hex'), items: excludedItems };
+  }
+
+  private _addChild(char: string) {
+    this._children.set(char, new TrieNode());
+    // The hash requires the children to be sorted, and sorting on insert/update is cheaper than
+    // sorting each time we need to update the hash
+    this._children = new Map([...this._children.entries()].sort());
+  }
+
+  private _setKeyValue(key: string | undefined, value: string | undefined) {
+    this._key = key;
+    this._value = value;
+    this._updateHash();
+  }
+
+  // Splits a leaf node into a non-leaf node by clearing its key/value and adding a child for
+  // the next char in its key
+  private _splitLeafNode(current_index: number) {
+    if (!this._key || !this._value) {
+      // This should never happen, check is here for type safety
+      throw new HubError('bad_request', 'Cannot split a leaf node without a key and value');
+    }
+    const newChildChar = this._key.charAt(current_index);
+    this._addChild(newChildChar);
+    this._children.get(newChildChar)?.insert(this._key, this._value, current_index + 1);
+    this._setKeyValue(undefined, undefined);
+  }
+
+  private _updateHash() {
+    // TODO: Optimize by using a faster hash algorithm. Potentially murmurhash v3
+    if (this.isLeaf) {
+      this._hash = createHash('sha256')
+        .update(this._value || '')
+        .digest('hex');
+    } else {
+      const hash = createHash('sha256');
+      this._children.forEach((child) => {
+        hash.update(child.hash);
+      });
+      this._hash = hash.digest('hex');
+    }
+  }
+}
+
+export { TrieNode };

--- a/src/rpc/server/serviceImplementations/syncImplementation.ts
+++ b/src/rpc/server/serviceImplementations/syncImplementation.ts
@@ -1,11 +1,25 @@
 import grpc from '@grpc/grpc-js';
-import { GetAllMessagesByFidRequest, MessagesResponse } from '~/flatbuffers/generated/rpc_generated';
+import { Builder, ByteBuffer } from 'flatbuffers';
+import {
+  GetAllMessagesByFidRequest,
+  GetAllMessagesByFidRequestT,
+  GetAllMessagesBySyncIdsRequest,
+  GetAllMessagesBySyncIdsRequestT,
+  GetAllSyncIdsByPrefixResponse,
+  GetTrieNodesByPrefixRequest,
+  GetTrieNodesByPrefixRequestT,
+  MessagesResponse,
+  SyncIdHashT,
+  TrieNodeMetadataResponse,
+} from '~/flatbuffers/generated/rpc_generated';
+import MessageModel from '~/flatbuffers/models/messageModel';
 import * as types from '~/flatbuffers/models/types';
-import { toMessagesResponse, toServiceError } from '~/rpc/server';
+import SyncEngine from '~/network/sync/syncEngine';
+import { toMessagesResponse, toServiceError, toSyncIdsResponse, toTrieNodeMetadataResponse } from '~/rpc/server';
 import Engine from '~/storage/engine';
 import { HubError } from '~/utils/hubErrors';
 
-export const syncImplementation = (engine: Engine) => {
+export const syncImplementation = (engine: Engine, syncEngine: SyncEngine) => {
   return {
     getAllCastMessagesByFid: async (
       call: grpc.ServerUnaryCall<GetAllMessagesByFidRequest, MessagesResponse>,
@@ -96,5 +110,72 @@ export const syncImplementation = (engine: Engine) => {
         }
       );
     },
+
+    getAllSyncIdsByPrefix: async (
+      call: grpc.ServerUnaryCall<GetTrieNodesByPrefixRequest, GetAllSyncIdsByPrefixResponse>,
+      callback: grpc.sendUnaryData<GetAllSyncIdsByPrefixResponse>
+    ) => {
+      const result = syncEngine.getIdsByPrefix(
+        new TextDecoder().decode(call.request.prefixArray() ?? new Uint8Array())
+      );
+      callback(null, toSyncIdsResponse(result));
+    },
+
+    getAllMessagesBySyncIds: async (
+      call: grpc.ServerUnaryCall<GetAllMessagesBySyncIdsRequest, MessagesResponse>,
+      callback: grpc.sendUnaryData<MessagesResponse>
+    ) => {
+      const syncIdHashes: string[] = [];
+      for (let i = 0; i < call.request.syncIdsLength(); i++) {
+        syncIdHashes.push(new TextDecoder().decode(call.request.syncIds(i)?.syncIdHashArray() ?? new Uint8Array()));
+      }
+
+      const result = await engine.getAllMessagesBySyncIds(syncIdHashes);
+      result.match(
+        (messages: MessageModel[]) => {
+          callback(null, toMessagesResponse(messages));
+        },
+        (err: HubError) => {
+          callback(toServiceError(err));
+        }
+      );
+    },
+
+    getSyncMetadataByPrefix: async (
+      call: grpc.ServerUnaryCall<GetTrieNodesByPrefixRequest, TrieNodeMetadataResponse>,
+      callback: grpc.sendUnaryData<TrieNodeMetadataResponse>
+    ) => {
+      const prefix = new TextDecoder().decode(call.request.prefixArray() ?? new Uint8Array());
+      const result = syncEngine.getTrieNodeMetadata(prefix);
+      if (result) {
+        callback(null, toTrieNodeMetadataResponse(result));
+      } else {
+        const err = new HubError('bad_request', 'Failed to get trie node metadata');
+        callback(toServiceError(err));
+      }
+    },
   };
+};
+
+export const createSyncServiceRequest = (fid: Uint8Array): GetAllMessagesByFidRequest => {
+  const builder = new Builder(1);
+  const requestT = new GetAllMessagesByFidRequestT(Array.from(fid));
+  builder.finish(requestT.pack(builder));
+  return GetAllMessagesByFidRequest.getRootAsGetAllMessagesByFidRequest(new ByteBuffer(builder.asUint8Array()));
+};
+
+export const createByPrefixRequest = (prefix: Uint8Array): GetTrieNodesByPrefixRequest => {
+  const builder = new Builder(1);
+  const requestT = new GetTrieNodesByPrefixRequestT(Array.from(prefix));
+  builder.finish(requestT.pack(builder));
+  return GetTrieNodesByPrefixRequest.getRootAsGetTrieNodesByPrefixRequest(new ByteBuffer(builder.asUint8Array()));
+};
+
+export const createAllMessagesByHashesRequest = (hashes: Uint8Array[]): GetAllMessagesBySyncIdsRequest => {
+  const hashes_list = hashes.map((hash) => new SyncIdHashT(Array.from(hash)));
+
+  const builder = new Builder(1);
+  const hashesT = new GetAllMessagesBySyncIdsRequestT(hashes_list);
+  builder.finish(hashesT.pack(builder));
+  return GetAllMessagesBySyncIdsRequest.getRootAsGetAllMessagesBySyncIdsRequest(new ByteBuffer(builder.asUint8Array()));
 };

--- a/src/rpc/serviceDefinitions/syncDefinition.ts
+++ b/src/rpc/serviceDefinitions/syncDefinition.ts
@@ -1,4 +1,11 @@
-import { GetAllMessagesByFidRequest, MessagesResponse } from '~/flatbuffers/generated/rpc_generated';
+import {
+  GetAllMessagesByFidRequest,
+  GetAllMessagesBySyncIdsRequest,
+  GetAllSyncIdsByPrefixResponse,
+  GetTrieNodesByPrefixRequest,
+  MessagesResponse,
+  TrieNodeMetadataResponse,
+} from '~/flatbuffers/generated/rpc_generated';
 import { toByteBuffer } from '~/flatbuffers/utils/bytes';
 import { defaultMethod } from '~/rpc/client';
 
@@ -44,6 +51,37 @@ export const syncDefinition = () => {
     getAllUserDataMessagesByFid: {
       ...defaultSyncMethod(),
       path: '/getAllUserDataMessagesByFid',
+    },
+    getAllSyncIdsByPrefix: {
+      ...defaultMethod,
+      requestDeserialize: (buffer: Buffer): GetTrieNodesByPrefixRequest => {
+        return GetTrieNodesByPrefixRequest.getRootAsGetTrieNodesByPrefixRequest(toByteBuffer(buffer));
+      },
+      responseDeserialize: (buffer: Buffer): GetAllSyncIdsByPrefixResponse => {
+        return GetAllSyncIdsByPrefixResponse.getRootAsGetAllSyncIdsByPrefixResponse(toByteBuffer(buffer));
+      },
+      path: '/getAllSyncIdsByPrefix',
+    },
+    getAllMessagesBySyncIds: {
+      ...defaultMethod,
+      requestDeserialize: (buffer: Buffer): GetAllMessagesBySyncIdsRequest => {
+        return GetAllMessagesBySyncIdsRequest.getRootAsGetAllMessagesBySyncIdsRequest(toByteBuffer(buffer));
+      },
+      responseDeserialize: (buffer: Buffer): MessagesResponse => {
+        return MessagesResponse.getRootAsMessagesResponse(toByteBuffer(buffer));
+      },
+
+      path: '/getAllMessagesBySyncIds',
+    },
+    getSyncMetadataByPrefix: {
+      ...defaultMethod,
+      requestDeserialize: (buffer: Buffer): GetTrieNodesByPrefixRequest => {
+        return GetTrieNodesByPrefixRequest.getRootAsGetTrieNodesByPrefixRequest(toByteBuffer(buffer));
+      },
+      responseDeserialize: (buffer: Buffer): TrieNodeMetadataResponse => {
+        return TrieNodeMetadataResponse.getRootAsTrieNodeMetadataResponse(toByteBuffer(buffer));
+      },
+      path: '/getSyncMetadataByPrefix',
     },
   };
 };

--- a/src/rpc/test/ampService.test.ts
+++ b/src/rpc/test/ampService.test.ts
@@ -4,6 +4,7 @@ import { UserId } from '~/flatbuffers/generated/message_generated';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { AmpAddModel, KeyPair, SignerAddModel } from '~/flatbuffers/models/types';
+import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -21,7 +22,7 @@ let server: Server;
 let client: Client;
 
 beforeAll(async () => {
-  server = new Server(hub, engine);
+  server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
   client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });

--- a/src/rpc/test/castService.test.ts
+++ b/src/rpc/test/castService.test.ts
@@ -4,6 +4,7 @@ import { CastId, UserId } from '~/flatbuffers/generated/message_generated';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { CastAddModel, KeyPair, SignerAddModel } from '~/flatbuffers/models/types';
+import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -21,7 +22,7 @@ let server: Server;
 let client: Client;
 
 beforeAll(async () => {
-  server = new Server(hub, engine);
+  server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
   client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });

--- a/src/rpc/test/eventService.test.ts
+++ b/src/rpc/test/eventService.test.ts
@@ -5,6 +5,7 @@ import { EventResponse, EventType } from '~/flatbuffers/generated/rpc_generated'
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { CastAddModel, KeyPair, SignerAddModel } from '~/flatbuffers/models/types';
+import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -21,7 +22,7 @@ let server: Server;
 let client: Client;
 
 beforeAll(async () => {
-  server = new Server(hub, engine);
+  server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
   client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });

--- a/src/rpc/test/reactionService.test.ts
+++ b/src/rpc/test/reactionService.test.ts
@@ -4,6 +4,7 @@ import { CastId, ReactionType } from '~/flatbuffers/generated/message_generated'
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { KeyPair, ReactionAddModel, SignerAddModel } from '~/flatbuffers/models/types';
+import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -21,7 +22,7 @@ let server: Server;
 let client: Client;
 
 beforeAll(async () => {
-  server = new Server(hub, engine);
+  server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
   client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });

--- a/src/rpc/test/signerService.test.ts
+++ b/src/rpc/test/signerService.test.ts
@@ -3,6 +3,7 @@ import Factories from '~/flatbuffers/factories';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { KeyPair, SignerAddModel } from '~/flatbuffers/models/types';
+import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -20,7 +21,7 @@ let server: Server;
 let client: Client;
 
 beforeAll(async () => {
-  server = new Server(hub, engine);
+  server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
   client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });

--- a/src/rpc/test/submitService.test.ts
+++ b/src/rpc/test/submitService.test.ts
@@ -6,6 +6,7 @@ import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel';
 import { CastAddModel, KeyPair, SignerAddModel } from '~/flatbuffers/models/types';
+import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -23,7 +24,7 @@ let server: Server;
 let client: Client;
 
 beforeAll(async () => {
-  server = new Server(hub, engine);
+  server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
   client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });

--- a/src/rpc/test/syncService.test.ts
+++ b/src/rpc/test/syncService.test.ts
@@ -16,6 +16,7 @@ import {
   VerificationAddEthAddressModel,
   VerificationRemoveModel,
 } from '~/flatbuffers/models/types';
+import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -33,7 +34,7 @@ let server: Server;
 let client: Client;
 
 beforeAll(async () => {
-  server = new Server(hub, engine);
+  server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
   client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });

--- a/src/rpc/test/userDataService.test.ts
+++ b/src/rpc/test/userDataService.test.ts
@@ -6,6 +6,7 @@ import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel';
 import { KeyPair, SignerAddModel, UserDataAddModel } from '~/flatbuffers/models/types';
+import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -23,7 +24,7 @@ let server: Server;
 let client: Client;
 
 beforeAll(async () => {
-  server = new Server(hub, engine);
+  server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
   client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });

--- a/src/rpc/test/verificationService.test.ts
+++ b/src/rpc/test/verificationService.test.ts
@@ -3,6 +3,7 @@ import Factories from '~/flatbuffers/factories';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { KeyPair, SignerAddModel, VerificationAddEthAddressModel } from '~/flatbuffers/models/types';
+import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -20,7 +21,7 @@ let server: Server;
 let client: Client;
 
 beforeAll(async () => {
-  server = new Server(hub, engine);
+  server = new Server(hub, engine, new SyncEngine(engine));
   const port = await server.start();
   client = new Client(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
 });


### PR DESCRIPTION
## Motivation

Sync messages between Hubs to keep them in Sync

## Change Summary

- Move all data to flatbuffers
- New RPC methods to allow querying SyncID, Hashes and Messages over RPC
- New Merkle Trie keys to use in Sync.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

## Additional Context

The sync is basically working, although I'm sure there are loads of edge cases and bugs. This is a very basic implementation of a Sync that does a single-threaded sync, pulling messages from a remote Hub grouped into timestamps. 

There is a basic benchmark test, which shows the current sync performance is ~100 casts per second for:
- Single threaded server
- both Servers on the same machine (i.e., not assuming any latency)

There's loads of optimizations possible (remove Merkle Trie keys, connect to multiple Hubs, parallel fetch hashes etc...), which will be addressed in a follow up PR.
