### PR TITLE
fix: numberToBytes method and validate fid is not padded

### DIFF
--- a/src/flatbuffers/factories/flatbuffer.ts
+++ b/src/flatbuffers/factories/flatbuffer.ts
@@ -17,6 +17,7 @@ import { signMessageHash, signVerificationEthAddressClaim } from '~/flatbuffers/
 import { toFarcasterTime } from '~/flatbuffers/utils/time';
 import { NETWORK_TOPIC_PRIMARY } from '~/network/p2p/protocol';
 import { generateEd25519KeyPair } from '~/utils/crypto';
+import { numberToBytes } from '../utils/bytes';
 
 /* eslint-disable security/detect-object-injection */
 const BytesFactory = Factory.define<Uint8Array, { length?: number }>(({ transientParams }) => {
@@ -29,10 +30,7 @@ const BytesFactory = Factory.define<Uint8Array, { length?: number }>(({ transien
 });
 
 const FIDFactory = Factory.define<Uint8Array, { fid?: number }>(({ transientParams }) => {
-  const builder = new Builder(4);
-  const fid = transientParams.fid ?? faker.datatype.number({ max: 2 ** 32 - 1 });
-  builder.addInt32(fid);
-  return builder.asUint8Array();
+  return numberToBytes(transientParams.fid ?? faker.datatype.number());
 });
 
 const FnameFactory = Factory.define<Uint8Array>(() => {

--- a/src/flatbuffers/factories/flatbuffer.ts
+++ b/src/flatbuffers/factories/flatbuffer.ts
@@ -13,11 +13,11 @@ import * as message_generated from '~/flatbuffers/generated/message_generated';
 import * as name_registry_event_generated from '~/flatbuffers/generated/name_registry_event_generated';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { KeyPair, VerificationEthAddressClaim } from '~/flatbuffers/models/types';
+import { numberToBytes } from '~/flatbuffers/utils/bytes';
 import { signMessageHash, signVerificationEthAddressClaim } from '~/flatbuffers/utils/eip712';
 import { toFarcasterTime } from '~/flatbuffers/utils/time';
 import { NETWORK_TOPIC_PRIMARY } from '~/network/p2p/protocol';
 import { generateEd25519KeyPair } from '~/utils/crypto';
-import { numberToBytes } from '../utils/bytes';
 
 /* eslint-disable security/detect-object-injection */
 const BytesFactory = Factory.define<Uint8Array, { length?: number }>(({ transientParams }) => {

--- a/src/flatbuffers/factories/flatbuffer.ts
+++ b/src/flatbuffers/factories/flatbuffer.ts
@@ -30,7 +30,7 @@ const BytesFactory = Factory.define<Uint8Array, { length?: number }>(({ transien
 });
 
 const FIDFactory = Factory.define<Uint8Array, { fid?: number }>(({ transientParams }) => {
-  return numberToBytes(transientParams.fid ?? faker.datatype.number());
+  return numberToBytes(transientParams.fid ?? faker.datatype.number({ min: 1 }));
 });
 
 const FnameFactory = Factory.define<Uint8Array>(() => {

--- a/src/flatbuffers/models/validations.test.ts
+++ b/src/flatbuffers/models/validations.test.ts
@@ -128,6 +128,12 @@ describe('validateFid', () => {
       new HubError('bad_request.validation_failure', 'fid is missing')
     );
   });
+
+  test('fails with padded little endian byte array', () => {
+    expect(validations.validateFid(new Uint8Array([1, 0]))._unsafeUnwrapErr()).toEqual(
+      new HubError('bad_request.validation_failure', 'fid is padded')
+    );
+  });
 });
 
 describe('validateTsHash', () => {

--- a/src/flatbuffers/models/validations.ts
+++ b/src/flatbuffers/models/validations.ts
@@ -118,6 +118,10 @@ export const validateFid = (fid?: Uint8Array | null): HubResult<Uint8Array> => {
     return err(new HubError('bad_request.validation_failure', 'fid > 32 bytes'));
   }
 
+  if (fid[fid.byteLength - 1] === 0) {
+    return err(new HubError('bad_request.validation_failure', 'fid is padded'));
+  }
+
   return ok(fid);
 };
 

--- a/src/flatbuffers/utils/bytes.test.ts
+++ b/src/flatbuffers/utils/bytes.test.ts
@@ -1,4 +1,4 @@
-import { bytesCompare, bytesDecrement, bytesIncrement } from '~/flatbuffers/utils/bytes';
+import { bytesCompare, bytesDecrement, bytesIncrement, numberToBytes } from '~/flatbuffers/utils/bytes';
 import { HubError } from '~/utils/hubErrors';
 
 describe('bytesCompare', () => {
@@ -48,7 +48,7 @@ describe('bytesDecrement', () => {
     [new Uint8Array([1, 0, 0, 0]), new Uint8Array([0, 255, 255, 255])],
   ];
 
-  const failingCases: [Uint8Array][] = [[new Uint8Array([0])], [new Uint8Array([0, 0])]];
+  const failingCases: Uint8Array[] = [new Uint8Array([0]), new Uint8Array([0, 0])];
 
   for (const [input, output] of passingCases) {
     test(`decrements byte array: ${input}`, () => {
@@ -56,9 +56,33 @@ describe('bytesDecrement', () => {
     });
   }
 
-  for (const [input] of failingCases) {
-    test(`should when decrementing byte array: ${input}`, () => {
+  for (const input of failingCases) {
+    test(`fails when decrementing byte array: ${input}`, () => {
       expect(() => bytesDecrement(input)).toThrow(HubError);
+    });
+  }
+});
+
+describe('numberToBytes', () => {
+  const passingCases: [number, Uint8Array][] = [
+    [1, new Uint8Array([1])],
+    [255, new Uint8Array([255])],
+    [256, new Uint8Array([0, 1])],
+    [257, new Uint8Array([1, 1])],
+    [26_309_012, new Uint8Array([148, 113, 145, 1])],
+  ];
+
+  for (const [input, output] of passingCases) {
+    test(`converts number to little endian byte array: ${input}`, () => {
+      expect(numberToBytes(input)).toEqual(output);
+    });
+  }
+
+  const failingCases: number[] = [-1, 0, -26_309_012];
+
+  for (const input of failingCases) {
+    test(`fails with number: ${input}`, () => {
+      expect(() => numberToBytes(input)).toThrow(HubError);
     });
   }
 });

--- a/src/flatbuffers/utils/bytes.ts
+++ b/src/flatbuffers/utils/bytes.ts
@@ -63,3 +63,16 @@ export const toByteBuffer = (buffer: Buffer): ByteBuffer => {
 export const toNumber = (bytesUint8Array: Uint8Array) => {
   return Buffer.from(bytesUint8Array).readUintLE(0, bytesUint8Array.length);
 };
+
+/** Converts number to little endian byte array */
+export const numberToBytes = (value: number) => {
+  if (value <= 0) {
+    throw new HubError('bad_request.invalid_param', 'value must be positive');
+  }
+  const bytes = [];
+  while (value !== 0) {
+    bytes.push(value & 255);
+    value >>= 8;
+  }
+  return new Uint8Array(bytes);
+};


### PR DESCRIPTION
## Motivation

We've encountered issues with padded vs unpadded fids. Fids should be unpadded little endian byte arrays.

## Change Summary

* Add `numberToBytes` util method that converts a javascript number into an unpadded little endian byte array
* Expand `validateFid` method to return an error when the fid is padded

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
