### PR TITLE
feat: RPC to get Trie snapshots/hashes

### DIFF
--- a/app/src/network/sync/syncEngine.ts
+++ b/app/src/network/sync/syncEngine.ts
@@ -207,6 +207,14 @@ class SyncEngine {
     return this._trie;
   }
 
+  public getSnapshotByPrefix(prefix?: string): TrieSnapshot {
+    if (!prefix || prefix === '') {
+      return this.snapshot;
+    } else {
+      return this._trie.getSnapshot(prefix);
+    }
+  }
+
   public get snapshot(): TrieSnapshot {
     // Ignore the least significant digit when fetching the snapshot timestamp because
     // second resolution is too fine grained, and fall outside sync threshold anyway

--- a/app/src/rpc/server/index.ts
+++ b/app/src/rpc/server/index.ts
@@ -6,6 +6,7 @@ import MessageModel from '~/flatbuffers/models/messageModel';
 import { HubInterface } from '~/flatbuffers/models/types';
 import { NodeMetadata } from '~/network/sync/merkleTrie';
 import SyncEngine from '~/network/sync/syncEngine';
+import { TrieSnapshot } from '~/network/sync/trieNode';
 import * as implementations from '~/rpc/server/serviceImplementations';
 import * as definitions from '~/rpc/serviceDefinitions';
 import Engine from '~/storage/engine';
@@ -90,6 +91,25 @@ export const toTrieNodeMetadataResponse = (metadata: NodeMetadata): flatbuffers.
   const builder = new Builder(1);
   builder.finish(metadataT.pack(builder));
   const response = flatbuffers.TrieNodeMetadataResponse.getRootAsTrieNodeMetadataResponse(
+    new ByteBuffer(builder.asUint8Array())
+  );
+  return response;
+};
+
+export const toTrieNodeSnapshotResponse = (
+  snapshot: TrieSnapshot,
+  rootHash: string
+): flatbuffers.TrieNodeSnapshotResponse => {
+  const snapshotT = new flatbuffers.TrieNodeSnapshotResponseT(
+    snapshot.prefix,
+    snapshot.excludedHashes,
+    BigInt(snapshot.numMessages),
+    rootHash
+  );
+
+  const builder = new Builder(1);
+  builder.finish(snapshotT.pack(builder));
+  const response = flatbuffers.TrieNodeSnapshotResponse.getRootAsTrieNodeSnapshotResponse(
     new ByteBuffer(builder.asUint8Array())
   );
   return response;

--- a/app/src/rpc/serviceDefinitions/syncDefinition.ts
+++ b/app/src/rpc/serviceDefinitions/syncDefinition.ts
@@ -76,5 +76,16 @@ export const syncDefinition = () => {
       },
       path: '/getSyncMetadataByPrefix',
     },
+    getSyncTrieNodeSnapshotByPrefix: {
+      ...defaultMethod,
+      requestDeserialize: (buffer: Buffer): flatbuffers.GetTrieNodesByPrefixRequest => {
+        return flatbuffers.GetTrieNodesByPrefixRequest.getRootAsGetTrieNodesByPrefixRequest(toByteBuffer(buffer));
+      },
+      responseDeserialize: (buffer: Buffer): flatbuffers.TrieNodeSnapshotResponse => {
+        return flatbuffers.TrieNodeSnapshotResponse.getRootAsTrieNodeSnapshotResponse(toByteBuffer(buffer));
+      },
+
+      path: '/getSyncTrieNodeSnapshotByPrefix',
+    },
   };
 };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "./node_modules/.bin/turbo run build",
     "dev": "./node_modules/.bin/turbo run dev --parallel",
+    "flatc": "flatc --ts --ts-flat-files --gen-object-api -o packages/flatbuffers/src/generated packages/flatbuffers/src/schemas/*.fbs",
     "test": "./node_modules/.bin/turbo run test --parallel",
     "test:ci": "./node_modules/.bin/turbo run test:ci --parallel --",
     "lint": "./node_modules/.bin/turbo run lint --parallel",

--- a/packages/flatbuffers/src/generated/rpc_generated.ts
+++ b/packages/flatbuffers/src/generated/rpc_generated.ts
@@ -555,6 +555,142 @@ pack(builder:flatbuffers.Builder): flatbuffers.Offset {
 }
 }
 
+export class TrieNodeSnapshotResponse implements flatbuffers.IUnpackableObject<TrieNodeSnapshotResponseT> {
+  bb: flatbuffers.ByteBuffer|null = null;
+  bb_pos = 0;
+  __init(i:number, bb:flatbuffers.ByteBuffer):TrieNodeSnapshotResponse {
+  this.bb_pos = i;
+  this.bb = bb;
+  return this;
+}
+
+static getRootAsTrieNodeSnapshotResponse(bb:flatbuffers.ByteBuffer, obj?:TrieNodeSnapshotResponse):TrieNodeSnapshotResponse {
+  return (obj || new TrieNodeSnapshotResponse()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+static getSizePrefixedRootAsTrieNodeSnapshotResponse(bb:flatbuffers.ByteBuffer, obj?:TrieNodeSnapshotResponse):TrieNodeSnapshotResponse {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new TrieNodeSnapshotResponse()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+prefix():string|null
+prefix(optionalEncoding:flatbuffers.Encoding):string|Uint8Array|null
+prefix(optionalEncoding?:any):string|Uint8Array|null {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.__string(this.bb_pos + offset, optionalEncoding) : null;
+}
+
+excludedHashes(index: number):string
+excludedHashes(index: number,optionalEncoding:flatbuffers.Encoding):string|Uint8Array
+excludedHashes(index: number,optionalEncoding?:any):string|Uint8Array|null {
+  const offset = this.bb!.__offset(this.bb_pos, 6);
+  return offset ? this.bb!.__string(this.bb!.__vector(this.bb_pos + offset) + index * 4, optionalEncoding) : null;
+}
+
+excludedHashesLength():number {
+  const offset = this.bb!.__offset(this.bb_pos, 6);
+  return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
+}
+
+numMessages():bigint {
+  const offset = this.bb!.__offset(this.bb_pos, 8);
+  return offset ? this.bb!.readUint64(this.bb_pos + offset) : BigInt('0');
+}
+
+rootHash():string|null
+rootHash(optionalEncoding:flatbuffers.Encoding):string|Uint8Array|null
+rootHash(optionalEncoding?:any):string|Uint8Array|null {
+  const offset = this.bb!.__offset(this.bb_pos, 10);
+  return offset ? this.bb!.__string(this.bb_pos + offset, optionalEncoding) : null;
+}
+
+static startTrieNodeSnapshotResponse(builder:flatbuffers.Builder) {
+  builder.startObject(4);
+}
+
+static addPrefix(builder:flatbuffers.Builder, prefixOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(0, prefixOffset, 0);
+}
+
+static addExcludedHashes(builder:flatbuffers.Builder, excludedHashesOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(1, excludedHashesOffset, 0);
+}
+
+static createExcludedHashesVector(builder:flatbuffers.Builder, data:flatbuffers.Offset[]):flatbuffers.Offset {
+  builder.startVector(4, data.length, 4);
+  for (let i = data.length - 1; i >= 0; i--) {
+    builder.addOffset(data[i]!);
+  }
+  return builder.endVector();
+}
+
+static startExcludedHashesVector(builder:flatbuffers.Builder, numElems:number) {
+  builder.startVector(4, numElems, 4);
+}
+
+static addNumMessages(builder:flatbuffers.Builder, numMessages:bigint) {
+  builder.addFieldInt64(2, numMessages, BigInt('0'));
+}
+
+static addRootHash(builder:flatbuffers.Builder, rootHashOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(3, rootHashOffset, 0);
+}
+
+static endTrieNodeSnapshotResponse(builder:flatbuffers.Builder):flatbuffers.Offset {
+  const offset = builder.endObject();
+  return offset;
+}
+
+static createTrieNodeSnapshotResponse(builder:flatbuffers.Builder, prefixOffset:flatbuffers.Offset, excludedHashesOffset:flatbuffers.Offset, numMessages:bigint, rootHashOffset:flatbuffers.Offset):flatbuffers.Offset {
+  TrieNodeSnapshotResponse.startTrieNodeSnapshotResponse(builder);
+  TrieNodeSnapshotResponse.addPrefix(builder, prefixOffset);
+  TrieNodeSnapshotResponse.addExcludedHashes(builder, excludedHashesOffset);
+  TrieNodeSnapshotResponse.addNumMessages(builder, numMessages);
+  TrieNodeSnapshotResponse.addRootHash(builder, rootHashOffset);
+  return TrieNodeSnapshotResponse.endTrieNodeSnapshotResponse(builder);
+}
+
+unpack(): TrieNodeSnapshotResponseT {
+  return new TrieNodeSnapshotResponseT(
+    this.prefix(),
+    this.bb!.createScalarList<string>(this.excludedHashes.bind(this), this.excludedHashesLength()),
+    this.numMessages(),
+    this.rootHash()
+  );
+}
+
+
+unpackTo(_o: TrieNodeSnapshotResponseT): void {
+  _o.prefix = this.prefix();
+  _o.excludedHashes = this.bb!.createScalarList<string>(this.excludedHashes.bind(this), this.excludedHashesLength());
+  _o.numMessages = this.numMessages();
+  _o.rootHash = this.rootHash();
+}
+}
+
+export class TrieNodeSnapshotResponseT implements flatbuffers.IGeneratedObject {
+constructor(
+  public prefix: string|Uint8Array|null = null,
+  public excludedHashes: (string)[] = [],
+  public numMessages: bigint = BigInt('0'),
+  public rootHash: string|Uint8Array|null = null
+){}
+
+
+pack(builder:flatbuffers.Builder): flatbuffers.Offset {
+  const prefix = (this.prefix !== null ? builder.createString(this.prefix!) : 0);
+  const excludedHashes = TrieNodeSnapshotResponse.createExcludedHashesVector(builder, builder.createObjectOffsetList(this.excludedHashes));
+  const rootHash = (this.rootHash !== null ? builder.createString(this.rootHash!) : 0);
+
+  return TrieNodeSnapshotResponse.createTrieNodeSnapshotResponse(builder,
+    prefix,
+    excludedHashes,
+    this.numMessages,
+    rootHash
+  );
+}
+}
+
 export class GetCastRequest implements flatbuffers.IUnpackableObject<GetCastRequestT> {
   bb: flatbuffers.ByteBuffer|null = null;
   bb_pos = 0;

--- a/packages/flatbuffers/src/schemas/rpc.fbs
+++ b/packages/flatbuffers/src/schemas/rpc.fbs
@@ -38,8 +38,14 @@ table TrieNodeMetadataResponse {
   children: [TrieNodeMetadataResponse]; 
 }
 
-// Cast Requests
+table TrieNodeSnapshotResponse {
+  prefix: string;
+  excluded_hashes: [string];
+  num_messages: uint64;
+  root_hash: string;
+}
 
+// Cast Requests
 table GetCastRequest {
   fid: [ubyte] (required);
   ts_hash: [ubyte] (required);


### PR DESCRIPTION
Fixes #363

## Motivation

A new RPC that allows clients to fetch a remote Hub's rootHash and the Trie snapshot at any prefix, so nodes can check if they need to sync in the first place. 

## Change Summary

- New `getSyncTrieNodeSnapshotByPrefix` RPC
- Tests 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged
