### PR TITLE
chore: Use farcaster time when creating snapshots

### DIFF
--- a/src/network/sync/syncEngine.test.ts
+++ b/src/network/sync/syncEngine.test.ts
@@ -6,6 +6,7 @@ import { MessageType } from '~/flatbuffers/generated/message_generated';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { CastAddModel, CastRemoveModel, KeyPair, SignerAddModel } from '~/flatbuffers/models/types';
+import { getFarcasterTime } from '~/flatbuffers/utils/time';
 import SyncEngine from '~/network/sync/syncEngine';
 import { SyncId } from '~/network/sync/syncId';
 import Client from '~/rpc/client';
@@ -128,10 +129,13 @@ describe('SyncEngine', () => {
 
     // The trie should contain the message remove
     expect(syncEngine.trie.exists(id)).toBeTruthy();
+
+    // The trie should not contain the cast add
+    expect(syncEngine.trie.exists(new SyncId(castAdd))).toBeFalsy();
   });
 
   test('snapshotTimestampPrefix trims the seconds', async () => {
-    const nowInSeconds = Date.now() / 1000;
+    const nowInSeconds = getFarcasterTime();
     const snapshotTimestamp = syncEngine.snapshotTimestamp;
     expect(snapshotTimestamp).toBeLessThanOrEqual(nowInSeconds);
     expect(snapshotTimestamp).toEqual(Math.floor(nowInSeconds / 10) * 10);

--- a/src/network/sync/syncEngine.ts
+++ b/src/network/sync/syncEngine.ts
@@ -1,12 +1,13 @@
 import { arrayify } from 'ethers/lib/utils';
 import { err } from 'neverthrow';
 import MessageModel from '~/flatbuffers/models/messageModel';
+import { getFarcasterTime } from '~/flatbuffers/utils/time';
 import Client from '~/rpc/client';
 import Engine from '~/storage/engine';
 import { HubError, HubResult } from '~/utils/hubErrors';
 import { logger } from '~/utils/logger';
 import { MerkleTrie, NodeMetadata } from './merkleTrie';
-import { SyncId } from './syncId';
+import { SyncId, timestampToPaddedTimestampPrefix } from './syncId';
 import { TrieSnapshot } from './trieNode';
 
 // Number of seconds to wait for the network to "settle" before syncing. We will only
@@ -209,13 +210,13 @@ class SyncEngine {
   public get snapshot(): TrieSnapshot {
     // Ignore the least significant digit when fetching the snapshot timestamp because
     // second resolution is too fine grained, and fall outside sync threshold anyway
-    return this._trie.getSnapshot((this.snapshotTimestamp / 10).toString());
+    return this._trie.getSnapshot(timestampToPaddedTimestampPrefix(this.snapshotTimestamp / 10).toString());
   }
 
   // Returns the most recent timestamp in seconds that's within the sync threshold
   // (i.e. highest timestamp that's < current time and timestamp % sync_threshold == 0)
   public get snapshotTimestamp(): number {
-    const currentTimeInSeconds = Math.floor(Date.now() / 1000);
+    const currentTimeInSeconds = Math.floor(getFarcasterTime());
     return Math.floor(currentTimeInSeconds / SYNC_THRESHOLD_IN_SECONDS) * SYNC_THRESHOLD_IN_SECONDS;
   }
 

--- a/src/network/sync/syncId.ts
+++ b/src/network/sync/syncId.ts
@@ -29,7 +29,7 @@ class SyncId {
     // For our MerkleTrie, seconds is a good enough resolution
     // We also want to normalize the length to 10 characters, so that the MerkleTrie
     // will always have the same depth for any timestamp (even 0).
-    const timestampString = Math.floor(this._timestamp).toString().padStart(TIMESTAMP_LENGTH, '0');
+    const timestampString = timestampToPaddedTimestampPrefix(this._timestamp);
 
     const buf = MessageModel.primaryKey(this._fid, MessageModel.typeToSetPostfix(this._type), this._tsHash);
     return timestampString + buf.toString('hex');
@@ -47,4 +47,8 @@ class SyncId {
   }
 }
 
-export { SyncId, TIMESTAMP_LENGTH, HASH_LENGTH };
+const timestampToPaddedTimestampPrefix = (timestamp: number): string => {
+  return Math.floor(timestamp).toString().padStart(TIMESTAMP_LENGTH, '0');
+};
+
+export { SyncId, timestampToPaddedTimestampPrefix, TIMESTAMP_LENGTH, HASH_LENGTH };


### PR DESCRIPTION
## Motivation

Use `getFarcasterTime()` to get the current time instead of `Date.now()` when creating snapshots

## Change Summary

We use farcaster time instead of wall time in message timestamps, so we should use the same to create the snapshots. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

