### PR TITLE
chore: configure no-unused-var to ignore '^_' args

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,6 +14,7 @@ module.exports = {
     '@typescript-eslint/ban-ts-ignore': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     'no-restricted-imports': [
       'error',
       {

--- a/src/network/p2p/connectionFilter.test.ts
+++ b/src/network/p2p/connectionFilter.test.ts
@@ -23,7 +23,7 @@ describe('connectionFilter tests', () => {
 
   test('denies all connections by default', async () => {
     const filter = new ConnectionFilter([]);
-    const { inbound: _localConnection, outbound: remoteConnection } = mockMultiaddrConnPair({
+    const { outbound: remoteConnection } = mockMultiaddrConnPair({
       addrs: [multiaddr(localMultiAddrStr), multiaddr(allowedMultiAddrStr)],
       remotePeer: allowedPeerId,
     });
@@ -41,7 +41,7 @@ describe('connectionFilter tests', () => {
 
   test('allows selected peers', async () => {
     const filter = new ConnectionFilter([allowedPeerId.toString()]);
-    const { inbound: _localConnection, outbound: remoteConnection } = mockMultiaddrConnPair({
+    const { outbound: remoteConnection } = mockMultiaddrConnPair({
       addrs: [multiaddr(localMultiAddrStr), multiaddr(allowedMultiAddrStr)],
       remotePeer: allowedPeerId,
     });
@@ -59,7 +59,7 @@ describe('connectionFilter tests', () => {
 
   test('filters unknown peers', async () => {
     const filter = new ConnectionFilter([allowedPeerId.toString()]);
-    const { inbound: _localConnection, outbound: remoteConnection } = mockMultiaddrConnPair({
+    const { outbound: remoteConnection } = mockMultiaddrConnPair({
       addrs: [multiaddr(localMultiAddrStr), multiaddr(filteredMultiAddrStr)],
       remotePeer: blockedPeerId,
     });


### PR DESCRIPTION
## Motivation

There were 10 lint warnings for unused variables. In all cases the variables were prefixed with _ indicating that they were unused. This configures the linting rule to respect the convention and flag violations as errors.

## Change Summary

Configures the @typescript-eslint/no-unused-vars lint rule to ignore arguments that match `^_`. 
Removes unused variable declarations from `connectionFilter.test.ts`.

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
