### PR TITLE
refactor: use little endian byte arrays

### DIFF
--- a/app/src/eth/utils.test.ts
+++ b/app/src/eth/utils.test.ts
@@ -1,0 +1,32 @@
+import { BigNumber } from 'ethers';
+import { bigNumberToBytes, bytes32ToBytes } from '~/eth/utils';
+
+describe('bytes32ToBytes', () => {
+  const passingCases: [BigNumber, Uint8Array][] = [
+    [
+      BigNumber.from('50839975223553296918063695500986414185067076564032165621192833738513116561408'),
+      new Uint8Array([104, 102, 112]),
+    ],
+  ];
+
+  for (const [input, output] of passingCases) {
+    test(`converts BigNumber bytes32 to little endian byte array: ${input.toString()}`, () => {
+      expect(bytes32ToBytes(input, { endianness: 'little' })._unsafeUnwrap()).toEqual(output);
+    });
+  }
+});
+
+describe('bigNumberToBytes', () => {
+  describe('little endian', () => {
+    const passingCases: [BigNumber, Uint8Array][] = [
+      [BigNumber.from(1000), new Uint8Array([232, 3])],
+      [BigNumber.from(`${Number.MAX_SAFE_INTEGER}`).add(BigNumber.from(1)), new Uint8Array([0, 0, 0, 0, 0, 0, 32])],
+    ];
+
+    for (const [input, output] of passingCases) {
+      test(`converts BigNumber to little endian byte array: ${input?.toString()}`, () => {
+        expect(bigNumberToBytes(input, { endianness: 'little' })._unsafeUnwrap()).toEqual(output);
+      });
+    }
+  });
+});

--- a/app/src/eth/utils.ts
+++ b/app/src/eth/utils.ts
@@ -1,0 +1,17 @@
+import { BigNumber } from 'ethers';
+import { hexStringToBytes, ToBytesOptions } from '~/flatbuffers/utils/bytes';
+import { HubResult } from '~/utils/hubErrors';
+
+export const bytes32ToBytes = (value: BigNumber, options: ToBytesOptions = {}): HubResult<Uint8Array> => {
+  // Remove right padding
+  let hex = value.toHexString();
+  while (hex.substring(hex.length - 2) === '00') {
+    hex = hex.substring(0, hex.length - 2);
+  }
+
+  return hexStringToBytes(hex, options);
+};
+
+export const bigNumberToBytes = (value: BigNumber, options: ToBytesOptions = {}): HubResult<Uint8Array> => {
+  return hexStringToBytes(value._hex, options);
+};

--- a/app/src/eth/utils.ts
+++ b/app/src/eth/utils.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'ethers';
-import { hexStringToBytes, ToBytesOptions } from '~/flatbuffers/utils/bytes';
+import { BytesOptions, bytesToHexString, hexStringToBytes, ToBytesOptions } from '~/flatbuffers/utils/bytes';
 import { HubResult } from '~/utils/hubErrors';
 
 export const bytes32ToBytes = (value: BigNumber, options: ToBytesOptions = {}): HubResult<Uint8Array> => {
@@ -14,4 +14,8 @@ export const bytes32ToBytes = (value: BigNumber, options: ToBytesOptions = {}): 
 
 export const bigNumberToBytes = (value: BigNumber, options: ToBytesOptions = {}): HubResult<Uint8Array> => {
   return hexStringToBytes(value._hex, options);
+};
+
+export const bytesToBigNumber = (bytes: Uint8Array, options: BytesOptions = {}): HubResult<BigNumber> => {
+  return bytesToHexString(bytes, options).map((hexString) => BigNumber.from(hexString));
 };

--- a/app/src/flatbuffers/factories.test.ts
+++ b/app/src/flatbuffers/factories.test.ts
@@ -4,12 +4,13 @@ import { isPeerId } from '@libp2p/interface-peer-id';
 import { peerIdFromBytes } from '@libp2p/peer-id';
 import * as ed from '@noble/ed25519';
 import { blake3 } from '@noble/hashes/blake3';
-import { hexlify } from 'ethers/lib/utils';
+import { bytesToBigNumber } from '~/eth/utils';
 import Factories from '~/flatbuffers/factories';
 import { VerificationEthAddressClaim } from '~/flatbuffers/models/types';
 import { verifyVerificationEthAddressClaimSignature } from '~/flatbuffers/utils/eip712';
 import { toFarcasterTime } from '~/flatbuffers/utils/time';
 import { GOSSIP_PROTOCOL_VERSION } from '~/network/p2p/protocol';
+import { bytesToHexString } from './utils/bytes';
 
 describe('UserIdFactory', () => {
   test('accepts fid', async () => {
@@ -92,16 +93,16 @@ describe('VerificationAddEthAddressBodyFactory', () => {
     const signature = body.ethSignatureArray();
     expect(signature).toBeTruthy();
     const reconstructedClaim: VerificationEthAddressClaim = {
-      fid,
-      address: hexlify(body.addressArray() ?? new Uint8Array()),
+      fid: bytesToBigNumber(fid)._unsafeUnwrap(),
+      address: bytesToHexString(body.addressArray() ?? new Uint8Array())._unsafeUnwrap(),
       network,
-      blockHash: body.blockHashArray() ?? new Uint8Array(),
+      blockHash: bytesToHexString(body.blockHashArray() ?? new Uint8Array())._unsafeUnwrap(),
     };
     const verifiedAddress = await verifyVerificationEthAddressClaimSignature(
       reconstructedClaim,
       signature ?? new Uint8Array()
     );
-    expect(verifiedAddress).toEqual(body.addressArray());
+    expect(verifiedAddress._unsafeUnwrap()).toEqual(body.addressArray());
   });
 });
 

--- a/app/src/flatbuffers/factories.ts
+++ b/app/src/flatbuffers/factories.ts
@@ -31,7 +31,9 @@ const BytesFactory = Factory.define<Uint8Array, { length?: number }>(({ transien
 });
 
 const FIDFactory = Factory.define<Uint8Array, { fid?: number }>(({ transientParams }) => {
-  return numberToBytes(transientParams.fid ?? faker.datatype.number({ min: 1 }))._unsafeUnwrap();
+  return numberToBytes(transientParams.fid ?? faker.datatype.number({ min: 1 }), {
+    endianness: 'little',
+  })._unsafeUnwrap();
 });
 
 const FnameFactory = Factory.define<Uint8Array>(() => {

--- a/app/src/flatbuffers/factories.ts
+++ b/app/src/flatbuffers/factories.ts
@@ -9,12 +9,11 @@ import { createEd25519PeerId } from '@libp2p/peer-id-factory';
 import * as ed from '@noble/ed25519';
 import { blake3 } from '@noble/hashes/blake3';
 import { ethers, utils, Wallet } from 'ethers';
-import { arrayify } from 'ethers/lib/utils';
 import { Factory } from 'fishery';
 import { Builder, ByteBuffer } from 'flatbuffers';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { KeyPair, SignerAddModel, VerificationEthAddressClaim } from '~/flatbuffers/models/types';
-import { numberToLittleEndianBytes } from '~/flatbuffers/utils/bytes';
+import { hexStringToBytes, numberToBytes } from '~/flatbuffers/utils/bytes';
 import { signMessageHash, signVerificationEthAddressClaim } from '~/flatbuffers/utils/eip712';
 import { toFarcasterTime } from '~/flatbuffers/utils/time';
 import { NETWORK_TOPIC_PRIMARY } from '~/network/p2p/protocol';
@@ -32,7 +31,7 @@ const BytesFactory = Factory.define<Uint8Array, { length?: number }>(({ transien
 });
 
 const FIDFactory = Factory.define<Uint8Array, { fid?: number }>(({ transientParams }) => {
-  return numberToLittleEndianBytes(transientParams.fid ?? faker.datatype.number({ min: 1 }))._unsafeUnwrap();
+  return numberToBytes(transientParams.fid ?? faker.datatype.number({ min: 1 }))._unsafeUnwrap();
 });
 
 const FnameFactory = Factory.define<Uint8Array>(() => {
@@ -237,7 +236,7 @@ const VerificationAddEthAddressBodyFactory = Factory.define<
   onCreate(async (params) => {
     // Generate address and signature
     const wallet = transientParams.wallet ?? new Wallet(utils.randomBytes(32));
-    params.address = Array.from(arrayify(wallet.address));
+    params.address = Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap());
 
     const fid = transientParams.fid ?? FIDFactory.build();
     const claim: VerificationEthAddressClaim = {
@@ -247,7 +246,7 @@ const VerificationAddEthAddressBodyFactory = Factory.define<
       blockHash: Uint8Array.from(params.blockHash),
     };
     const signature = await signVerificationEthAddressClaim(claim, wallet);
-    params.ethSignature = Array.from(arrayify(signature));
+    params.ethSignature = Array.from(signature);
 
     const builder = new Builder(1);
     builder.finish(params.pack(builder));
@@ -257,9 +256,9 @@ const VerificationAddEthAddressBodyFactory = Factory.define<
   });
 
   return new message_generated.VerificationAddEthAddressBodyT(
-    Array.from(arrayify(faker.datatype.hexadecimal({ length: 40 }))),
-    Array.from(arrayify(faker.datatype.hexadecimal({ length: 130 }))),
-    Array.from(arrayify(faker.datatype.hexadecimal({ length: 64 })))
+    Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 40 }))._unsafeUnwrap()),
+    Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 130 }))._unsafeUnwrap()),
+    Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 64 }))._unsafeUnwrap())
   );
 });
 
@@ -293,7 +292,7 @@ const VerificationRemoveBodyFactory = Factory.define<
   });
 
   return new message_generated.VerificationRemoveBodyT(
-    Array.from(arrayify(faker.datatype.hexadecimal({ length: 40 })))
+    Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 40 }))._unsafeUnwrap())
   );
 });
 
@@ -321,7 +320,9 @@ const SignerBodyFactory = Factory.define<message_generated.SignerBodyT, any, mes
       return message_generated.SignerBody.getRootAsSignerBody(new ByteBuffer(builder.asUint8Array()));
     });
 
-    return new message_generated.SignerBodyT(Array.from(arrayify(faker.datatype.hexadecimal({ length: 64 }))));
+    return new message_generated.SignerBodyT(
+      Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 64 }))._unsafeUnwrap())
+    );
   }
 );
 
@@ -399,7 +400,7 @@ const MessageFactory = Factory.define<
       } else if (transientParams.wallet) {
         params.signature = Array.from(await signMessageHash(new Uint8Array(params.hash), transientParams.wallet));
         params.signatureScheme = message_generated.SignatureScheme.Eip712;
-        params.signer = Array.from(arrayify(transientParams.wallet.address));
+        params.signer = Array.from(hexStringToBytes(transientParams.wallet.address)._unsafeUnwrap());
       } else {
         const signer = await generateEd25519KeyPair();
         params.signature = Array.from(await ed.sign(new Uint8Array(params.hash), signer.privateKey));
@@ -439,13 +440,13 @@ const IdRegistryEventFactory = Factory.define<
 
   return new id_registry_event_generated.IdRegistryEventT(
     faker.datatype.number({ max: 100000 }),
-    Array.from(arrayify(faker.datatype.hexadecimal({ length: 64 }))),
-    Array.from(arrayify(faker.datatype.hexadecimal({ length: 64 }))),
+    Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 64 }))._unsafeUnwrap()),
+    Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 64 }))._unsafeUnwrap()),
     faker.datatype.number({ max: 1000 }),
     Array.from(FIDFactory.build()),
-    Array.from(arrayify(faker.datatype.hexadecimal({ length: 40 }))),
+    Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 40 }))._unsafeUnwrap()),
     id_registry_event_generated.IdRegistryEventType.IdRegistryRegister,
-    Array.from(arrayify(faker.datatype.hexadecimal({ length: 40 })))
+    Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 40 }))._unsafeUnwrap())
   );
 });
 
@@ -464,12 +465,12 @@ const NameRegistryEventFactory = Factory.define<
 
   return new name_registry_event_generated.NameRegistryEventT(
     faker.datatype.number({ max: 100000 }),
-    Array.from(arrayify(faker.datatype.hexadecimal({ length: 64 }))),
-    Array.from(arrayify(faker.datatype.hexadecimal({ length: 64 }))),
+    Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 64 }))._unsafeUnwrap()),
+    Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 64 }))._unsafeUnwrap()),
     faker.datatype.number({ max: 1000 }),
     Array.from(FnameFactory.build()),
-    Array.from(arrayify(faker.datatype.hexadecimal({ length: 40 }))),
-    Array.from(arrayify(faker.datatype.hexadecimal({ length: 40 }))),
+    Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 40 }))._unsafeUnwrap()),
+    Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 40 }))._unsafeUnwrap()),
     name_registry_event_generated.NameRegistryEventType.NameRegistryTransfer
   );
 });
@@ -552,7 +553,9 @@ const SyncIdFactory = Factory.define<undefined, { date: Date; hash: string; fid:
         timestamp: (date || faker.date.recent()).getTime() / 1000,
       });
 
-      const hashBytes = Array.from(arrayify(hash || faker.datatype.hexadecimal({ length: HASH_LENGTH })));
+      const hashBytes = Array.from(
+        hexStringToBytes(hash || faker.datatype.hexadecimal({ length: HASH_LENGTH }))._unsafeUnwrap()
+      );
       const signerAdd = new MessageModel(
         await Factories.Message.create(
           {

--- a/app/src/flatbuffers/models/nameRegistryEventModel.test.ts
+++ b/app/src/flatbuffers/models/nameRegistryEventModel.test.ts
@@ -1,9 +1,9 @@
 import { NameRegistryEventType } from '@hub/flatbuffers';
-import { arrayify } from 'ethers/lib/utils';
 import Factories from '~/flatbuffers/factories';
 import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import { generateEthereumSigner } from '~/utils/crypto';
+import { hexStringToBytes } from '../utils/bytes';
 
 const db = jestRocksDB('flatbuffers.nameRegistryEventModel.test');
 
@@ -15,7 +15,7 @@ let custody2Address: Uint8Array;
 
 beforeAll(async () => {
   const custody1 = await generateEthereumSigner();
-  custody1Address = arrayify(custody1.signerKey);
+  custody1Address = hexStringToBytes(custody1.signerKey)._unsafeUnwrap();
 
   const nameRegistryEvent = await Factories.NameRegistryEvent.create({
     fname: Array.from(fname),
@@ -43,7 +43,7 @@ describe('instance methods', () => {
       await model.put(db);
 
       const custody2 = await generateEthereumSigner();
-      custody2Address = arrayify(custody2.signerKey);
+      custody2Address = hexStringToBytes(custody2.signerKey)._unsafeUnwrap();
 
       // Transfer evemt
       const transferNameRegistryEvent = await Factories.NameRegistryEvent.create({

--- a/app/src/flatbuffers/models/types.ts
+++ b/app/src/flatbuffers/models/types.ts
@@ -142,10 +142,10 @@ export interface UserDataAddModel extends MessageModel {
 }
 
 export type VerificationEthAddressClaim = {
-  fid: Uint8Array; // Must be big-endian typed array
-  address: string;
+  fid: Uint8Array; // Big endian typed array
+  address: string; // Hex string
   network: message_generated.FarcasterNetwork;
-  blockHash: Uint8Array;
+  blockHash: Uint8Array; // Big endian typed array
 };
 
 export type StorePruneOptions = {

--- a/app/src/flatbuffers/models/types.ts
+++ b/app/src/flatbuffers/models/types.ts
@@ -142,10 +142,10 @@ export interface UserDataAddModel extends MessageModel {
 }
 
 export type VerificationEthAddressClaim = {
-  fid: Uint8Array; // Big endian typed array
+  fid: ethers.BigNumber;
   address: string; // Hex string
   network: message_generated.FarcasterNetwork;
-  blockHash: Uint8Array; // Big endian typed array
+  blockHash: string; // Hex string
 };
 
 export type StorePruneOptions = {

--- a/app/src/flatbuffers/models/validations.test.ts
+++ b/app/src/flatbuffers/models/validations.test.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 import * as message_generated from '@hub/flatbuffers';
 import { utils, Wallet } from 'ethers';
+import { bytesToBigNumber } from '~/eth/utils';
 import Factories from '~/flatbuffers/factories';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import * as types from '~/flatbuffers/models/types';
@@ -493,16 +494,16 @@ describe('validateVerificationAddEthAddressMessage', () => {
 
     test('with invalid eth signature', async () => {
       const claim: types.VerificationEthAddressClaim = {
-        fid,
+        fid: bytesToBigNumber(fid)._unsafeUnwrap(),
         address: faker.datatype.hexadecimal({ length: 40, case: 'lower' }), // mismatched address
         network: message_generated.FarcasterNetwork.Testnet,
-        blockHash: hexStringToBytes(faker.datatype.hexadecimal({ length: 64, case: 'lower' }))._unsafeUnwrap(),
+        blockHash: faker.datatype.hexadecimal({ length: 64, case: 'lower' }),
       };
       const signature = await signVerificationEthAddressClaim(claim, wallet);
       body = new message_generated.VerificationAddEthAddressBodyT(
         Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()),
-        Array.from(signature),
-        Array.from(claim.blockHash)
+        Array.from(signature._unsafeUnwrap()),
+        Array.from(hexStringToBytes(claim.blockHash)._unsafeUnwrap())
       );
       hubErrorMessage = 'ethSignature does not match address';
     });

--- a/app/src/flatbuffers/utils/bytes.test.ts
+++ b/app/src/flatbuffers/utils/bytes.test.ts
@@ -2,8 +2,10 @@ import {
   bytesCompare,
   bytesDecrement,
   bytesIncrement,
-  numberToBigEndianBytes,
-  numberToLittleEndianBytes,
+  bytesToHexString,
+  bytesToUtf8String,
+  hexStringToBytes,
+  numberToBytes,
 } from '~/flatbuffers/utils/bytes';
 import { HubError } from '~/utils/hubErrors';
 
@@ -69,118 +71,207 @@ describe('bytesDecrement', () => {
   }
 });
 
-describe('numberToLittleEndianBytes', () => {
-  describe('without size', () => {
-    const passingCases: [number, Uint8Array][] = [
-      [1, new Uint8Array([1])],
-      [255, new Uint8Array([255])],
-      [256, new Uint8Array([0, 1])],
-      [257, new Uint8Array([1, 1])],
-      [26_309_012, new Uint8Array([148, 113, 145, 1])],
-      [1_672_260_013_391, new Uint8Array([79, 205, 118, 90, 133, 1])],
-      [Number.MAX_SAFE_INTEGER, new Uint8Array([255, 255, 255, 255, 255, 255, 31])],
+describe('hexStringToBytes', () => {
+  describe('little endian', () => {
+    const passingCases: [string, Uint8Array][] = [
+      [
+        '0xda107a1caf36d198b12c16c7b6a1d1c795978c42',
+        new Uint8Array([66, 140, 151, 149, 199, 209, 161, 182, 199, 22, 44, 177, 152, 209, 54, 175, 28, 122, 16, 218]),
+      ],
+      ['0x3e8', new Uint8Array([232, 3])],
+      ['3e8', new Uint8Array([232, 3])],
+      ['0x03e8', new Uint8Array([232, 3])],
+      ['0x003e8', new Uint8Array([232, 3])],
+      ['0x0003e8', new Uint8Array([232, 3])],
+      ['0x00000000000003e8', new Uint8Array([232, 3])],
+      ['0x3e800', new Uint8Array([0, 232, 3])],
     ];
 
     for (const [input, output] of passingCases) {
-      test(`converts number to little endian byte array: ${input}`, () => {
-        expect(numberToLittleEndianBytes(input)._unsafeUnwrap()).toEqual(output);
-      });
-    }
-
-    const failingCases: number[] = [-1, 0, -26_309_012];
-
-    for (const input of failingCases) {
-      test(`fails with number: ${input}`, () => {
-        expect(numberToLittleEndianBytes(input)._unsafeUnwrapErr()).toBeInstanceOf(HubError);
+      test(`converts hex string to little endian byte array: ${input}`, () => {
+        expect(hexStringToBytes(input)._unsafeUnwrap()).toEqual(output);
       });
     }
   });
 
-  describe('with size', () => {
-    const passingCases: [number, number, Uint8Array][] = [
-      [1, 4, new Uint8Array([1, 0, 0, 0])],
-      [255, 1, new Uint8Array([255])],
-      [256, 3, new Uint8Array([0, 1, 0])],
-      [257, 2, new Uint8Array([1, 1])],
-      [26_309_012, 6, new Uint8Array([148, 113, 145, 1, 0, 0])],
-      [1_516_072_972, 6, new Uint8Array([12, 112, 93, 90, 0, 0])],
+  describe('big endian', () => {
+    const passingCases: [string, Uint8Array][] = [
+      [
+        '0xda107a1caf36d198b12c16c7b6a1d1c795978c42',
+        new Uint8Array([218, 16, 122, 28, 175, 54, 209, 152, 177, 44, 22, 199, 182, 161, 209, 199, 149, 151, 140, 66]),
+      ],
+      ['0x3e8', new Uint8Array([3, 232])],
+      ['3e8', new Uint8Array([3, 232])],
+      ['0x03e8', new Uint8Array([3, 232])],
+      ['0x003e8', new Uint8Array([3, 232])],
+      ['0x0003e8', new Uint8Array([3, 232])],
+      ['0x00000000000003e8', new Uint8Array([3, 232])],
+      ['0x3e800', new Uint8Array([3, 232, 0])],
     ];
 
-    for (const [input, size, output] of passingCases) {
-      test(`converts number to fixed size little endian byte array: ${input}`, () => {
-        expect(numberToLittleEndianBytes(input, size)._unsafeUnwrap()).toEqual(output);
-      });
-    }
-
-    const failingCases: [number, number][] = [
-      [1, 0],
-      [256, 1],
-      [257, 1],
-      [26_309_012, 3],
-    ];
-
-    for (const [input, size] of failingCases) {
-      test(`fails with number: ${input}`, () => {
-        expect(numberToLittleEndianBytes(input, size)._unsafeUnwrapErr()).toBeInstanceOf(HubError);
+    for (const [input, output] of passingCases) {
+      test(`converts hex string to big endian byte array: ${input}`, () => {
+        expect(hexStringToBytes(input, { endianness: 'big' })._unsafeUnwrap()).toEqual(output);
       });
     }
   });
 });
 
-describe('numberToBigEndianBytes', () => {
-  describe('without size', () => {
-    const passingCases: [number, Uint8Array][] = [
-      [1, new Uint8Array([1])],
-      [255, new Uint8Array([255])],
-      [256, new Uint8Array([1, 0])],
-      [257, new Uint8Array([1, 1])],
-      [26_309_012, new Uint8Array([1, 145, 113, 148])],
-      [1_672_260_013_391, new Uint8Array([1, 133, 90, 118, 205, 79])],
-      [Number.MAX_SAFE_INTEGER, new Uint8Array([31, 255, 255, 255, 255, 255, 255])],
+describe('bytesToHexString', () => {
+  describe('little endian', () => {
+    const passingCases: [Uint8Array, string][] = [
+      [new Uint8Array([232, 3]), '0x03e8'],
+      [new Uint8Array([232, 3, 0]), '0x03e8'],
+      [new Uint8Array([0, 232, 3, 0]), '0x03e800'],
     ];
 
     for (const [input, output] of passingCases) {
-      test(`converts number to big endian byte array: ${input}`, () => {
-        expect(numberToBigEndianBytes(input)._unsafeUnwrap()).toEqual(output);
+      test(`converts little endian byte array to hex string: ${input}`, () => {
+        expect(bytesToHexString(input)._unsafeUnwrap()).toEqual(output);
       });
     }
+  });
+});
 
-    const failingCases: number[] = [-1, 0, -26_309_012];
+describe('bytesToUtf8String', () => {
+  describe('little endian', () => {
+    const passingCases: [Uint8Array, string][] = [
+      [new Uint8Array([104, 102, 112]), 'pfh'],
+      // [new Uint8Array([104, 102, 112, 0, 0]), 'pfh'],
+    ];
 
-    for (const input of failingCases) {
-      test(`fails with number: ${input}`, () => {
-        expect(numberToBigEndianBytes(input)._unsafeUnwrapErr()).toBeInstanceOf(HubError);
+    for (const [input, output] of passingCases) {
+      test(`converts little endian byte array to utf8 string: ${input}`, () => {
+        expect(bytesToUtf8String(input)._unsafeUnwrap()).toEqual(output);
       });
     }
   });
 
-  describe('with size', () => {
-    const passingCases: [number, number, Uint8Array][] = [
-      [1, 4, new Uint8Array([0, 0, 0, 1])],
-      [255, 1, new Uint8Array([255])],
-      [256, 3, new Uint8Array([0, 1, 0])],
-      [257, 2, new Uint8Array([1, 1])],
-      [26_309_012, 6, new Uint8Array([0, 0, 1, 145, 113, 148])],
-      [1_516_072_972, 6, new Uint8Array([0, 0, 90, 93, 112, 12])],
-    ];
+  describe('big endian', () => {
+    const passingCases: [Uint8Array, string][] = [[new Uint8Array([104, 102, 112]), 'hfp']];
 
-    for (const [input, size, output] of passingCases) {
-      test(`converts number to fixed size big endian byte array: ${input}`, () => {
-        expect(numberToBigEndianBytes(input, size)._unsafeUnwrap()).toEqual(output);
+    for (const [input, output] of passingCases) {
+      test(`converts big endian byte array to utf8 string: ${input}`, () => {
+        expect(bytesToUtf8String(input, { endianness: 'big' })._unsafeUnwrap()).toEqual(output);
       });
     }
+  });
+});
 
-    const failingCases: [number, number][] = [
-      [1, 0],
-      [256, 1],
-      [257, 1],
-      [26_309_012, 3],
-    ];
+describe('numberToBytes', () => {
+  describe('little endian', () => {
+    describe('without size', () => {
+      const passingCases: [number, Uint8Array][] = [
+        [1, new Uint8Array([1])],
+        [255, new Uint8Array([255])],
+        [256, new Uint8Array([0, 1])],
+        [257, new Uint8Array([1, 1])],
+        [26_309_012, new Uint8Array([148, 113, 145, 1])],
+        [1_672_260_013_391, new Uint8Array([79, 205, 118, 90, 133, 1])],
+        [Number.MAX_SAFE_INTEGER, new Uint8Array([255, 255, 255, 255, 255, 255, 31])],
+      ];
 
-    for (const [input, size] of failingCases) {
-      test(`fails with number: ${input}`, () => {
-        expect(numberToBigEndianBytes(input, size)._unsafeUnwrapErr()).toBeInstanceOf(HubError);
-      });
-    }
+      for (const [input, output] of passingCases) {
+        test(`converts number to little endian byte array: ${input}`, () => {
+          expect(numberToBytes(input, { endianness: 'little' })._unsafeUnwrap()).toEqual(output);
+        });
+      }
+
+      const failingCases: number[] = [-1, 0, -26_309_012];
+
+      for (const input of failingCases) {
+        test(`fails with number: ${input}`, () => {
+          expect(numberToBytes(input, { endianness: 'little' })._unsafeUnwrapErr()).toBeInstanceOf(HubError);
+        });
+      }
+    });
+
+    describe('with size', () => {
+      const passingCases: [number, number, Uint8Array][] = [
+        [1, 4, new Uint8Array([1, 0, 0, 0])],
+        [255, 1, new Uint8Array([255])],
+        [256, 3, new Uint8Array([0, 1, 0])],
+        [257, 2, new Uint8Array([1, 1])],
+        [26_309_012, 6, new Uint8Array([148, 113, 145, 1, 0, 0])],
+        [1_516_072_972, 6, new Uint8Array([12, 112, 93, 90, 0, 0])],
+      ];
+
+      for (const [input, size, output] of passingCases) {
+        test(`converts number to fixed size little endian byte array: ${input}`, () => {
+          expect(numberToBytes(input, { size, endianness: 'little' })._unsafeUnwrap()).toEqual(output);
+        });
+      }
+
+      const failingCases: [number, number][] = [
+        [1, 0],
+        [256, 1],
+        [257, 1],
+        [26_309_012, 3],
+      ];
+
+      for (const [input, size] of failingCases) {
+        test(`fails with number: ${input}`, () => {
+          expect(numberToBytes(input, { size, endianness: 'little' })._unsafeUnwrapErr()).toBeInstanceOf(HubError);
+        });
+      }
+    });
+  });
+
+  describe('big endian', () => {
+    describe('without size', () => {
+      const passingCases: [number, Uint8Array][] = [
+        [1, new Uint8Array([1])],
+        [255, new Uint8Array([255])],
+        [256, new Uint8Array([1, 0])],
+        [257, new Uint8Array([1, 1])],
+        [26_309_012, new Uint8Array([1, 145, 113, 148])],
+        [1_672_260_013_391, new Uint8Array([1, 133, 90, 118, 205, 79])],
+        [Number.MAX_SAFE_INTEGER, new Uint8Array([31, 255, 255, 255, 255, 255, 255])],
+      ];
+
+      for (const [input, output] of passingCases) {
+        test(`converts number to big endian byte array: ${input}`, () => {
+          expect(numberToBytes(input, { endianness: 'big' })._unsafeUnwrap()).toEqual(output);
+        });
+      }
+
+      const failingCases: number[] = [-1, 0, -26_309_012];
+
+      for (const input of failingCases) {
+        test(`fails with number: ${input}`, () => {
+          expect(numberToBytes(input, { endianness: 'big' })._unsafeUnwrapErr()).toBeInstanceOf(HubError);
+        });
+      }
+    });
+
+    describe('with size', () => {
+      const passingCases: [number, number, Uint8Array][] = [
+        [1, 4, new Uint8Array([0, 0, 0, 1])],
+        [255, 1, new Uint8Array([255])],
+        [256, 3, new Uint8Array([0, 1, 0])],
+        [257, 2, new Uint8Array([1, 1])],
+        [26_309_012, 6, new Uint8Array([0, 0, 1, 145, 113, 148])],
+        [1_516_072_972, 6, new Uint8Array([0, 0, 90, 93, 112, 12])],
+      ];
+
+      for (const [input, size, output] of passingCases) {
+        test(`converts number to fixed size big endian byte array: ${input}`, () => {
+          expect(numberToBytes(input, { size, endianness: 'big' })._unsafeUnwrap()).toEqual(output);
+        });
+      }
+
+      const failingCases: [number, number][] = [
+        [1, 0],
+        [256, 1],
+        [257, 1],
+        [26_309_012, 3],
+      ];
+
+      for (const [input, size] of failingCases) {
+        test(`fails with number: ${input}`, () => {
+          expect(numberToBytes(input, { size, endianness: 'big' })._unsafeUnwrapErr()).toBeInstanceOf(HubError);
+        });
+      }
+    });
   });
 });

--- a/app/src/flatbuffers/utils/bytes.test.ts
+++ b/app/src/flatbuffers/utils/bytes.test.ts
@@ -138,7 +138,7 @@ describe('bytesToUtf8String', () => {
   describe('little endian', () => {
     const passingCases: [Uint8Array, string][] = [
       [new Uint8Array([104, 102, 112]), 'pfh'],
-      // [new Uint8Array([104, 102, 112, 0, 0]), 'pfh'],
+      [new Uint8Array([104, 102, 112, 0, 0]), 'pfh'],
     ];
 
     for (const [input, output] of passingCases) {
@@ -149,7 +149,11 @@ describe('bytesToUtf8String', () => {
   });
 
   describe('big endian', () => {
-    const passingCases: [Uint8Array, string][] = [[new Uint8Array([104, 102, 112]), 'hfp']];
+    const passingCases: [Uint8Array, string][] = [
+      [new Uint8Array([104, 102, 112]), 'hfp'],
+      [new Uint8Array([112, 102, 104]), 'pfh'],
+      [new Uint8Array([0, 0, 0, 112, 102, 104]), 'pfh'],
+    ];
 
     for (const [input, output] of passingCases) {
       test(`converts big endian byte array to utf8 string: ${input}`, () => {

--- a/app/src/flatbuffers/utils/bytes.test.ts
+++ b/app/src/flatbuffers/utils/bytes.test.ts
@@ -3,6 +3,7 @@ import {
   bytesDecrement,
   bytesIncrement,
   bytesToHexString,
+  bytesToNumber,
   bytesToUtf8String,
   hexStringToBytes,
   numberToBytes,
@@ -155,6 +156,21 @@ describe('bytesToUtf8String', () => {
         expect(bytesToUtf8String(input, { endianness: 'big' })._unsafeUnwrap()).toEqual(output);
       });
     }
+  });
+});
+
+describe('bytesToNumber', () => {
+  const passingCases: [Uint8Array, number][] = [[new Uint8Array([148, 113, 145, 1]), 26_309_012]];
+
+  for (const [input, output] of passingCases) {
+    test(`converts little endian byte array to number: ${input}`, () => {
+      expect(bytesToNumber(input, { endianness: 'little' })._unsafeUnwrap()).toEqual(output);
+    });
+  }
+
+  test('fails when number is larger than 48 bits', () => {
+    const maxSafeInt = new Uint8Array([255, 255, 255, 255, 255, 255, 31]);
+    expect(bytesToNumber(maxSafeInt)._unsafeUnwrapErr().errCode).toEqual('bad_request.invalid_param');
   });
 });
 

--- a/app/src/flatbuffers/utils/bytes.ts
+++ b/app/src/flatbuffers/utils/bytes.ts
@@ -84,8 +84,8 @@ export const bytesToUtf8String = (bytes: Uint8Array, options: BytesOptions = {})
   }
 };
 
+// TODO: support numbers up to Number.MAX_SAFE_INTEGER
 export const bytesToNumber = (bytes: Uint8Array, options: BytesOptions = {}): HubResult<number> => {
-  // TODO: validate size is not too large (ie less than 48 bits)
   const endianness: Endianness = options.endianness ?? 'little';
   const safeReadUInt = Result.fromThrowable(
     (bytes: Uint8Array) => {
@@ -143,9 +143,6 @@ export const bytesToHexString = (bytes: Uint8Array, options: BytesOptions = {}):
 };
 
 export const hexStringToBytes = (hex: string, options: ToBytesOptions = {}): HubResult<Uint8Array> => {
-  // TODO: validate hex
-  // TODO: validate hex is even length
-
   const endianness: Endianness = options.endianness ?? 'little';
 
   if (hex.substring(0, 2) === '0x') {

--- a/app/src/flatbuffers/utils/bytes.ts
+++ b/app/src/flatbuffers/utils/bytes.ts
@@ -78,10 +78,18 @@ export const bytesToUtf8String = (bytes: Uint8Array, options: BytesOptions = {})
   const endianness: Endianness = options.endianness ?? 'little';
   const decoder = new TextDecoder();
   if (endianness === 'little') {
-    return ok(decoder.decode(bytes.reverse()));
+    while (bytes[bytes.length - 1] === 0) {
+      bytes = bytes.subarray(0, bytes.length - 1);
+    }
+
+    bytes = bytes.reverse(); // reverse because TextDecoder takes big endian
   } else {
-    return ok(decoder.decode(bytes));
+    while (bytes[0] === 0) {
+      bytes = bytes.subarray(1);
+    }
   }
+
+  return ok(decoder.decode(bytes));
 };
 
 // TODO: support numbers up to Number.MAX_SAFE_INTEGER

--- a/app/src/flatbuffers/utils/bytes.ts
+++ b/app/src/flatbuffers/utils/bytes.ts
@@ -1,7 +1,18 @@
 import { ByteBuffer } from 'flatbuffers';
-import { err, ok } from 'neverthrow';
+import { err, ok, Result } from 'neverthrow';
 import { HubError, HubResult } from '~/utils/hubErrors';
 
+export const DEFAULT_ENDIANNESS: Endianness = 'little';
+
+export type Endianness = 'little' | 'big';
+export type BytesOptions = {
+  endianness?: Endianness; // Endianness of byte array
+};
+export type ToBytesOptions = BytesOptions & {
+  size?: number; // Size of byte array
+};
+
+// TODO: support both big and little endian
 export const bytesCompare = (a: Uint8Array, b: Uint8Array): number => {
   const aValue = a[0];
   const bValue = b[0];
@@ -23,6 +34,7 @@ export const bytesCompare = (a: Uint8Array, b: Uint8Array): number => {
   }
 };
 
+// TOOD: support both big and little endian
 /* eslint-disable security/detect-object-injection */
 export const bytesIncrement = (bytes: Uint8Array): Uint8Array => {
   let i = bytes.length - 1;
@@ -38,6 +50,7 @@ export const bytesIncrement = (bytes: Uint8Array): Uint8Array => {
   return new Uint8Array([1, ...bytes]);
 };
 
+// TODO: support both big and little endian
 export const bytesDecrement = (bytes: Uint8Array): Uint8Array => {
   let i = bytes.length - 1;
   while (i >= 0) {
@@ -61,64 +74,159 @@ export const toByteBuffer = (buffer: Buffer): ByteBuffer => {
   return new ByteBuffer(new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.length / Uint8Array.BYTES_PER_ELEMENT));
 };
 
-export const toNumber = (bytesUint8Array: Uint8Array) => {
-  return Buffer.from(bytesUint8Array).readUintLE(0, bytesUint8Array.length);
+export const bytesToUtf8String = (bytes: Uint8Array, options: BytesOptions = {}): HubResult<string> => {
+  const endianness: Endianness = options.endianness ?? 'little';
+  const decoder = new TextDecoder();
+  if (endianness === 'little') {
+    return ok(decoder.decode(bytes.reverse()));
+  } else {
+    return ok(decoder.decode(bytes));
+  }
 };
 
-export const bigEndianBytesToNumber = (bytes: Uint8Array) => {
-  return Buffer.from(bytes).readUIntBE(0, bytes.length);
+export const bytesToNumber = (bytes: Uint8Array, options: BytesOptions = {}): HubResult<number> => {
+  // TODO: validate size is not too large (ie less than 48 bits)
+  const endianness: Endianness = options.endianness ?? 'little';
+  const safeReadUInt = Result.fromThrowable(
+    (bytes: Uint8Array) => {
+      if (endianness === 'little') {
+        return Buffer.from(bytes).readUIntLE(0, bytes.length);
+      } else {
+        return Buffer.from(bytes).readUIntBE(0, bytes.length);
+      }
+    },
+    (e) => new HubError('bad_request.invalid_param', e as Error)
+  );
+  return safeReadUInt(bytes);
 };
 
-/** Converts number to little endian byte array */
-export const numberToLittleEndianBytes = (value: number, size?: number) => {
-  if (value <= 0) {
-    return err(new HubError('bad_request.invalid_param', 'value must be positive'));
+export const bytesToHexString = (bytes: Uint8Array, options: BytesOptions = {}): HubResult<string> => {
+  const endianness = options.endianness ?? 'little';
+
+  let hex = '0x';
+
+  if (endianness === 'little') {
+    // Start at end
+    let i = bytes.length - 1;
+
+    // Skip padding
+    while (bytes[i] === 0) {
+      i--;
+    }
+
+    for (i; i >= 0; i--) {
+      let hexChars = bytes[i]?.toString(16);
+      if (hexChars?.length === 1) {
+        hexChars = '0' + hexChars;
+      }
+      hex = hex + hexChars;
+    }
+  } else {
+    // Start at beginning
+    let i = 0;
+
+    // Skip padding
+    while (bytes[i] === 0) {
+      i++;
+    }
+
+    for (i; i < bytes.length; i++) {
+      let hexChars = bytes[i]?.toString(16);
+      if (hexChars?.length === 1) {
+        hexChars = '0' + hexChars;
+      }
+      hex = hex + hexChars;
+    }
   }
 
-  if (typeof size === 'number' && size <= 0) {
-    return err(new HubError('bad_request.invalid_param', 'size must be positive'));
+  return ok(hex);
+};
+
+export const hexStringToBytes = (hex: string, options: ToBytesOptions = {}): HubResult<Uint8Array> => {
+  // TODO: validate hex
+  // TODO: validate hex is even length
+
+  const endianness: Endianness = options.endianness ?? 'little';
+
+  if (hex.substring(0, 2) === '0x') {
+    hex = hex.substring(2);
+  }
+
+  // Pad hex string if length is odd
+  if (hex.length % 2) {
+    hex = '0' + hex;
   }
 
   const bytes = [];
-  let bigIntValue = BigInt(value);
 
-  while (bigIntValue !== 0n) {
-    if (size && bytes.length >= size) {
-      return err(new HubError('bad_request.invalid_param', 'value does not fit in size'));
-    }
-    bytes.push(Number(bigIntValue & 255n));
-    bigIntValue >>= 8n;
+  let i = 0;
+
+  // Skip padding
+  while (hex.substring(i, i + 2) === '00') {
+    i += 2;
   }
 
-  while (size && bytes.length < size) {
-    bytes.push(0);
+  for (i; i < hex.length; i += 2) {
+    const byte = parseInt(hex.substring(i, i + 2), 16);
+    if (endianness === 'little') {
+      bytes.unshift(byte);
+    } else {
+      bytes.push(byte);
+    }
   }
 
   return ok(new Uint8Array(bytes));
 };
 
-export const numberToBigEndianBytes = (value: number, size?: number): HubResult<Uint8Array> => {
-  if (value <= 0) {
+export const utf8StringToBytes = (utf8: string, options: ToBytesOptions = {}): HubResult<Uint8Array> => {
+  const endianness: Endianness = options.endianness ?? 'little';
+
+  const encoder = new TextEncoder();
+
+  if (endianness === 'little') {
+    return ok(encoder.encode(utf8).reverse());
+  } else {
+    return ok(encoder.encode(utf8));
+  }
+};
+
+export const numberToBytes = (value: number, options: ToBytesOptions = {}): HubResult<Uint8Array> => {
+  return bigIntToBytes(BigInt(value), options);
+};
+
+export const bigIntToBytes = (value: bigint, options: ToBytesOptions = {}): HubResult<Uint8Array> => {
+  if (value <= 0n) {
     return err(new HubError('bad_request.invalid_param', 'value must be positive'));
   }
 
-  if (typeof size === 'number' && size <= 0) {
+  if (typeof options.size === 'number' && options.size <= 0) {
     return err(new HubError('bad_request.invalid_param', 'size must be positive'));
   }
 
-  const bytes = [];
-  let bigIntValue = BigInt(value);
+  const endianness: Endianness = options.endianness ?? 'little';
 
-  while (bigIntValue !== 0n) {
-    if (size && bytes.length >= size) {
+  const bytes = [];
+
+  while (value !== 0n) {
+    if (options.size && bytes.length >= options.size) {
       return err(new HubError('bad_request.invalid_param', 'value does not fit in size'));
     }
-    bytes.unshift(Number(bigIntValue & 255n));
-    bigIntValue >>= 8n;
+    const byte = Number(value & 255n);
+    if (endianness === 'little') {
+      bytes.push(byte);
+    } else {
+      bytes.unshift(byte);
+    }
+
+    value >>= 8n;
   }
 
-  while (size && bytes.length < size) {
-    bytes.unshift(0);
+  while (options.size && bytes.length < options.size) {
+    if (endianness === 'little') {
+      bytes.push(0);
+    } else {
+      bytes.unshift(0);
+    }
   }
 
   return ok(new Uint8Array(bytes));

--- a/app/src/flatbuffers/utils/eip712.test.ts
+++ b/app/src/flatbuffers/utils/eip712.test.ts
@@ -5,9 +5,10 @@ import { utils, Wallet } from 'ethers';
 import Factories from '~/flatbuffers/factories';
 import { VerificationEthAddressClaim } from '~/flatbuffers/models/types';
 import * as eip712 from '~/flatbuffers/utils/eip712';
-import { hexStringToBytes } from './bytes';
+import { bytesToHexString, hexStringToBytes, numberToBytes } from './bytes';
 
 const wallet = new Wallet(utils.randomBytes(32));
+const fidNumber = faker.datatype.number({ min: 1, max: 1_000_000 });
 
 describe('signVerificationEthAddressClaim', () => {
   let claim: VerificationEthAddressClaim;
@@ -15,45 +16,52 @@ describe('signVerificationEthAddressClaim', () => {
 
   beforeAll(async () => {
     claim = {
-      fid: Factories.FID.build(),
+      fid: numberToBytes(fidNumber, { endianness: 'big' })._unsafeUnwrap(),
       address: wallet.address,
-      blockHash: utils.arrayify(faker.datatype.hexadecimal({ length: 64, case: 'lower' })),
+      blockHash: hexStringToBytes(faker.datatype.hexadecimal({ length: 64, case: 'lower' }), {
+        endianness: 'big',
+      })._unsafeUnwrap(),
       network: FarcasterNetwork.Testnet,
     };
-    signature = await eip712.signVerificationEthAddressClaim(claim, wallet);
+    signature = (await eip712.signVerificationEthAddressClaim(claim, wallet))._unsafeUnwrap();
   });
 
   test('succeeds', async () => {
     expect(signature).toBeTruthy();
     const recoveredAddress = eip712.verifyVerificationEthAddressClaimSignature(claim, signature);
-    expect(recoveredAddress).toEqual(utils.arrayify(wallet.address));
+    expect(recoveredAddress._unsafeUnwrap()).toEqual(hexStringToBytes(wallet.address)._unsafeUnwrap());
   });
 
   test('succeeds when encoding twice', async () => {
     const claim2: VerificationEthAddressClaim = { ...claim };
     const signature2 = await eip712.signVerificationEthAddressClaim(claim2, wallet);
-    expect(signature2).toEqual(signature);
-    expect(utils.hexlify(signature2)).toEqual(utils.hexlify(signature));
+    expect(signature2._unsafeUnwrap()).toEqual(signature);
+    expect(bytesToHexString(signature2._unsafeUnwrap())._unsafeUnwrap()).toEqual(
+      bytesToHexString(signature)._unsafeUnwrap()
+    );
   });
 
   test('succeeds with big-endian padding', async () => {
     const paddedFid = new Uint8Array([0, 0, 0, 0, ...claim.fid]);
     const claim2: VerificationEthAddressClaim = { ...claim, fid: paddedFid };
     const signature2 = await eip712.signVerificationEthAddressClaim(claim2, wallet);
-    expect(signature2).toEqual(signature);
+    expect(signature2._unsafeUnwrap()).toEqual(signature);
   });
 
   test('succeeds with lowercased address', async () => {
     const claim2: VerificationEthAddressClaim = { ...claim, address: claim.address.toLowerCase() };
     expect(claim2.address).not.toEqual(claim.address); // sanity check that original address was not lowercased
     const signature2 = await eip712.signVerificationEthAddressClaim(claim2, wallet);
-    expect(signature2).toEqual(signature);
+    expect(signature2._unsafeUnwrap()).toEqual(signature);
   });
 
   test('fails with little-endian fid', async () => {
-    const claim2: VerificationEthAddressClaim = { ...claim, fid: claim.fid.reverse() };
+    const claim2: VerificationEthAddressClaim = {
+      ...claim,
+      fid: numberToBytes(fidNumber, { endianness: 'little' })._unsafeUnwrap(),
+    };
     const signature2 = await eip712.signVerificationEthAddressClaim(claim2, wallet);
-    expect(signature2).not.toEqual(signature);
+    expect(signature2._unsafeUnwrap()).not.toEqual(signature);
   });
 });
 
@@ -63,8 +71,7 @@ describe('signMessageHash', () => {
     const bytes = messageData.bb?.bytes() ?? new Uint8Array();
     const hash = blake3(bytes, { dkLen: 16 });
     const signature = await eip712.signMessageHash(hash, wallet);
-    expect(signature).toBeTruthy();
-    const recoveredAddress = eip712.verifyMessageHashSignature(hash, signature);
-    expect(recoveredAddress).toEqual(hexStringToBytes(wallet.address)._unsafeUnwrap());
+    const recoveredAddress = eip712.verifyMessageHashSignature(hash, signature._unsafeUnwrap());
+    expect(recoveredAddress._unsafeUnwrap()).toEqual(hexStringToBytes(wallet.address)._unsafeUnwrap());
   });
 });

--- a/app/src/flatbuffers/utils/eip712.test.ts
+++ b/app/src/flatbuffers/utils/eip712.test.ts
@@ -5,6 +5,7 @@ import { utils, Wallet } from 'ethers';
 import Factories from '~/flatbuffers/factories';
 import { VerificationEthAddressClaim } from '~/flatbuffers/models/types';
 import * as eip712 from '~/flatbuffers/utils/eip712';
+import { hexStringToBytes } from './bytes';
 
 const wallet = new Wallet(utils.randomBytes(32));
 
@@ -64,6 +65,6 @@ describe('signMessageHash', () => {
     const signature = await eip712.signMessageHash(hash, wallet);
     expect(signature).toBeTruthy();
     const recoveredAddress = eip712.verifyMessageHashSignature(hash, signature);
-    expect(recoveredAddress).toEqual(utils.arrayify(wallet.address));
+    expect(recoveredAddress).toEqual(hexStringToBytes(wallet.address)._unsafeUnwrap());
   });
 });

--- a/app/src/flatbuffers/utils/eip712.ts
+++ b/app/src/flatbuffers/utils/eip712.ts
@@ -1,6 +1,7 @@
 import { utils, Wallet } from 'ethers';
 import { arrayify } from 'ethers/lib/utils';
 import { VerificationEthAddressClaim } from '~/flatbuffers/models/types';
+import { bytesToHexString, hexStringToBytes } from '~/flatbuffers/utils/bytes';
 
 export const EIP_712_FARCASTER_DOMAIN = {
   name: 'Farcaster Verify Ethereum Address',
@@ -63,18 +64,34 @@ export const verifyVerificationEthAddressClaimSignature = (
 };
 
 export const signMessageHash = async (hash: Uint8Array, wallet: Wallet): Promise<Uint8Array> => {
-  return arrayify(
+  const signature = hexStringToBytes(
     await wallet._signTypedData(EIP_712_FARCASTER_DOMAIN, { MessageData: EIP_712_FARCASTER_MESSAGE_DATA }, { hash })
   );
+  if (signature.isErr()) {
+    throw signature.error;
+  }
+  return signature.value;
 };
 
 export const verifyMessageHashSignature = (hash: Uint8Array, signature: Uint8Array): Uint8Array => {
-  return arrayify(
-    utils.verifyTypedData(
-      EIP_712_FARCASTER_DOMAIN,
-      { MessageData: EIP_712_FARCASTER_MESSAGE_DATA },
-      { hash },
-      signature
-    )
+  // Convert little endian signature to hex
+  const hexSignature = bytesToHexString(signature, { endianness: 'little' });
+  if (hexSignature.isErr()) {
+    throw hexSignature.error;
+  }
+
+  // Recover address from signature
+  const recoveredHexAddress = utils.verifyTypedData(
+    EIP_712_FARCASTER_DOMAIN,
+    { MessageData: EIP_712_FARCASTER_MESSAGE_DATA },
+    { hash },
+    hexSignature.value
   );
+
+  // Convert hex address to little endian bytes
+  const recoveredAddress = hexStringToBytes(recoveredHexAddress, { endianness: 'little' });
+  if (recoveredAddress.isErr()) {
+    throw recoveredAddress.error;
+  }
+  return recoveredAddress.value;
 };

--- a/app/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/app/src/network/sync/multiPeerSyncEngine.test.ts
@@ -4,6 +4,7 @@ import Factories from '~/flatbuffers/factories';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { CastRemoveModel, SignerAddModel } from '~/flatbuffers/models/types';
+import { hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import SyncEngine from '~/network/sync/syncEngine';
 import { SyncId } from '~/network/sync/syncId';
 import Client from '~/rpc/client';
@@ -28,7 +29,7 @@ let signerAdd: SignerAddModel;
 beforeAll(async () => {
   custodyEvent = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create(
-      { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid) },
+      { to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()), fid: Array.from(fid) },
       { transient: { wallet } }
     )
   );

--- a/app/src/network/sync/syncEngine.test.ts
+++ b/app/src/network/sync/syncEngine.test.ts
@@ -6,6 +6,7 @@ import Factories from '~/flatbuffers/factories';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { CastAddModel, CastRemoveModel, KeyPair, SignerAddModel } from '~/flatbuffers/models/types';
+import { hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import { getFarcasterTime } from '~/flatbuffers/utils/time';
 import SyncEngine from '~/network/sync/syncEngine';
 import { SyncId } from '~/network/sync/syncId';
@@ -26,7 +27,7 @@ let castAdd: CastAddModel;
 beforeAll(async () => {
   custodyEvent = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create(
-      { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid) },
+      { to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()), fid: Array.from(fid) },
       { transient: { wallet } }
     )
   );

--- a/app/src/rpc/client/index.ts
+++ b/app/src/rpc/client/index.ts
@@ -263,6 +263,13 @@ class Client {
     );
   }
 
+  async getNameRegistryEvent(fname: Uint8Array): HubAsyncResult<NameRegistryEventModel> {
+    return this.makeUnaryNameRegistryEventRequest(
+      definitions.userDataDefinition().getNameRegistryEvent,
+      requests.userDataRequests.getNameRegistryEvent(fname)
+    );
+  }
+
   /* -------------------------------------------------------------------------- */
   /*                                   Sync Methods                             */
   /* -------------------------------------------------------------------------- */

--- a/app/src/rpc/client/serviceRequests/userDataRequests.ts
+++ b/app/src/rpc/client/serviceRequests/userDataRequests.ts
@@ -18,4 +18,13 @@ export const userDataRequests = {
       new ByteBuffer(builder.asUint8Array())
     );
   },
+
+  getNameRegistryEvent: (fname: Uint8Array): rpc_generated.GetNameRegistryEventRequest => {
+    const builder = new Builder(1);
+    const requestT = new rpc_generated.GetNameRegistryEventRequestT(Array.from(fname));
+    builder.finish(requestT.pack(builder));
+    return rpc_generated.GetNameRegistryEventRequest.getRootAsGetNameRegistryEventRequest(
+      new ByteBuffer(builder.asUint8Array())
+    );
+  },
 };

--- a/app/src/rpc/server/serviceImplementations/userDataImplementation.ts
+++ b/app/src/rpc/server/serviceImplementations/userDataImplementation.ts
@@ -1,5 +1,13 @@
 import grpc from '@grpc/grpc-js';
-import { GetUserDataByFidRequest, GetUserDataRequest, Message, MessagesResponse } from '@hub/flatbuffers';
+import {
+  GetNameRegistryEventRequest,
+  GetUserDataByFidRequest,
+  GetUserDataRequest,
+  Message,
+  MessagesResponse,
+  NameRegistryEvent,
+} from '@hub/flatbuffers';
+import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel';
 import { UserDataAddModel } from '~/flatbuffers/models/types';
 import { toMessagesResponse, toServiceError } from '~/rpc/server';
 import Engine from '~/storage/engine';
@@ -30,6 +38,21 @@ export const userDataImplementations = (engine: Engine) => {
       result.match(
         (messages: UserDataAddModel[]) => {
           callback(null, toMessagesResponse(messages));
+        },
+        (err: HubError) => {
+          callback(toServiceError(err));
+        }
+      );
+    },
+
+    getNameRegistryEvent: async (
+      call: grpc.ServerUnaryCall<GetNameRegistryEventRequest, NameRegistryEvent>,
+      callback: grpc.sendUnaryData<NameRegistryEvent>
+    ) => {
+      const result = await engine.getNameRegistryEvent(call.request.fnameArray() ?? new Uint8Array());
+      result.match(
+        (model: NameRegistryEventModel) => {
+          callback(null, model.event);
         },
         (err: HubError) => {
           callback(toServiceError(err));

--- a/app/src/rpc/serviceDefinitions/userDataDefinition.ts
+++ b/app/src/rpc/serviceDefinitions/userDataDefinition.ts
@@ -1,4 +1,11 @@
-import { GetUserDataByFidRequest, GetUserDataRequest, Message, MessagesResponse } from '@hub/flatbuffers';
+import {
+  GetNameRegistryEventRequest,
+  GetUserDataByFidRequest,
+  GetUserDataRequest,
+  Message,
+  MessagesResponse,
+  NameRegistryEvent,
+} from '@hub/flatbuffers';
 import { toByteBuffer } from '~/flatbuffers/utils/bytes';
 import { defaultMethod } from '~/rpc/client';
 
@@ -23,6 +30,17 @@ export const userDataDefinition = () => {
       },
       responseDeserialize: (buffer: Buffer): MessagesResponse => {
         return MessagesResponse.getRootAsMessagesResponse(toByteBuffer(buffer));
+      },
+    },
+
+    getNameRegistryEvent: {
+      ...defaultMethod,
+      path: '/getNameRegistryEvent',
+      requestDeserialize: (buffer: Buffer): GetNameRegistryEventRequest => {
+        return GetNameRegistryEventRequest.getRootAsGetNameRegistryEventRequest(toByteBuffer(buffer));
+      },
+      responseDeserialize: (buffer: Buffer): NameRegistryEvent => {
+        return NameRegistryEvent.getRootAsNameRegistryEvent(toByteBuffer(buffer));
       },
     },
   };

--- a/app/src/rpc/test/ampService.test.ts
+++ b/app/src/rpc/test/ampService.test.ts
@@ -4,6 +4,7 @@ import Factories from '~/flatbuffers/factories';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { AmpAddModel, KeyPair, SignerAddModel } from '~/flatbuffers/models/types';
+import { hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
@@ -41,7 +42,7 @@ let ampAdd: AmpAddModel;
 beforeAll(async () => {
   custodyEvent = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create(
-      { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid) },
+      { to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()), fid: Array.from(fid) },
       { transient: { wallet } }
     )
   );

--- a/app/src/rpc/test/castService.test.ts
+++ b/app/src/rpc/test/castService.test.ts
@@ -4,6 +4,7 @@ import Factories from '~/flatbuffers/factories';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { CastAddModel, KeyPair, SignerAddModel } from '~/flatbuffers/models/types';
+import { hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
@@ -41,7 +42,7 @@ let castAdd: CastAddModel;
 beforeAll(async () => {
   custodyEvent = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create(
-      { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid) },
+      { to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()), fid: Array.from(fid) },
       { transient: { wallet } }
     )
   );

--- a/app/src/rpc/test/eventService.test.ts
+++ b/app/src/rpc/test/eventService.test.ts
@@ -6,6 +6,7 @@ import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel';
 import { CastAddModel, KeyPair, SignerAddModel } from '~/flatbuffers/models/types';
+import { hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
@@ -42,7 +43,7 @@ let castAdd: CastAddModel;
 beforeAll(async () => {
   custodyEvent = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create(
-      { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid) },
+      { to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()), fid: Array.from(fid) },
       { transient: { wallet } }
     )
   );

--- a/app/src/rpc/test/reactionService.test.ts
+++ b/app/src/rpc/test/reactionService.test.ts
@@ -4,6 +4,7 @@ import Factories from '~/flatbuffers/factories';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { KeyPair, ReactionAddModel, SignerAddModel } from '~/flatbuffers/models/types';
+import { hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
@@ -44,7 +45,7 @@ let reactionAddRecast: ReactionAddModel;
 beforeAll(async () => {
   custodyEvent = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create(
-      { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid) },
+      { to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()), fid: Array.from(fid) },
       { transient: { wallet } }
     )
   );

--- a/app/src/rpc/test/signerService.test.ts
+++ b/app/src/rpc/test/signerService.test.ts
@@ -3,6 +3,7 @@ import Factories from '~/flatbuffers/factories';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { KeyPair, SignerAddModel } from '~/flatbuffers/models/types';
+import { hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
@@ -39,7 +40,7 @@ let signerAdd: SignerAddModel;
 beforeAll(async () => {
   custodyEvent = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create(
-      { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid) },
+      { to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()), fid: Array.from(fid) },
       { transient: { wallet } }
     )
   );

--- a/app/src/rpc/test/submitService.test.ts
+++ b/app/src/rpc/test/submitService.test.ts
@@ -5,6 +5,7 @@ import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel';
 import { CastAddModel, KeyPair, SignerAddModel } from '~/flatbuffers/models/types';
+import { hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
@@ -42,7 +43,7 @@ let castAdd: CastAddModel;
 beforeAll(async () => {
   custodyEvent = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create(
-      { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid) },
+      { to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()), fid: Array.from(fid) },
       { transient: { wallet } }
     )
   );
@@ -98,7 +99,11 @@ describe('submitIdRegistryEvent', () => {
   xtest('fails with invalid event', async () => {
     const invalidEvent = new IdRegistryEventModel(
       await Factories.IdRegistryEvent.create(
-        { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid), type: 0 as IdRegistryEventType },
+        {
+          to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()),
+          fid: Array.from(fid),
+          type: 0 as IdRegistryEventType,
+        },
         { transient: { wallet } }
       )
     );
@@ -111,7 +116,7 @@ describe('submitNameRegistryEvent', () => {
   test('succeeds', async () => {
     const nameRegistryEvent = new NameRegistryEventModel(
       await Factories.NameRegistryEvent.create(
-        { to: Array.from(utils.arrayify(wallet.address)) },
+        { to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()) },
         { transient: { wallet } }
       )
     );
@@ -124,7 +129,7 @@ describe('submitNameRegistryEvent', () => {
   xtest('fails with invalid event', async () => {
     const invalidEvent = new NameRegistryEventModel(
       await Factories.NameRegistryEvent.create(
-        { to: Array.from(utils.arrayify(wallet.address)), type: 0 as NameRegistryEventType },
+        { to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()), type: 0 as NameRegistryEventType },
         { transient: { wallet } }
       )
     );

--- a/app/src/rpc/test/syncService.test.ts
+++ b/app/src/rpc/test/syncService.test.ts
@@ -16,6 +16,7 @@ import {
   VerificationAddEthAddressModel,
   VerificationRemoveModel,
 } from '~/flatbuffers/models/types';
+import { hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
@@ -52,7 +53,7 @@ let signerAdd: SignerAddModel;
 beforeAll(async () => {
   custodyEvent = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create(
-      { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid) },
+      { to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()), fid: Array.from(fid) },
       { transient: { wallet } }
     )
   );

--- a/app/src/rpc/test/userDataService.test.ts
+++ b/app/src/rpc/test/userDataService.test.ts
@@ -6,6 +6,7 @@ import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel';
 import { KeyPair, SignerAddModel, UserDataAddModel } from '~/flatbuffers/models/types';
+import { hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
@@ -47,7 +48,7 @@ let addFname: UserDataAddModel;
 beforeAll(async () => {
   custodyEvent = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create(
-      { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid) },
+      { to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()), fid: Array.from(fid) },
       { transient: { wallet } }
     )
   );
@@ -104,7 +105,7 @@ describe('getUserData', () => {
 
     const nameRegistryEvent = await Factories.NameRegistryEvent.create({
       fname: Array.from(fname),
-      to: Array.from(utils.arrayify(wallet.address)),
+      to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()),
     });
     const model = new NameRegistryEventModel(nameRegistryEvent);
     await model.put(db);

--- a/app/src/rpc/test/verificationService.test.ts
+++ b/app/src/rpc/test/verificationService.test.ts
@@ -3,6 +3,7 @@ import Factories from '~/flatbuffers/factories';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { KeyPair, SignerAddModel, VerificationAddEthAddressModel } from '~/flatbuffers/models/types';
+import { hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import SyncEngine from '~/network/sync/syncEngine';
 import Client from '~/rpc/client';
 import Server from '~/rpc/server';
@@ -41,7 +42,7 @@ let verificationAdd: VerificationAddEthAddressModel;
 beforeAll(async () => {
   custodyEvent = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create(
-      { to: Array.from(utils.arrayify(wallet.address)), fid: Array.from(fid) },
+      { to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()), fid: Array.from(fid) },
       { transient: { wallet } }
     )
   );

--- a/app/src/storage/engine/index.test.ts
+++ b/app/src/storage/engine/index.test.ts
@@ -7,6 +7,7 @@ import MessageModel from '~/flatbuffers/models/messageModel';
 import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel';
 import * as types from '~/flatbuffers/models/types';
 import { KeyPair } from '~/flatbuffers/models/types';
+import { hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import Engine from '~/storage/engine';
 import AmpStore from '~/storage/stores/ampStore';
@@ -50,7 +51,7 @@ let userDataAdd: types.UserDataAddModel;
 
 beforeAll(async () => {
   custodyWallet = new Wallet(utils.randomBytes(32));
-  custodyAddress = utils.arrayify(custodyWallet.address);
+  custodyAddress = hexStringToBytes(custodyWallet.address)._unsafeUnwrap();
   custodyEvent = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create({ fid: Array.from(fid), to: Array.from(custodyAddress) })
   );

--- a/app/src/storage/engine/index.ts
+++ b/app/src/storage/engine/index.ts
@@ -7,7 +7,7 @@ import { isSignerAdd, isSignerRemove, isUserDataAdd } from '~/flatbuffers/models
 import * as types from '~/flatbuffers/models/types';
 import { RootPrefix } from '~/flatbuffers/models/types';
 import * as validations from '~/flatbuffers/models/validations';
-import { bytesCompare, toNumber } from '~/flatbuffers/utils/bytes';
+import { bytesCompare, bytesToNumber } from '~/flatbuffers/utils/bytes';
 import { SyncId } from '~/network/sync/syncId';
 import RocksDB from '~/storage/db/rocksdb';
 import AmpStore from '~/storage/stores/ampStore';
@@ -489,6 +489,10 @@ class Engine {
     return ResultAsync.fromPromise(this._userDataStore.getUserDataAddsByUser(fid), (e) => e as HubError);
   }
 
+  async getNameRegistryEvent(fname: Uint8Array): HubAsyncResult<NameRegistryEventModel> {
+    return ResultAsync.fromPromise(this._userDataStore.getNameRegistryEvent(fname), (e) => e as HubError);
+  }
+
   /* -------------------------------------------------------------------------- */
   /*                               Private Methods                              */
   /* -------------------------------------------------------------------------- */
@@ -500,7 +504,7 @@ class Engine {
       () => undefined
     );
     if (custodyAddress.isErr()) {
-      return err(new HubError('bad_request.validation_failure', `unknown fid ${toNumber(message.fid())}`));
+      return err(new HubError('bad_request.validation_failure', `unknown fid ${bytesToNumber(message.fid())}`));
     }
 
     // 2. Check that the signer is valid if message is not a signer message

--- a/app/src/storage/engine/seed.ts
+++ b/app/src/storage/engine/seed.ts
@@ -3,6 +3,7 @@ import Factories from '~/flatbuffers/factories';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { SignerAddModel } from '~/flatbuffers/models/types';
+import { hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import Engine from '~/storage/engine';
 
 /** Util to seed engine with all the data needed to make a signer valid for an fid */
@@ -14,7 +15,7 @@ export const seedSigner = async (engine: Engine, fid: Uint8Array, signer: Uint8A
   const idRegistryEvent = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create({
       fid: Array.from(fid),
-      to: Array.from(ethers.utils.arrayify(wallet.address)),
+      to: Array.from(hexStringToBytes(wallet.address)._unsafeUnwrap()),
     })
   );
 

--- a/app/src/storage/jobs/revokeSignerJob.test.ts
+++ b/app/src/storage/jobs/revokeSignerJob.test.ts
@@ -76,7 +76,8 @@ describe('jobKeyToTimestamp', () => {
     const timestamp = Date.now();
     const hash = Factories.Bytes.build({}, { transient: { length: 4 } });
     const jobKey = RevokeSignerJobQueue.makeJobKey(timestamp, hash);
-    expect(RevokeSignerJobQueue.jobKeyToTimestamp(jobKey._unsafeUnwrap())).toEqual(timestamp);
+    const recoveredTimestamp = RevokeSignerJobQueue.jobKeyToTimestamp(jobKey._unsafeUnwrap());
+    expect(recoveredTimestamp._unsafeUnwrap()).toEqual(timestamp);
   });
 });
 

--- a/app/src/storage/stores/signerStore.test.ts
+++ b/app/src/storage/stores/signerStore.test.ts
@@ -1,11 +1,10 @@
 import { faker } from '@faker-js/faker';
 import { IdRegistryEventType, MessageType } from '@hub/flatbuffers';
-import { arrayify } from 'ethers/lib/utils';
 import Factories from '~/flatbuffers/factories';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { EthereumSigner, SignerAddModel, SignerRemoveModel, UserPostfix } from '~/flatbuffers/models/types';
-import { bytesDecrement, bytesIncrement } from '~/flatbuffers/utils/bytes';
+import { bytesDecrement, bytesIncrement, hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import { getFarcasterTime } from '~/flatbuffers/utils/time';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import SignerStore from '~/storage/stores/signerStore';
@@ -32,7 +31,7 @@ let signerRemove: SignerRemoveModel;
 
 beforeAll(async () => {
   custody1 = await generateEthereumSigner();
-  custody1Address = arrayify(custody1.signerKey);
+  custody1Address = hexStringToBytes(custody1.signerKey)._unsafeUnwrap();
   const idRegistryEvent = await Factories.IdRegistryEvent.create({
     fid: Array.from(fid),
     to: Array.from(custody1Address),
@@ -40,7 +39,7 @@ beforeAll(async () => {
   custody1Event = new IdRegistryEventModel(idRegistryEvent);
 
   custody2 = await generateEthereumSigner();
-  custody2Address = arrayify(custody2.signerKey);
+  custody2Address = hexStringToBytes(custody2.signerKey)._unsafeUnwrap();
 
   signer = (await generateEd25519KeyPair()).publicKey;
 
@@ -174,7 +173,7 @@ describe('mergeIdRegistryEvent', () => {
   test('fails if events have the same blockNumber but different blockHashes', async () => {
     const idRegistryEvent = await Factories.IdRegistryEvent.create({
       ...custody1Event.event.unpack(),
-      blockHash: Array.from(arrayify(faker.datatype.hexadecimal({ length: 64 }))),
+      blockHash: Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 64 }))._unsafeUnwrap()),
     });
 
     const blockHashConflictEvent = new IdRegistryEventModel(idRegistryEvent);
@@ -186,7 +185,7 @@ describe('mergeIdRegistryEvent', () => {
   test('fails if events have the same blockNumber and logIndex but different transactionHashes', async () => {
     const idRegistryEvent = await Factories.IdRegistryEvent.create({
       ...custody1Event.event.unpack(),
-      transactionHash: Array.from(arrayify(faker.datatype.hexadecimal({ length: 64 }))),
+      transactionHash: Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 64 }))._unsafeUnwrap()),
     });
 
     const txHashConflictEvent = new IdRegistryEventModel(idRegistryEvent);
@@ -215,7 +214,7 @@ describe('mergeIdRegistryEvent', () => {
     test('when it has a higher block number', async () => {
       const idRegistryEvent = await Factories.IdRegistryEvent.create({
         ...custody1Event.event.unpack(),
-        transactionHash: Array.from(arrayify(faker.datatype.hexadecimal({ length: 64 }))),
+        transactionHash: Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 64 }))._unsafeUnwrap()),
         to: Array.from(custody2Address),
         blockNumber: custody1Event.blockNumber() + 1,
       });
@@ -225,7 +224,7 @@ describe('mergeIdRegistryEvent', () => {
     test('when it has the same block number and a higher log index', async () => {
       const idRegistryEvent = await Factories.IdRegistryEvent.create({
         ...custody1Event.event.unpack(),
-        transactionHash: Array.from(arrayify(faker.datatype.hexadecimal({ length: 64 }))),
+        transactionHash: Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 64 }))._unsafeUnwrap()),
         to: Array.from(custody2Address),
         logIndex: custody1Event.logIndex() + 1,
       });
@@ -252,7 +251,7 @@ describe('mergeIdRegistryEvent', () => {
     test('when it has a lower block number', async () => {
       const idRegistryEvent = await Factories.IdRegistryEvent.create({
         ...custody1Event.event.unpack(),
-        transactionHash: Array.from(arrayify(faker.datatype.hexadecimal({ length: 64 }))),
+        transactionHash: Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 64 }))._unsafeUnwrap()),
         to: Array.from(custody2Address),
         blockNumber: custody1Event.blockNumber() - 1,
       });

--- a/app/src/storage/stores/userDataStore.test.ts
+++ b/app/src/storage/stores/userDataStore.test.ts
@@ -1,12 +1,11 @@
 import { NameRegistryEventType, UserDataType } from '@hub/flatbuffers';
 import { utils, Wallet } from 'ethers';
-import { arrayify } from 'ethers/lib/utils';
 import Factories from '~/flatbuffers/factories';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel';
 import { KeyPair, SignerAddModel, UserDataAddModel, UserPostfix } from '~/flatbuffers/models/types';
-import { bytesIncrement } from '~/flatbuffers/utils/bytes';
+import { bytesIncrement, hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import { getFarcasterTime } from '~/flatbuffers/utils/time';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import Engine from '~/storage/engine';
@@ -34,7 +33,7 @@ let addBio: UserDataAddModel;
 let addFname: UserDataAddModel;
 
 beforeAll(async () => {
-  custody1Address = arrayify(wallet.address);
+  custody1Address = hexStringToBytes(wallet.address)._unsafeUnwrap();
   custody1Event = new IdRegistryEventModel(
     await Factories.IdRegistryEvent.create(
       {
@@ -272,7 +271,7 @@ describe('userfname', () => {
 
     // Now, generate a new address
     const custody2 = await generateEthereumSigner();
-    const custody2Address = arrayify(custody2.signerKey);
+    const custody2Address = hexStringToBytes(custody2.signerKey)._unsafeUnwrap();
 
     // transfer the name to custody2address
     const nameRegistryEvent2 = await Factories.NameRegistryEvent.create({

--- a/app/src/storage/stores/verificationStore.test.ts
+++ b/app/src/storage/stores/verificationStore.test.ts
@@ -1,5 +1,4 @@
 import { FarcasterNetwork } from '@hub/flatbuffers';
-import { arrayify } from 'ethers/lib/utils';
 import Factories from '~/flatbuffers/factories';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import {
@@ -8,7 +7,7 @@ import {
   VerificationAddEthAddressModel,
   VerificationRemoveModel,
 } from '~/flatbuffers/models/types';
-import { bytesDecrement, bytesIncrement } from '~/flatbuffers/utils/bytes';
+import { bytesDecrement, bytesIncrement, hexStringToBytes } from '~/flatbuffers/utils/bytes';
 import { getFarcasterTime } from '~/flatbuffers/utils/time';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import StoreEventHandler from '~/storage/stores/storeEventHandler';
@@ -28,7 +27,7 @@ let verificationRemove: VerificationRemoveModel;
 
 beforeAll(async () => {
   ethSigner = await generateEthereumSigner();
-  address = arrayify(ethSigner.signerKey);
+  address = hexStringToBytes(ethSigner.signerKey)._unsafeUnwrap();
 
   const addBody = await Factories.VerificationAddEthAddressBody.create(
     {},

--- a/app/src/utils/logger.ts
+++ b/app/src/utils/logger.ts
@@ -1,10 +1,8 @@
-import { BigNumber } from 'ethers';
-import { hexlify } from 'ethers/lib/utils';
 import { default as Pino } from 'pino';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel';
-import { toNumber } from '~/flatbuffers/utils/bytes';
+import { bytesToHexString, bytesToNumber } from '~/flatbuffers/utils/bytes';
 import { fromFarcasterTime } from '~/flatbuffers/utils/time';
 
 /**
@@ -48,8 +46,8 @@ export const logger = Pino(defaultOptions);
 export const messageToLog = (message: MessageModel) => {
   return {
     timestamp: fromFarcasterTime(message.timestamp()),
-    hash: hexlify(message.hash()),
-    fid: BigNumber.from(message.fid()).toNumber(),
+    hash: bytesToHexString(message.hash())._unsafeUnwrap(),
+    fid: bytesToNumber(message.fid())._unsafeUnwrap(),
     type: message.typeName(),
   };
 };
@@ -57,9 +55,9 @@ export const messageToLog = (message: MessageModel) => {
 export const idRegistryEventToLog = (event: IdRegistryEventModel) => {
   return {
     blockNumber: event.blockNumber(),
-    transactionHash: hexlify(event.transactionHash()),
-    fid: toNumber(event.fid()),
-    to: hexlify(event.to()),
+    transactionHash: bytesToHexString(event.transactionHash())._unsafeUnwrap(),
+    fid: bytesToNumber(event.fid())._unsafeUnwrap(),
+    to: bytesToHexString(event.to())._unsafeUnwrap(),
     type: event.typeName(),
   };
 };
@@ -67,9 +65,9 @@ export const idRegistryEventToLog = (event: IdRegistryEventModel) => {
 export const nameRegistryEventToLog = (event: NameRegistryEventModel) => {
   return {
     blockNumber: event.blockNumber(),
-    transactionHash: hexlify(event.transactionHash()),
+    transactionHash: bytesToHexString(event.transactionHash())._unsafeUnwrap(),
     fname: Buffer.from(event.fname()).toString('utf-8').replace(/\0/g, ''),
-    to: hexlify(event.to()),
+    to: bytesToHexString(event.to())._unsafeUnwrap(),
     type: event.typeName(),
   };
 };

--- a/packages/flatbuffers/package.json
+++ b/packages/flatbuffers/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "build": "yarn clean && tsc --project ./tsconfig.json",
-    "flatc": "flatc --ts --ts-flat-files --gen-object-api -o src/flatbuffers/generated src/flatbuffers/schemas/*.fbs",
+    "flatc": "flatc --ts --ts-flat-files --gen-object-api -o src/generated src/schemas/*.fbs",
     "clean": "rm -rf ./build",
     "lint": "eslint  src/ --color --ext .ts",
     "lint:fix": "yarn run lint -- --fix"

--- a/packages/flatbuffers/src/generated/rpc_generated.ts
+++ b/packages/flatbuffers/src/generated/rpc_generated.ts
@@ -2273,48 +2273,48 @@ pack(builder:flatbuffers.Builder): flatbuffers.Offset {
 }
 }
 
-export class GetUserNameRequest implements flatbuffers.IUnpackableObject<GetUserNameRequestT> {
+export class GetNameRegistryEventRequest implements flatbuffers.IUnpackableObject<GetNameRegistryEventRequestT> {
   bb: flatbuffers.ByteBuffer|null = null;
   bb_pos = 0;
-  __init(i:number, bb:flatbuffers.ByteBuffer):GetUserNameRequest {
+  __init(i:number, bb:flatbuffers.ByteBuffer):GetNameRegistryEventRequest {
   this.bb_pos = i;
   this.bb = bb;
   return this;
 }
 
-static getRootAsGetUserNameRequest(bb:flatbuffers.ByteBuffer, obj?:GetUserNameRequest):GetUserNameRequest {
-  return (obj || new GetUserNameRequest()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+static getRootAsGetNameRegistryEventRequest(bb:flatbuffers.ByteBuffer, obj?:GetNameRegistryEventRequest):GetNameRegistryEventRequest {
+  return (obj || new GetNameRegistryEventRequest()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 }
 
-static getSizePrefixedRootAsGetUserNameRequest(bb:flatbuffers.ByteBuffer, obj?:GetUserNameRequest):GetUserNameRequest {
+static getSizePrefixedRootAsGetNameRegistryEventRequest(bb:flatbuffers.ByteBuffer, obj?:GetNameRegistryEventRequest):GetNameRegistryEventRequest {
   bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
-  return (obj || new GetUserNameRequest()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  return (obj || new GetNameRegistryEventRequest()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 }
 
-fid(index: number):number|null {
+fname(index: number):number|null {
   const offset = this.bb!.__offset(this.bb_pos, 4);
   return offset ? this.bb!.readUint8(this.bb!.__vector(this.bb_pos + offset) + index) : 0;
 }
 
-fidLength():number {
+fnameLength():number {
   const offset = this.bb!.__offset(this.bb_pos, 4);
   return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
 }
 
-fidArray():Uint8Array|null {
+fnameArray():Uint8Array|null {
   const offset = this.bb!.__offset(this.bb_pos, 4);
   return offset ? new Uint8Array(this.bb!.bytes().buffer, this.bb!.bytes().byteOffset + this.bb!.__vector(this.bb_pos + offset), this.bb!.__vector_len(this.bb_pos + offset)) : null;
 }
 
-static startGetUserNameRequest(builder:flatbuffers.Builder) {
+static startGetNameRegistryEventRequest(builder:flatbuffers.Builder) {
   builder.startObject(1);
 }
 
-static addFid(builder:flatbuffers.Builder, fidOffset:flatbuffers.Offset) {
-  builder.addFieldOffset(0, fidOffset, 0);
+static addFname(builder:flatbuffers.Builder, fnameOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(0, fnameOffset, 0);
 }
 
-static createFidVector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset {
+static createFnameVector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset {
   builder.startVector(1, data.length, 1);
   for (let i = data.length - 1; i >= 0; i--) {
     builder.addInt8(data[i]!);
@@ -2322,45 +2322,45 @@ static createFidVector(builder:flatbuffers.Builder, data:number[]|Uint8Array):fl
   return builder.endVector();
 }
 
-static startFidVector(builder:flatbuffers.Builder, numElems:number) {
+static startFnameVector(builder:flatbuffers.Builder, numElems:number) {
   builder.startVector(1, numElems, 1);
 }
 
-static endGetUserNameRequest(builder:flatbuffers.Builder):flatbuffers.Offset {
+static endGetNameRegistryEventRequest(builder:flatbuffers.Builder):flatbuffers.Offset {
   const offset = builder.endObject();
-  builder.requiredField(offset, 4) // fid
+  builder.requiredField(offset, 4) // fname
   return offset;
 }
 
-static createGetUserNameRequest(builder:flatbuffers.Builder, fidOffset:flatbuffers.Offset):flatbuffers.Offset {
-  GetUserNameRequest.startGetUserNameRequest(builder);
-  GetUserNameRequest.addFid(builder, fidOffset);
-  return GetUserNameRequest.endGetUserNameRequest(builder);
+static createGetNameRegistryEventRequest(builder:flatbuffers.Builder, fnameOffset:flatbuffers.Offset):flatbuffers.Offset {
+  GetNameRegistryEventRequest.startGetNameRegistryEventRequest(builder);
+  GetNameRegistryEventRequest.addFname(builder, fnameOffset);
+  return GetNameRegistryEventRequest.endGetNameRegistryEventRequest(builder);
 }
 
-unpack(): GetUserNameRequestT {
-  return new GetUserNameRequestT(
-    this.bb!.createScalarList<number>(this.fid.bind(this), this.fidLength())
+unpack(): GetNameRegistryEventRequestT {
+  return new GetNameRegistryEventRequestT(
+    this.bb!.createScalarList<number>(this.fname.bind(this), this.fnameLength())
   );
 }
 
 
-unpackTo(_o: GetUserNameRequestT): void {
-  _o.fid = this.bb!.createScalarList<number>(this.fid.bind(this), this.fidLength());
+unpackTo(_o: GetNameRegistryEventRequestT): void {
+  _o.fname = this.bb!.createScalarList<number>(this.fname.bind(this), this.fnameLength());
 }
 }
 
-export class GetUserNameRequestT implements flatbuffers.IGeneratedObject {
+export class GetNameRegistryEventRequestT implements flatbuffers.IGeneratedObject {
 constructor(
-  public fid: (number)[] = []
+  public fname: (number)[] = []
 ){}
 
 
 pack(builder:flatbuffers.Builder): flatbuffers.Offset {
-  const fid = GetUserNameRequest.createFidVector(builder, this.fid);
+  const fname = GetNameRegistryEventRequest.createFnameVector(builder, this.fname);
 
-  return GetUserNameRequest.createGetUserNameRequest(builder,
-    fid
+  return GetNameRegistryEventRequest.createGetNameRegistryEventRequest(builder,
+    fname
   );
 }
 }

--- a/packages/flatbuffers/src/schemas/rpc.fbs
+++ b/packages/flatbuffers/src/schemas/rpc.fbs
@@ -129,8 +129,8 @@ table GetUserDataByFidRequest {
   fid: [ubyte] (required);
 }
 
-table GetUserNameRequest {
-  fid: [ubyte] (required);
+table GetNameRegistryEventRequest {
+  fname: [ubyte] (required);
 }
 
 // Sync Requests


### PR DESCRIPTION
## Motivation

We have not been explicit about the endianness of our byte arrays throughout the system. This PR adds utils for converting to/from byte arrays and makes endianness explicit.

## Change Summary

* Default to little endian everywhere in the hub
* Add utils to `bytes.ts` file that help convert to/from byte arrays
* Refactor EthEventsProvider to convert all event data to little endian

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged
