### PR TITLE
refactor: update gRPC EventResponse to use bytes directly

### DIFF
--- a/src/flatbuffers/schemas/rpc.fbs
+++ b/src/flatbuffers/schemas/rpc.fbs
@@ -1,5 +1,4 @@
 include "message.fbs";
-include "id_registry_event.fbs";
 
 // IDL file for Farcaster RPC Requests
 
@@ -9,7 +8,8 @@ enum EventType: uint8 {
   MergeMessage = 0,
   PruneMessage = 1,
   RevokeMessage = 2,
-  MergeContractEvent = 3
+  MergeIdRegistryEvent = 3,
+  MergeNameRegistryEvent = 4
 }
 
 // Responses
@@ -27,8 +27,7 @@ table FidsResponse {
 
 table EventResponse {
   type: EventType;
-  message: Message;
-  contract_event: IdRegistryEvent;
+  bytes: [ubyte];
 }
 
 // A partial trie node response

--- a/src/rpc/client/index.ts
+++ b/src/rpc/client/index.ts
@@ -7,11 +7,7 @@ import { IdRegistryEvent } from '~/flatbuffers/generated/id_registry_event_gener
 import { CastId, Message, ReactionType, UserDataType, UserId } from '~/flatbuffers/generated/message_generated';
 import { NameRegistryEvent } from '~/flatbuffers/generated/name_registry_event_generated';
 import * as rpc_generated from '~/flatbuffers/generated/rpc_generated';
-import {
-  GetAllSyncIdsByPrefixResponse,
-  MessagesResponse,
-  TrieNodeMetadataResponse,
-} from '~/flatbuffers/generated/rpc_generated';
+import { GetAllSyncIdsByPrefixResponse, TrieNodeMetadataResponse } from '~/flatbuffers/generated/rpc_generated';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel';
@@ -309,7 +305,7 @@ class Client {
   }
 
   async getAllMessagesBySyncIds(hashes: Uint8Array[]): HubAsyncResult<MessageModel[]> {
-    return this.makeUnaryMessagesByHashesRequest(
+    return this.makeUnaryMessagesRequest(
       definitions.syncDefinition().getAllMessagesBySyncIds,
       createAllMessagesByHashesRequest(hashes)
     );
@@ -463,33 +459,33 @@ class Client {
     });
   }
 
-  private makeUnaryMessagesByHashesRequest<RequestType, ResponseMessageType extends MessageModel>(
-    method: grpc.MethodDefinition<RequestType, MessagesResponse>,
-    request: RequestType
-  ): HubAsyncResult<ResponseMessageType[]> {
-    return new Promise((resolve) => {
-      this.client.makeUnaryRequest(
-        method.path,
-        method.requestSerialize,
-        method.responseDeserialize,
-        request,
-        (e: grpc.ServiceError | null, response?: MessagesResponse) => {
-          if (e) {
-            resolve(err(fromServiceError(e)));
-          } else if (response) {
-            const messages: ResponseMessageType[] = [];
-            for (let i = 0; i < response.messagesLength(); i++) {
-              const mb = Message.getRootAsMessage(
-                new ByteBuffer(response.messages(i)?.messageBytesArray() ?? new Uint8Array())
-              );
-              messages.push(new MessageModel(mb) as ResponseMessageType);
-            }
-            resolve(ok(messages));
-          }
-        }
-      );
-    });
-  }
+  // private makeUnaryMessagesByHashesRequest<RequestType, ResponseMessageType extends MessageModel>(
+  //   method: grpc.MethodDefinition<RequestType, MessagesResponse>,
+  //   request: RequestType
+  // ): HubAsyncResult<ResponseMessageType[]> {
+  //   return new Promise((resolve) => {
+  //     this.client.makeUnaryRequest(
+  //       method.path,
+  //       method.requestSerialize,
+  //       method.responseDeserialize,
+  //       request,
+  //       (e: grpc.ServiceError | null, response?: MessagesResponse) => {
+  //         if (e) {
+  //           resolve(err(fromServiceError(e)));
+  //         } else if (response) {
+  //           const messages: ResponseMessageType[] = [];
+  //           for (let i = 0; i < response.messagesLength(); i++) {
+  //             const mb = Message.getRootAsMessage(
+  //               new ByteBuffer(response.messages(i)?.messageBytesArray() ?? new Uint8Array())
+  //             );
+  //             messages.push(new MessageModel(mb) as ResponseMessageType);
+  //           }
+  //           resolve(ok(messages));
+  //         }
+  //       }
+  //     );
+  //   });
+  // }
 
   private makeUnaryMessagesRequest<RequestType, ResponseMessageType extends MessageModel>(
     method: grpc.MethodDefinition<RequestType, rpc_generated.MessagesResponse>,
@@ -507,10 +503,9 @@ class Client {
           } else if (response) {
             const messages: ResponseMessageType[] = [];
             for (let i = 0; i < response.messagesLength(); i++) {
-              const mb = Message.getRootAsMessage(
-                new ByteBuffer(response.messages(i)?.messageBytesArray() ?? new Uint8Array())
+              messages.push(
+                MessageModel.from(response.messages(i)?.messageBytesArray() ?? new Uint8Array()) as ResponseMessageType
               );
-              messages.push(new MessageModel(mb) as ResponseMessageType);
             }
             resolve(ok(messages));
           }

--- a/src/rpc/client/index.ts
+++ b/src/rpc/client/index.ts
@@ -459,34 +459,6 @@ class Client {
     });
   }
 
-  // private makeUnaryMessagesByHashesRequest<RequestType, ResponseMessageType extends MessageModel>(
-  //   method: grpc.MethodDefinition<RequestType, MessagesResponse>,
-  //   request: RequestType
-  // ): HubAsyncResult<ResponseMessageType[]> {
-  //   return new Promise((resolve) => {
-  //     this.client.makeUnaryRequest(
-  //       method.path,
-  //       method.requestSerialize,
-  //       method.responseDeserialize,
-  //       request,
-  //       (e: grpc.ServiceError | null, response?: MessagesResponse) => {
-  //         if (e) {
-  //           resolve(err(fromServiceError(e)));
-  //         } else if (response) {
-  //           const messages: ResponseMessageType[] = [];
-  //           for (let i = 0; i < response.messagesLength(); i++) {
-  //             const mb = Message.getRootAsMessage(
-  //               new ByteBuffer(response.messages(i)?.messageBytesArray() ?? new Uint8Array())
-  //             );
-  //             messages.push(new MessageModel(mb) as ResponseMessageType);
-  //           }
-  //           resolve(ok(messages));
-  //         }
-  //       }
-  //     );
-  //   });
-  // }
-
   private makeUnaryMessagesRequest<RequestType, ResponseMessageType extends MessageModel>(
     method: grpc.MethodDefinition<RequestType, rpc_generated.MessagesResponse>,
     request: RequestType

--- a/src/rpc/server/serviceImplementations/eventImplementation.ts
+++ b/src/rpc/server/serviceImplementations/eventImplementation.ts
@@ -3,6 +3,7 @@ import { Builder, ByteBuffer } from 'flatbuffers';
 import { EventResponse, EventResponseT, EventType, SubscribeRequest } from '~/flatbuffers/generated/rpc_generated';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
+import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel';
 import Engine from '~/storage/engine';
 
 const packAndWriteEventResponse = (
@@ -19,29 +20,35 @@ export const eventImplementation = (engine: Engine) => {
   return {
     subscribe: async (stream: grpc.ServerWritableStream<SubscribeRequest, EventResponse>) => {
       const mergeMessageListener = (message: MessageModel) => {
-        const unpackedResponse = new EventResponseT(EventType.MergeMessage, message.message.unpack(), undefined);
+        const unpackedResponse = new EventResponseT(EventType.MergeMessage, Array.from(message.toBytes()));
         packAndWriteEventResponse(unpackedResponse, stream);
       };
 
       const pruneMessageListener = (message: MessageModel) => {
-        const unpackedResponse = new EventResponseT(EventType.PruneMessage, message.message.unpack(), undefined);
+        const unpackedResponse = new EventResponseT(EventType.PruneMessage, Array.from(message.toBytes()));
         packAndWriteEventResponse(unpackedResponse, stream);
       };
 
       const revokeMessageListener = (message: MessageModel) => {
-        const unpackedResponse = new EventResponseT(EventType.RevokeMessage, message.message.unpack(), undefined);
+        const unpackedResponse = new EventResponseT(EventType.RevokeMessage, Array.from(message.toBytes()));
         packAndWriteEventResponse(unpackedResponse, stream);
       };
 
-      const mergeEventListener = (event: IdRegistryEventModel) => {
-        const unpackedResponse = new EventResponseT(EventType.MergeContractEvent, undefined, event.event.unpack());
+      const mergeIdRegistryEventListener = (event: IdRegistryEventModel) => {
+        const unpackedResponse = new EventResponseT(EventType.MergeIdRegistryEvent, Array.from(event.toBytes()));
+        packAndWriteEventResponse(unpackedResponse, stream);
+      };
+
+      const mergeNameRegistryEventListener = (event: NameRegistryEventModel) => {
+        const unpackedResponse = new EventResponseT(EventType.MergeNameRegistryEvent, Array.from(event.toBytes()));
         packAndWriteEventResponse(unpackedResponse, stream);
       };
 
       engine.eventHandler.on('mergeMessage', mergeMessageListener);
       engine.eventHandler.on('pruneMessage', pruneMessageListener);
       engine.eventHandler.on('revokeMessage', revokeMessageListener);
-      engine.eventHandler.on('mergeIdRegistryEvent', mergeEventListener);
+      engine.eventHandler.on('mergeIdRegistryEvent', mergeIdRegistryEventListener);
+      engine.eventHandler.on('mergeNameRegistryEvent', mergeNameRegistryEventListener);
 
       stream.on('cancelled', () => {
         stream.destroy();
@@ -51,7 +58,8 @@ export const eventImplementation = (engine: Engine) => {
         engine.eventHandler.off('mergeMessage', mergeMessageListener);
         engine.eventHandler.off('pruneMessage', pruneMessageListener);
         engine.eventHandler.off('revokeMessage', revokeMessageListener);
-        engine.eventHandler.off('mergeIdRegistryEvent', mergeEventListener);
+        engine.eventHandler.off('mergeIdRegistryEvent', mergeIdRegistryEventListener);
+        engine.eventHandler.off('mergeNameRegistryEvent', mergeNameRegistryEventListener);
       });
 
       const readyMetadata = new Metadata();

--- a/src/rpc/test/ampService.test.ts
+++ b/src/rpc/test/ampService.test.ts
@@ -103,8 +103,7 @@ describe('getAmpsByFid', () => {
   test('succeeds', async () => {
     await engine.mergeMessage(ampAdd);
     const amps = await client.getAmpsByFid(fid);
-    // The underlying buffers are different, so we can't compare full messages directly
-    expect(amps._unsafeUnwrap().map((msg) => msg.hash())).toEqual([ampAdd.hash()]);
+    expect(amps._unsafeUnwrap()).toEqual([ampAdd]);
   });
 
   test('returns empty array without messages', async () => {
@@ -122,8 +121,7 @@ describe('getAmpsByUser', () => {
   test('succeeds', async () => {
     await engine.mergeMessage(ampAdd);
     const amps = await client.getAmpsByUser(ampAdd.body().user() ?? new UserId());
-    // The underlying buffers are different, so we can't compare full messages directly
-    expect(amps._unsafeUnwrap().map((msg) => msg.hash())).toEqual([ampAdd.hash()]);
+    expect(amps._unsafeUnwrap()).toEqual([ampAdd]);
   });
 
   test('returns empty array without messages', async () => {

--- a/src/rpc/test/castService.test.ts
+++ b/src/rpc/test/castService.test.ts
@@ -105,8 +105,7 @@ describe('getCastsByFid', () => {
   test('succeeds', async () => {
     await engine.mergeMessage(castAdd);
     const casts = await client.getCastsByFid(fid);
-    // The underlying buffers are different, so we can't compare casts to [castAdd] directly
-    expect(casts._unsafeUnwrap().map((cast) => cast.hash())).toEqual([castAdd.hash()]);
+    expect(casts._unsafeUnwrap()).toEqual([castAdd]);
   });
 
   test('returns empty array without casts', async () => {
@@ -124,8 +123,7 @@ describe('getCastsByParent', () => {
   test('succeeds', async () => {
     await engine.mergeMessage(castAdd);
     const casts = await client.getCastsByParent(castAdd.body().parent() ?? new CastId());
-    // The underlying buffers are different, so we can't compare casts to [castAdd] directly
-    expect(casts._unsafeUnwrap().map((cast) => cast.hash())).toEqual([castAdd.hash()]);
+    expect(casts._unsafeUnwrap()).toEqual([castAdd]);
   });
 
   test('returns empty array without casts', async () => {

--- a/src/rpc/test/reactionService.test.ts
+++ b/src/rpc/test/reactionService.test.ts
@@ -160,14 +160,12 @@ describe('getReactionsByFid', () => {
 
     test('succeeds with type Like', async () => {
       const reactions = await client.getReactionsByFid(fid, ReactionType.Like);
-      // The underlying buffers are different, so we can't compare full objects
-      expect(reactions._unsafeUnwrap().map((reaction) => reaction.hash())).toEqual([reactionAddLike.hash()]);
+      expect(reactions._unsafeUnwrap()).toEqual([reactionAddLike]);
     });
 
     test('succeeds with type Recast', async () => {
       const reactions = await client.getReactionsByFid(fid, ReactionType.Recast);
-      // The underlying buffers are different, so we can't compare full objects
-      expect(reactions._unsafeUnwrap().map((reaction) => reaction.hash())).toEqual([reactionAddRecast.hash()]);
+      expect(reactions._unsafeUnwrap()).toEqual([reactionAddRecast]);
     });
   });
 
@@ -191,23 +189,17 @@ describe('getReactionsByCast', () => {
 
     test('succeeds without type', async () => {
       const reactions = await client.getReactionsByCast(castId);
-      // The underlying buffers are different, so we can't compare full objects
-      expect(reactions._unsafeUnwrap().map((reaction) => reaction.hash())).toEqual([
-        reactionAddLike.hash(),
-        reactionAddRecast.hash(),
-      ]);
+      expect(reactions._unsafeUnwrap()).toEqual([reactionAddLike, reactionAddRecast]);
     });
 
     test('succeeds with type Like', async () => {
       const reactions = await client.getReactionsByCast(castId, ReactionType.Like);
-      // The underlying buffers are different, so we can't compare full objects
-      expect(reactions._unsafeUnwrap().map((reaction) => reaction.hash())).toEqual([reactionAddLike.hash()]);
+      expect(reactions._unsafeUnwrap()).toEqual([reactionAddLike]);
     });
 
     test('succeeds with type Recast', async () => {
       const reactions = await client.getReactionsByCast(castId, ReactionType.Recast);
-      // The underlying buffers are different, so we can't compare full objects
-      expect(reactions._unsafeUnwrap().map((reaction) => reaction.hash())).toEqual([reactionAddRecast.hash()]);
+      expect(reactions._unsafeUnwrap()).toEqual([reactionAddRecast]);
     });
   });
 

--- a/src/rpc/test/signerService.test.ts
+++ b/src/rpc/test/signerService.test.ts
@@ -90,7 +90,7 @@ describe('getSignersByFid', () => {
   test('succeeds', async () => {
     await engine.mergeMessage(signerAdd);
     const result = await client.getSignersByFid(fid);
-    expect(result._unsafeUnwrap().map((msg) => msg.hash())).toEqual([signerAdd.hash()]);
+    expect(result._unsafeUnwrap()).toEqual([signerAdd]);
   });
 
   test('returns empty array without messages', async () => {

--- a/src/rpc/test/syncService.test.ts
+++ b/src/rpc/test/syncService.test.ts
@@ -69,7 +69,7 @@ beforeAll(async () => {
 });
 
 const assertMessagesMatchResult = (result: HubResult<MessageModel[]>, messages: MessageModel[]) => {
-  expect(new Set(result._unsafeUnwrap().map((msg) => msg.hash()))).toEqual(new Set(messages.map((msg) => msg.hash())));
+  expect(new Set(result._unsafeUnwrap())).toEqual(new Set(messages));
 };
 
 describe('getAllCastMessagesByFid', () => {

--- a/src/rpc/test/userDataService.test.ts
+++ b/src/rpc/test/userDataService.test.ts
@@ -139,9 +139,7 @@ describe('getUserDataByFid', () => {
     await engine.mergeMessage(pfpAdd);
     await engine.mergeMessage(locationAdd);
     const result = await client.getUserDataByFid(fid);
-    expect(new Set(result._unsafeUnwrap().map((msg) => msg.hash()))).toEqual(
-      new Set([pfpAdd.hash(), locationAdd.hash()])
-    );
+    expect(new Set(result._unsafeUnwrap())).toEqual(new Set([pfpAdd, locationAdd]));
   });
 
   test('returns empty array without messages', async () => {

--- a/src/rpc/test/verificationService.test.ts
+++ b/src/rpc/test/verificationService.test.ts
@@ -106,8 +106,7 @@ describe('getVerificationsByFid', () => {
   test('succeeds', async () => {
     await engine.mergeMessage(verificationAdd);
     const verifications = await client.getVerificationsByFid(fid);
-    // The underlying buffers are different, so we can't compare full objects
-    expect(verifications._unsafeUnwrap().map((msg) => msg.hash())).toEqual([verificationAdd.hash()]);
+    expect(verifications._unsafeUnwrap()).toEqual([verificationAdd]);
   });
 
   test('returns empty array without messages', async () => {


### PR DESCRIPTION
## Motivation

We need to refactor EventResponse as well as MessagesResponse to nest the flatbuffer byte array directly rather than including the flatbuffer table.

## Change Summary

* Update `EventResponse` flatbuffer to include `bytes: [ubyte]`
* Update gRPC events service to pack the message or event bytes
* Simplify gRPC tests now that MessagesResponse is fixed

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
