### PR TITLE
fix: Build flatbuffer byte representation from builder

### DIFF
--- a/src/flatbuffers/models/hubStateModel.ts
+++ b/src/flatbuffers/models/hubStateModel.ts
@@ -1,4 +1,4 @@
-import { ByteBuffer } from 'flatbuffers';
+import { Builder, ByteBuffer } from 'flatbuffers';
 import { HubState } from '~/flatbuffers/generated/hub_state_generated';
 import { RootPrefix } from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
@@ -38,7 +38,10 @@ export default class HubStateModel {
   }
 
   toBytes(): Uint8Array {
-    return this.state.bb?.bytes() || new Uint8Array();
+    const builder = new Builder(1);
+    const stateT = this.state.unpack();
+    builder.finish(stateT.pack(builder));
+    return builder.asUint8Array();
   }
 
   lastEthBlock(): bigint {

--- a/src/flatbuffers/models/idRegistryEventModel.ts
+++ b/src/flatbuffers/models/idRegistryEventModel.ts
@@ -1,4 +1,4 @@
-import { ByteBuffer } from 'flatbuffers';
+import { Builder, ByteBuffer } from 'flatbuffers';
 import { IdRegistryEvent, IdRegistryEventType } from '~/flatbuffers/generated/id_registry_event_generated';
 import { RootPrefix } from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
@@ -77,7 +77,10 @@ export default class IdRegistryEventModel {
   }
 
   toBytes(): Uint8Array {
-    return this.event.bb?.bytes() || new Uint8Array();
+    const builder = new Builder(1);
+    const eventT = this.event.unpack();
+    builder.finish(eventT.pack(builder));
+    return builder.asUint8Array();
   }
 
   blockNumber(): number {

--- a/src/flatbuffers/models/messageModel.ts
+++ b/src/flatbuffers/models/messageModel.ts
@@ -1,4 +1,4 @@
-import { ByteBuffer } from 'flatbuffers';
+import { Builder, ByteBuffer } from 'flatbuffers';
 import AbstractRocksDB from 'rocksdb';
 import * as message_generated from '~/flatbuffers/generated/message_generated';
 import { RootPrefix, UserMessagePostfix, UserPostfix } from '~/flatbuffers/models/types';
@@ -238,7 +238,10 @@ export default class MessageModel {
   }
 
   toBytes(): Uint8Array {
-    return this.message.bb?.bytes() ?? new Uint8Array();
+    const builder = new Builder(1);
+    const messageT = this.message.unpack();
+    builder.finish(messageT.pack(builder));
+    return builder.asUint8Array();
   }
 
   tsHash(): Uint8Array {

--- a/src/flatbuffers/models/messageModel.ts
+++ b/src/flatbuffers/models/messageModel.ts
@@ -222,7 +222,10 @@ export default class MessageModel {
   }
 
   dataBytes(): Uint8Array {
-    return this.data.bb?.bytes() ?? new Uint8Array();
+    const builder = new Builder(1);
+    const dataT = this.data.unpack();
+    builder.finish(dataT.pack(builder));
+    return builder.asUint8Array();
   }
 
   primaryKey(): Buffer {

--- a/src/flatbuffers/models/nameRegistryEventModel.ts
+++ b/src/flatbuffers/models/nameRegistryEventModel.ts
@@ -1,4 +1,4 @@
-import { ByteBuffer } from 'flatbuffers';
+import { Builder, ByteBuffer } from 'flatbuffers';
 import { NameRegistryEvent, NameRegistryEventType } from '~/flatbuffers/generated/name_registry_event_generated';
 import { RootPrefix } from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
@@ -57,7 +57,10 @@ export default class NameRegistryEventModel {
   }
 
   toBytes(): Uint8Array {
-    return this.event.bb?.bytes() || new Uint8Array();
+    const builder = new Builder(1);
+    const eventT = this.event.unpack();
+    builder.finish(eventT.pack(builder));
+    return builder.asUint8Array();
   }
 
   blockNumber(): number {


### PR DESCRIPTION
## Motivation

Build the byte representation of a flatbuffer from the `flatbuffers.Builder` instead of using the internal representation.

## Change Summary

- This was causing a nasty bug which would sometimes when the byte representation was being sent over RPC. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

## Additional Context


