### PR TITLE
fix: use little-endian conversion instead of big endian

### DIFF
--- a/src/flatbuffers/utils/bytes.ts
+++ b/src/flatbuffers/utils/bytes.ts
@@ -61,5 +61,5 @@ export const toByteBuffer = (buffer: Buffer): ByteBuffer => {
 };
 
 export const toNumber = (bytesUint8Array: Uint8Array) => {
-  return Buffer.from(bytesUint8Array).readUIntBE(0, bytesUint8Array.length);
+  return Buffer.from(bytesUint8Array).readUintLE(0, bytesUint8Array.length);
 };


### PR DESCRIPTION
## Change Summary

Change the `toNumber` helper to use LE conversion instead of the previously incorrect BE conversion

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)