### PR TITLE
feat: add PruneMessagesJobScheduler

### DIFF
--- a/app/src/hub.ts
+++ b/app/src/hub.ts
@@ -27,11 +27,11 @@ import SyncEngine from '~/network/sync/syncEngine';
 import Server from '~/rpc/server';
 import BinaryRocksDB from '~/storage/db/rocksdb';
 import Engine from '~/storage/engine';
+import { PruneMessagesJobScheduler } from '~/storage/jobs/pruneMessagesJob';
 import { RevokeSignerJobQueue, RevokeSignerJobScheduler } from '~/storage/jobs/revokeSignerJob';
 import { HubAsyncResult, HubError } from '~/utils/hubErrors';
 import { idRegistryEventToLog, logger, messageToLog, nameRegistryEventToLog } from '~/utils/logger';
 import { addressInfoFromGossip, ipFamilyToString, p2pMultiAddrStr } from '~/utils/p2p';
-import { PruneMessagesJobScheduler } from './storage/jobs/pruneMessagesJob';
 
 export interface HubOptions {
   /** The PeerId of this Hub */

--- a/app/src/hub.ts
+++ b/app/src/hub.ts
@@ -31,6 +31,7 @@ import { RevokeSignerJobQueue, RevokeSignerJobScheduler } from '~/storage/jobs/r
 import { HubAsyncResult, HubError } from '~/utils/hubErrors';
 import { idRegistryEventToLog, logger, messageToLog, nameRegistryEventToLog } from '~/utils/logger';
 import { addressInfoFromGossip, ipFamilyToString, p2pMultiAddrStr } from '~/utils/p2p';
+import { PruneMessagesJobScheduler } from './storage/jobs/pruneMessagesJob';
 
 export interface HubOptions {
   /** The PeerId of this Hub */
@@ -72,6 +73,9 @@ export interface HubOptions {
 
   /** Cron schedule for revoke signer jobs */
   revokeSignerJobCron?: string;
+
+  /** Cron schedule for prune messages job */
+  pruneMessagesJobCron?: string;
 }
 
 /** @returns A randomized string of the format `rocksdb.tmp.*` used for the DB Name */
@@ -101,6 +105,7 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
 
   private revokeSignerJobQueue: RevokeSignerJobQueue;
   private revokeSignerJobScheduler: RevokeSignerJobScheduler;
+  private pruneMessagesJobScheduler: PruneMessagesJobScheduler;
 
   engine: Engine;
   ethRegistryProvider: EthEventsProvider;
@@ -128,6 +133,7 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
 
     // Setup job schedulers
     this.revokeSignerJobScheduler = new RevokeSignerJobScheduler(this.revokeSignerJobQueue, this.engine);
+    this.pruneMessagesJobScheduler = new PruneMessagesJobScheduler(this.engine);
   }
 
   get rpcAddress() {
@@ -170,13 +176,15 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
     this.registerEventHandlers();
 
     // Start cron tasks
-    this.revokeSignerJobScheduler.start();
+    this.revokeSignerJobScheduler.start(this.options.revokeSignerJobCron);
+    this.pruneMessagesJobScheduler.start(this.options.pruneMessagesJobCron);
   }
 
   /** Stop the GossipNode and RPC Server */
   async stop() {
     clearInterval(this.contactTimer);
     this.revokeSignerJobScheduler.stop();
+    this.pruneMessagesJobScheduler.stop();
     await this.ethRegistryProvider.stop();
     await this.rpcServer.stop();
     await this.rocksDB.close();

--- a/app/src/storage/engine/index.ts
+++ b/app/src/storage/engine/index.ts
@@ -106,6 +106,17 @@ class Engine {
     return ok(undefined);
   }
 
+  async pruneMessages(fid: Uint8Array): HubAsyncResult<void> {
+    await this._castStore.pruneMessages(fid);
+    await this._ampStore.pruneMessages(fid);
+    await this._reactionStore.pruneMessages(fid);
+    await this._verificationStore.pruneMessages(fid);
+    await this._userDataStore.pruneMessages(fid);
+    await this._signerStore.pruneMessages(fid);
+
+    return ok(undefined);
+  }
+
   /* -------------------------------------------------------------------------- */
   /*                             Cast Store Methods                             */
   /* -------------------------------------------------------------------------- */

--- a/app/src/storage/jobs/pruneMessagesJob.test.ts
+++ b/app/src/storage/jobs/pruneMessagesJob.test.ts
@@ -1,0 +1,94 @@
+import Factories from '~/flatbuffers/factories';
+import MessageModel from '~/flatbuffers/models/messageModel';
+import { AmpAddModel, CastAddModel, KeyPair } from '~/flatbuffers/models/types';
+import { jestRocksDB } from '~/storage/db/jestUtils';
+import Engine from '~/storage/engine';
+import { seedSigner } from '~/storage/engine/seed';
+import { generateEd25519KeyPair } from '~/utils/crypto';
+import { PruneMessagesJobScheduler } from './pruneMessagesJob';
+
+const db = jestRocksDB('jobs.pruneMessagesJob.test');
+
+const engine = new Engine(db);
+const scheduler = new PruneMessagesJobScheduler(engine);
+
+// Use farcaster timestamp
+const seedMessagesFromTimestamp = async (engine: Engine, fid: Uint8Array, signer: KeyPair, timestamp: number) => {
+  const castAddData = await Factories.CastAddData.create({ fid: Array.from(fid), timestamp });
+  const castAdd = new MessageModel(
+    await Factories.Message.create(
+      { data: Array.from(castAddData.bb?.bytes() ?? new Uint8Array()) },
+      { transient: { signer } }
+    )
+  ) as CastAddModel;
+
+  const ampAddData = await Factories.AmpAddData.create({ fid: Array.from(fid), timestamp });
+  const ampAdd = new MessageModel(
+    await Factories.Message.create(
+      { data: Array.from(ampAddData.bb?.bytes() ?? new Uint8Array()) },
+      { transient: { signer } }
+    )
+  ) as AmpAddModel;
+
+  return engine.mergeMessages([castAdd, ampAdd]);
+};
+
+let prunedMessages: MessageModel[] = [];
+
+const pruneMessageListener = (message: MessageModel) => {
+  prunedMessages.push(message);
+};
+
+beforeAll(() => {
+  engine.eventHandler.on('pruneMessage', pruneMessageListener);
+});
+
+beforeEach(() => {
+  prunedMessages = [];
+});
+
+afterAll(() => {
+  engine.eventHandler.off('pruneMessage', pruneMessageListener);
+});
+
+describe('doJobs', () => {
+  test('succeeds without fids', async () => {
+    const result = await scheduler.doJobs();
+    expect(result._unsafeUnwrap()).toEqual(undefined);
+  });
+
+  test('prunes messages for all fids', async () => {
+    const timestampToPrune = 1; // 1 second after farcaster epoch (1/1/22)
+
+    const fid1 = Factories.FID.build();
+    const signer1 = await generateEd25519KeyPair();
+    await seedSigner(engine, fid1, signer1.publicKey);
+    await seedMessagesFromTimestamp(engine, fid1, signer1, timestampToPrune);
+
+    const fid2 = Factories.FID.build();
+    const signer2 = await generateEd25519KeyPair();
+    await seedSigner(engine, fid2, signer2.publicKey);
+    await seedMessagesFromTimestamp(engine, fid2, signer2, timestampToPrune);
+
+    for (const fid of [fid1, fid2]) {
+      const casts = await engine.getCastsByFid(fid);
+      expect(casts._unsafeUnwrap().length).toEqual(1);
+
+      const amps = await engine.getAmpsByFid(fid);
+      expect(amps._unsafeUnwrap().length).toEqual(1);
+    }
+
+    const result = await scheduler.doJobs();
+    expect(result._unsafeUnwrap()).toEqual(undefined);
+
+    for (const fid of [fid1, fid2]) {
+      const casts = await engine.getCastsByFid(fid);
+      expect(casts._unsafeUnwrap()).toEqual([]);
+
+      const amps = await engine.getAmpsByFid(fid);
+      expect(amps._unsafeUnwrap()).toEqual([]);
+    }
+
+    expect(prunedMessages.length).toEqual(4);
+  });
+});

--- a/app/src/storage/jobs/pruneMessagesJob.ts
+++ b/app/src/storage/jobs/pruneMessagesJob.ts
@@ -1,0 +1,53 @@
+import { err, ok } from 'neverthrow';
+import cron from 'node-cron';
+import Engine from '~/storage/engine';
+import { HubAsyncResult } from '~/utils/hubErrors';
+import { logger } from '~/utils/logger';
+
+export const DEFAULT_PRUNE_MESSAGES_JOB_CRON = '0 * * * *'; // Every hour
+
+const log = logger.child({
+  component: 'PruneMessagesJob',
+});
+
+type SchedulerStatus = 'started' | 'stopped';
+
+export class PruneMessagesJobScheduler {
+  private _engine: Engine;
+  private _cronTask?: cron.ScheduledTask;
+
+  constructor(engine: Engine) {
+    this._engine = engine;
+  }
+
+  start(cronSchedule?: string) {
+    this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_PRUNE_MESSAGES_JOB_CRON, () => {
+      this.doJobs();
+    });
+  }
+
+  stop() {
+    if (this._cronTask) {
+      this._cronTask.stop();
+    }
+  }
+
+  status(): SchedulerStatus {
+    return this._cronTask ? 'started' : 'stopped';
+  }
+
+  async doJobs(): HubAsyncResult<void> {
+    log.info({}, 'starting doJobs');
+
+    const fids = await this._engine.getFids();
+    if (fids.isErr()) {
+      return err(fids.error);
+    }
+
+    for (const fid of fids.value) {
+      await this._engine.pruneMessages(fid);
+    }
+
+    return ok(undefined);
+  }
+}

--- a/app/src/storage/jobs/revokeSignerJob.ts
+++ b/app/src/storage/jobs/revokeSignerJob.ts
@@ -14,7 +14,6 @@ import { logger } from '~/utils/logger';
 
 export const DEFAULT_REVOKE_SIGNER_JOB_DELAY = 1000 * 60 * 60; // 1 hour in ms
 export const DEFAULT_REVOKE_SIGNER_JOB_CRON = '0 * * * *'; // Every hour
-export const REVOKE_SIGNER_JOB_MAX_NONCE = 2 ** (2 * 8) - 1; // 2 bytes
 
 const log = logger.child({
   component: 'RevokeSignerJob',


### PR DESCRIPTION
## Motivation

We need to run pruneMessages task on a regular cadence.

## Change Summary

* Add `PruneMessagesJobScheduler` class
* Instantiate `pruneMessagesJobScheduler` in hub and start/stop it accordingly

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
