### PR TITLE
Blake3hash

### DIFF
--- a/app/src/network/sync/trieNode.test.ts
+++ b/app/src/network/sync/trieNode.test.ts
@@ -1,10 +1,10 @@
-import { createHash } from 'crypto';
+import { blake3 } from '@noble/hashes/blake3';
 import Factories from '~/flatbuffers/factories';
 import { TIMESTAMP_LENGTH } from '~/network/sync/syncId';
 import { TrieNode } from '~/network/sync/trieNode';
 
 const fid = Factories.FID.build();
-const emptyHash = createHash('sha256').digest('hex');
+const emptyHash = Buffer.from(blake3('', { dkLen: 16 })).toString('hex');
 const sharedDate = new Date(1665182332000);
 const sharedPrefixHashA =
   '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86a4321';


### PR DESCRIPTION
## Motivation

Switch the Sync Trie hash to blake3 vs sha256

## Change Summary

- Switch sha256 -> blake3
- 128-bit hash to compact trie

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

## Additional Context

