### PR TITLE
chrore: Remove 'value' from merkleTrie

### DIFF
--- a/src/flatbuffers/factories.ts
+++ b/src/flatbuffers/factories.ts
@@ -125,17 +125,20 @@ const CastAddDataFactory = Factory.define<message_generated.MessageDataT, any, m
   }
 );
 
-const CastRemoveBodyFactory = Factory.define<message_generated.CastRemoveBodyT, any, message_generated.CastRemoveBody>(
-  ({ onCreate }) => {
-    onCreate((params) => {
-      const builder = new Builder(1);
-      builder.finish(params.pack(builder));
-      return message_generated.CastRemoveBody.getRootAsCastRemoveBody(new ByteBuffer(builder.asUint8Array()));
-    });
+const CastRemoveBodyFactory = Factory.define<
+  message_generated.CastRemoveBodyT,
+  { targetTsHash: number[] },
+  message_generated.CastRemoveBody
+>(({ onCreate, transientParams }) => {
+  onCreate((params) => {
+    const builder = new Builder(1);
+    builder.finish(params.pack(builder));
+    return message_generated.CastRemoveBody.getRootAsCastRemoveBody(new ByteBuffer(builder.asUint8Array()));
+  });
 
-    return new message_generated.CastRemoveBodyT(Array.from(TsHashFactory.build()));
-  }
-);
+  const { targetTsHash } = transientParams;
+  return new message_generated.CastRemoveBodyT(targetTsHash || Array.from(TsHashFactory.build()));
+});
 
 const CastRemoveDataFactory = Factory.define<message_generated.MessageDataT, any, message_generated.MessageData>(
   ({ onCreate }) => {

--- a/src/network/sync/merkleTrie.test.ts
+++ b/src/network/sync/merkleTrie.test.ts
@@ -81,12 +81,12 @@ describe('MerkleTrie', () => {
       trie.insert(syncId);
       expect(trie.items).toEqual(1);
       expect(trie.rootHash).toBeTruthy();
-      expect(trie.get(syncId)).toBeTruthy();
+      expect(trie.exists(syncId)).toBeTruthy();
 
       trie.delete(syncId);
       expect(trie.items).toEqual(0);
       expect(trie.rootHash).toEqual(emptyHash);
-      expect(trie.get(syncId)).toBeFalsy();
+      expect(trie.exists(syncId)).toBeFalsy();
     });
 
     test('deleting an item that does not exist does not change the trie', async () => {
@@ -136,18 +136,18 @@ describe('MerkleTrie', () => {
     });
   });
 
-  test('succeeds getting single item', async () => {
+  test('succeeds with single item', async () => {
     const trie = new MerkleTrie();
     const syncId = await Factories.SyncId.create();
 
-    expect(trie.get(syncId)).toBeFalsy();
+    expect(trie.exists(syncId)).toBeFalsy();
 
     trie.insert(syncId);
 
-    expect(trie.get(syncId)).toEqual(syncId.idString());
+    expect(trie.exists(syncId)).toBeTruthy();
 
     const nonExistingSyncId = await Factories.SyncId.create();
-    expect(trie.get(nonExistingSyncId)).toBeFalsy();
+    expect(trie.exists(nonExistingSyncId)).toBeFalsy();
   });
 
   test('value is always undefined for non-leaf nodes', async () => {

--- a/src/network/sync/merkleTrie.ts
+++ b/src/network/sync/merkleTrie.ts
@@ -43,15 +43,15 @@ class MerkleTrie {
   public insert(id: SyncId): boolean {
     // TODO(aditya): Why should key and value be the same? Just remove the value
     // TODO(aditya): We should insert Uint8Array instead of string
-    return this._root.insert(id.toString(), id.toString());
+    return this._root.insert(id.toString());
   }
 
   public delete(id: SyncId): boolean {
     return this._root.delete(id.toString());
   }
 
-  public get(id: SyncId): string | undefined {
-    return this._root.get(id.toString());
+  public exists(id: SyncId): boolean {
+    return this._root.exists(id.toString());
   }
 
   // A snapshot captures the state of the trie excluding the nodes

--- a/src/network/sync/merkleTrie.ts
+++ b/src/network/sync/merkleTrie.ts
@@ -41,7 +41,6 @@ class MerkleTrie {
   }
 
   public insert(id: SyncId): boolean {
-    // TODO(aditya): Why should key and value be the same? Just remove the value
     // TODO(aditya): We should insert Uint8Array instead of string
     return this._root.insert(id.toString());
   }

--- a/src/network/sync/trieNode.test.ts
+++ b/src/network/sync/trieNode.test.ts
@@ -32,7 +32,7 @@ describe('TrieNode', () => {
       expect(root.items).toEqual(0);
       expect(root.hash).toEqual('');
 
-      root.insert(id.toString(), id.idString());
+      root.insert(id.toString());
 
       expect(root.items).toEqual(1);
       expect(root.hash).toBeTruthy();
@@ -42,36 +42,20 @@ describe('TrieNode', () => {
       const root = new TrieNode();
       const id = await Factories.SyncId.create();
 
-      root.insert(id.toString(), id.idString());
+      root.insert(id.toString());
       expect(root.items).toEqual(1);
       const previousHash = root.hash;
-      root.insert(id.toString(), id.idString());
+      root.insert(id.toString());
 
       expect(root.hash).toEqual(previousHash);
       expect(root.items).toEqual(1);
-    });
-
-    test('inserting the same key with a different value does nothing', async () => {
-      const root = new TrieNode();
-      const id = await Factories.SyncId.create();
-      const id2 = await Factories.SyncId.create();
-
-      root.insert(id.toString(), id.idString());
-      expect(root.items).toEqual(1);
-      expect(root.get(id.toString())).toEqual(id.idString());
-      const previousHash = root.hash;
-      root.insert(id.toString(), id2.idString());
-
-      expect(root.hash).toEqual(previousHash);
-      expect(root.items).toEqual(1);
-      expect(root.get(id.toString())).toEqual(id.idString());
     });
 
     test('insert compacts hashstring component of syncid to single node for efficiency', async () => {
       const root = new TrieNode();
       const id = await Factories.SyncId.create();
 
-      root.insert(id.toString(), id.idString());
+      root.insert(id.toString());
       let node = root;
       // Timestamp portion of the key is not collapsed, but the hash portion is
       for (let i = 0; i < TIMESTAMP_LENGTH; i++) {
@@ -102,8 +86,8 @@ describe('TrieNode', () => {
       const firstDiffPos = hash1.split('').findIndex((c, i) => c !== hash2[i]);
 
       const root = new TrieNode();
-      root.insert(id1.toString(), id1.idString());
-      root.insert(id2.toString(), id2.idString());
+      root.insert(id1.toString());
+      root.insert(id2.toString());
 
       const splitNode = traverse(root);
       expect(splitNode.items).toEqual(2);
@@ -127,7 +111,7 @@ describe('TrieNode', () => {
       const root = new TrieNode();
       const id = await Factories.SyncId.create();
 
-      root.insert(id.toString(), id.idString());
+      root.insert(id.toString());
       expect(root.items).toEqual(1);
 
       root.delete(id.toString());
@@ -140,14 +124,14 @@ describe('TrieNode', () => {
       const id1 = await Factories.SyncId.create(undefined, { transient: { date: sharedDate } });
       const id2 = await Factories.SyncId.create(undefined, { transient: { date: sharedDate } });
 
-      root.insert(id1.toString(), id1.idString());
+      root.insert(id1.toString());
       const previousHash = root.hash;
-      root.insert(id2.toString(), id2.idString());
+      root.insert(id2.toString());
       expect(root.items).toEqual(2);
 
       root.delete(id2.toString());
       expect(root.items).toEqual(1);
-      expect(root.get(id2.toString())).toBeUndefined();
+      expect(root.exists(id2.toString())).toBeFalsy();
       expect(root.hash).toEqual(previousHash);
     });
 
@@ -160,10 +144,10 @@ describe('TrieNode', () => {
       });
 
       const root = new TrieNode();
-      root.insert(id1.toString(), id1.idString());
+      root.insert(id1.toString());
       const previousRootHash = root.hash;
       const leafNode = traverse(root);
-      root.insert(id2.toString(), id2.idString());
+      root.insert(id2.toString());
 
       expect(root.hash).not.toEqual(previousRootHash);
 
@@ -180,22 +164,21 @@ describe('TrieNode', () => {
       const root = new TrieNode();
       const id = await Factories.SyncId.create();
 
-      root.insert(id.toString(), id.idString());
+      root.insert(id.toString());
       expect(root.items).toEqual(1);
 
-      const value = root.get(id.toString());
-      expect(value).toEqual(id.idString());
+      expect(root.exists(id.toString())).toBeTruthy();
     });
 
     test('getting an item after deleting it returns undefined', async () => {
       const root = new TrieNode();
       const id = await Factories.SyncId.create();
 
-      root.insert(id.toString(), id.idString());
+      root.insert(id.toString());
       expect(root.items).toEqual(1);
 
       root.delete(id.toString());
-      expect(root.get(id.toString())).toBeUndefined();
+      expect(root.exists(id.toString())).toBeFalsy();
       expect(root.items).toEqual(0);
     });
 
@@ -208,10 +191,10 @@ describe('TrieNode', () => {
       });
 
       const root = new TrieNode();
-      root.insert(id1.toString(), id1.idString());
+      root.insert(id1.toString());
 
       // id2 shares the same prefix, but doesn't exist, so it should return undefined
-      expect(root.get(id2.toString())).toBeUndefined();
+      expect(root.exists(id2.toString())).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
## Motivation

Remove the `value` field from the Merkle Trie used for sync, since it is the same as the `key`

## Change Summary

- Remove the `value` field from the trie to save memory. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

## Additional Context
