### PR TITLE
refactor: purge hexlify usage

### DIFF
--- a/app/src/utils/crypto.test.ts
+++ b/app/src/utils/crypto.test.ts
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker';
 import * as ed from '@noble/ed25519';
-import { hexToBytes, utf8ToBytes } from 'ethereum-cryptography/utils';
-import { ethers, utils } from 'ethers';
+import { ethers } from 'ethers';
 import { Ed25519Signer, EthereumSigner } from '~/flatbuffers/models/types';
+import { bytesToHexString, hexStringToBytes, utf8StringToBytes } from '~/flatbuffers/utils/bytes';
 import { generateEd25519Signer, generateEthereumSigner } from '~/utils/crypto';
 
 describe('generateEthereumSigner', () => {
@@ -42,7 +42,7 @@ describe('generateEd25519Signer', () => {
 
   beforeAll(async () => {
     signer = await generateEd25519Signer();
-    pubKey = await utils.hexlify(await ed.getPublicKey(signer.privateKey));
+    pubKey = bytesToHexString(await ed.getPublicKey(signer.privateKey))._unsafeUnwrap();
   });
 
   test('signerKey is public key', () => {
@@ -51,15 +51,23 @@ describe('generateEd25519Signer', () => {
 
   test('text can be signed and verified', async () => {
     const text = faker.lorem.sentence(2);
-    const signature = await ed.sign(utf8ToBytes(text), signer.privateKey);
-    const isValid = await ed.verify(signature, utf8ToBytes(text), hexToBytes(signer.signerKey));
+    const signature = await ed.sign(utf8StringToBytes(text)._unsafeUnwrap(), signer.privateKey);
+    const isValid = await ed.verify(
+      signature,
+      utf8StringToBytes(text)._unsafeUnwrap(),
+      hexStringToBytes(signer.signerKey)._unsafeUnwrap()
+    );
     expect(isValid).toBe(true);
   });
 
   test('hex can be signed and verified', async () => {
     const hex = faker.datatype.hexadecimal({ length: 40 });
-    const signature = await ed.sign(hexToBytes(hex), signer.privateKey);
-    const isValid = await ed.verify(signature, hexToBytes(hex), hexToBytes(signer.signerKey));
+    const signature = await ed.sign(hexStringToBytes(hex)._unsafeUnwrap(), signer.privateKey);
+    const isValid = await ed.verify(
+      signature,
+      hexStringToBytes(hex)._unsafeUnwrap(),
+      hexStringToBytes(signer.signerKey)._unsafeUnwrap()
+    );
     expect(isValid).toBe(true);
   });
 });

--- a/app/src/utils/crypto.ts
+++ b/app/src/utils/crypto.ts
@@ -1,8 +1,8 @@
 import { SignatureScheme } from '@hub/flatbuffers';
 import * as ed from '@noble/ed25519';
 import { ethers } from 'ethers';
-import { hexlify } from 'ethers/lib/utils';
 import { Ed25519Signer, EthereumSigner, KeyPair } from '~/flatbuffers/models/types';
+import { bytesToHexString } from '~/flatbuffers/utils/bytes';
 
 export const sleep = (ms: number) => {
   return new Promise((resolve) => {
@@ -29,8 +29,11 @@ export const generateEd25519KeyPair = async (): Promise<KeyPair> => {
  */
 export const generateEd25519Signer = async (): Promise<Ed25519Signer> => {
   const { privateKey, publicKey } = await generateEd25519KeyPair();
-  const signerKey = await hexlify(publicKey);
-  return { privateKey, signerKey, type: SignatureScheme.Ed25519 };
+  const signerKeyHex = bytesToHexString(publicKey);
+  if (signerKeyHex.isErr()) {
+    throw signerKeyHex.error;
+  }
+  return { privateKey, signerKey: signerKeyHex.value, type: SignatureScheme.Ed25519 };
 };
 
 /**


### PR DESCRIPTION
## Change Summary

Ethers.js `hexlify` uses big endian notation. Replace usage with bytes methods with explicit endianness.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
