### PR TITLE
fix: Emit revoke messages when casts, reactions and amps are removed

### DIFF
--- a/src/flatbuffers/factories.ts
+++ b/src/flatbuffers/factories.ts
@@ -125,20 +125,17 @@ const CastAddDataFactory = Factory.define<message_generated.MessageDataT, any, m
   }
 );
 
-const CastRemoveBodyFactory = Factory.define<
-  message_generated.CastRemoveBodyT,
-  { targetTsHash: number[] },
-  message_generated.CastRemoveBody
->(({ onCreate, transientParams }) => {
-  onCreate((params) => {
-    const builder = new Builder(1);
-    builder.finish(params.pack(builder));
-    return message_generated.CastRemoveBody.getRootAsCastRemoveBody(new ByteBuffer(builder.asUint8Array()));
-  });
+const CastRemoveBodyFactory = Factory.define<message_generated.CastRemoveBodyT, any, message_generated.CastRemoveBody>(
+  ({ onCreate }) => {
+    onCreate((params) => {
+      const builder = new Builder(1);
+      builder.finish(params.pack(builder));
+      return message_generated.CastRemoveBody.getRootAsCastRemoveBody(new ByteBuffer(builder.asUint8Array()));
+    });
 
-  const { targetTsHash } = transientParams;
-  return new message_generated.CastRemoveBodyT(targetTsHash || Array.from(TsHashFactory.build()));
-});
+    return new message_generated.CastRemoveBodyT(Array.from(TsHashFactory.build()));
+  }
+);
 
 const CastRemoveDataFactory = Factory.define<message_generated.MessageDataT, any, message_generated.MessageData>(
   ({ onCreate }) => {

--- a/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/src/network/sync/multiPeerSyncEngine.test.ts
@@ -205,6 +205,12 @@ describe('Multi peer sync engine', () => {
     expect(syncEngine2.trie.exists(castRemoveId)).toBeTruthy();
     expect(syncEngine2.trie.exists(new SyncId(castAdd))).toBeFalsy();
     expect(syncEngine2.trie.rootHash).toEqual(syncEngine1.trie.rootHash);
+
+    // Adding the castAdd to engine2 should not change the root hash,
+    // because it has already been removed, so adding it is a no-op
+    const beforeRootHash = syncEngine2.trie.rootHash;
+    await engine2.mergeMessage(castAdd);
+    expect(syncEngine2.trie.rootHash).toEqual(beforeRootHash);
   });
 
   xtest(

--- a/src/network/sync/syncEngine.test.ts
+++ b/src/network/sync/syncEngine.test.ts
@@ -130,7 +130,7 @@ describe('SyncEngine', () => {
     // The trie should contain the message remove
     expect(syncEngine.trie.exists(id)).toBeTruthy();
 
-    // The trie should not contain the cast add
+    // The trie should not contain the castAdd anymore
     expect(syncEngine.trie.exists(new SyncId(castAdd))).toBeFalsy();
   });
 


### PR DESCRIPTION
## Motivation

Emit revoke messages from the engine when casts, amps and reactions are removed, so they can be updated in the sync Trie

## Change Summary

- Emit 'revokeMessage' when casts, amps and reactions are removed
- Insert the revoked message into the trie and remove the corresponding add message from the trie.
- Add test for revoke

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

## Additional Context

