### PR TITLE
chore: Encode prefixes and hashes as little endian

### DIFF
--- a/app/src/network/sync/syncEngine.ts
+++ b/app/src/network/sync/syncEngine.ts
@@ -1,6 +1,6 @@
-import { arrayify } from 'ethers/lib/utils';
 import { err } from 'neverthrow';
 import MessageModel from '~/flatbuffers/models/messageModel';
+import { utf8StringToBytes } from '~/flatbuffers/utils/bytes';
 import { getFarcasterTime } from '~/flatbuffers/utils/time';
 import { MerkleTrie, NodeMetadata } from '~/network/sync/merkleTrie';
 import { SyncId, timestampToPaddedTimestampPrefix } from '~/network/sync/syncId';
@@ -103,7 +103,7 @@ class SyncEngine {
     }
 
     const messages = await rpcClient.getAllMessagesBySyncIds(
-      syncIDs.map((syncIdhash) => arrayify(Buffer.from(syncIdhash)))
+      syncIDs.map((syncIdhash) => utf8StringToBytes(syncIdhash)._unsafeUnwrap())
     );
     await messages.match(
       async (msgs) => {

--- a/app/src/rpc/client/index.ts
+++ b/app/src/rpc/client/index.ts
@@ -1,12 +1,12 @@
 import grpc, { ClientReadableStream, Metadata, MetadataValue } from '@grpc/grpc-js';
 import * as flatbuffers from '@hub/flatbuffers';
-import { arrayify } from 'ethers/lib/utils';
 import { ByteBuffer } from 'flatbuffers';
 import { err, ok } from 'neverthrow';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel';
 import * as FBTypes from '~/flatbuffers/models/types';
+import { bytesToUtf8String, utf8StringToBytes } from '~/flatbuffers/utils/bytes';
 import { NodeMetadata } from '~/network/sync/merkleTrie';
 import { TrieSnapshot } from '~/network/sync/trieNode';
 import * as requests from '~/rpc/client/serviceRequests';
@@ -37,21 +37,21 @@ const fromNodeMetadataResponse = (response: flatbuffers.TrieNodeMetadataResponse
   for (let i = 0; i < response.childrenLength(); i++) {
     const child = response.children(i);
 
-    const prefix = new TextDecoder().decode(child?.prefixArray() ?? new Uint8Array());
+    const prefix = bytesToUtf8String(child?.prefixArray() ?? new Uint8Array())._unsafeUnwrap();
     // Char is the last char of prefix
     const char = prefix[prefix.length - 1] ?? '';
 
     children.set(char, {
       numMessages: Number(child?.numMessages()),
       prefix,
-      hash: new TextDecoder().decode(child?.hashArray() ?? new Uint8Array()),
+      hash: bytesToUtf8String(child?.hashArray() ?? new Uint8Array())._unsafeUnwrap(),
     });
   }
 
   return {
-    prefix: new TextDecoder().decode(response.prefixArray() ?? new Uint8Array()),
+    prefix: bytesToUtf8String(response.prefixArray() ?? new Uint8Array())._unsafeUnwrap(),
     numMessages: Number(response.numMessages()),
-    hash: new TextDecoder().decode(response.hashArray() ?? new Uint8Array()),
+    hash: bytesToUtf8String(response.hashArray() ?? new Uint8Array())._unsafeUnwrap(),
     children,
   };
 };
@@ -343,14 +343,14 @@ class Client {
   async getSyncMetadataByPrefix(prefix: string): HubAsyncResult<NodeMetadata> {
     return this.makeUnarySyncNodeMetadataRequest(
       definitions.syncDefinition().getSyncMetadataByPrefix,
-      requests.syncRequests.createByPrefixRequest(arrayify(Buffer.from(prefix)))
+      requests.syncRequests.createByPrefixRequest(utf8StringToBytes(prefix)._unsafeUnwrap())
     );
   }
 
   async getSyncTrieNodeSnapshotByPrefix(prefix: string): HubAsyncResult<{ snapshot: TrieSnapshot; rootHash: string }> {
     return this.makeUnarySyncNodeSnapshotRequest(
       definitions.syncDefinition().getSyncTrieNodeSnapshotByPrefix,
-      requests.syncRequests.createByPrefixRequest(arrayify(Buffer.from(prefix)))
+      requests.syncRequests.createByPrefixRequest(utf8StringToBytes(prefix)._unsafeUnwrap())
     );
   }
 
@@ -364,7 +364,7 @@ class Client {
   async getSyncIdsByPrefix(prefix: string): HubAsyncResult<string[]> {
     return this.makeUnarySyncIdsByPrefixRequest(
       definitions.syncDefinition().getAllSyncIdsByPrefix,
-      requests.syncRequests.createByPrefixRequest(arrayify(Buffer.from(prefix)))
+      requests.syncRequests.createByPrefixRequest(utf8StringToBytes(prefix)._unsafeUnwrap())
     );
   }
 

--- a/app/src/rpc/server/index.ts
+++ b/app/src/rpc/server/index.ts
@@ -1,9 +1,9 @@
 import grpc from '@grpc/grpc-js';
 import * as flatbuffers from '@hub/flatbuffers';
-import { arrayify } from 'ethers/lib/utils';
 import { Builder, ByteBuffer } from 'flatbuffers';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { HubInterface } from '~/flatbuffers/models/types';
+import { utf8StringToBytes } from '~/flatbuffers/utils/bytes';
 import { NodeMetadata } from '~/network/sync/merkleTrie';
 import SyncEngine from '~/network/sync/syncEngine';
 import { TrieSnapshot } from '~/network/sync/trieNode';
@@ -73,9 +73,9 @@ export const toTrieNodeMetadataResponse = (metadata: NodeMetadata): flatbuffers.
     for (const [, child] of metadata.children) {
       childrenTrie.push(
         new flatbuffers.TrieNodeMetadataResponseT(
-          Array.from(arrayify(Buffer.from(child.prefix))),
+          Array.from(utf8StringToBytes(child.prefix)._unsafeUnwrap()),
           BigInt(child.numMessages),
-          Array.from(arrayify(Buffer.from(child.hash))),
+          Array.from(utf8StringToBytes(child.hash)._unsafeUnwrap()),
           []
         )
       );
@@ -83,9 +83,9 @@ export const toTrieNodeMetadataResponse = (metadata: NodeMetadata): flatbuffers.
   }
 
   const metadataT = new flatbuffers.TrieNodeMetadataResponseT(
-    Array.from(arrayify(Buffer.from(metadata.prefix))),
+    Array.from(utf8StringToBytes(metadata.prefix)._unsafeUnwrap()),
     BigInt(metadata.numMessages),
-    Array.from(arrayify(Buffer.from(metadata.hash))),
+    Array.from(utf8StringToBytes(metadata.hash)._unsafeUnwrap()),
     childrenTrie
   );
   const builder = new Builder(1);

--- a/app/src/rpc/server/serviceImplementations/syncImplementation.ts
+++ b/app/src/rpc/server/serviceImplementations/syncImplementation.ts
@@ -3,6 +3,7 @@ import * as flatbuffers from '@hub/flatbuffers';
 import { Builder, ByteBuffer } from 'flatbuffers';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import * as types from '~/flatbuffers/models/types';
+import { bytesToUtf8String } from '~/flatbuffers/utils/bytes';
 import SyncEngine from '~/network/sync/syncEngine';
 import {
   toMessagesResponse,
@@ -111,7 +112,7 @@ export const syncImplementation = (engine: Engine, syncEngine: SyncEngine) => {
       callback: grpc.sendUnaryData<flatbuffers.GetAllSyncIdsByPrefixResponse>
     ) => {
       const result = syncEngine.getIdsByPrefix(
-        new TextDecoder().decode(call.request.prefixArray() ?? new Uint8Array())
+        bytesToUtf8String(call.request.prefixArray() ?? new Uint8Array())._unsafeUnwrap()
       );
       callback(null, toSyncIdsResponse(result));
     },
@@ -122,7 +123,9 @@ export const syncImplementation = (engine: Engine, syncEngine: SyncEngine) => {
     ) => {
       const syncIdHashes: string[] = [];
       for (let i = 0; i < call.request.syncIdsLength(); i++) {
-        syncIdHashes.push(new TextDecoder().decode(call.request.syncIds(i)?.syncIdHashArray() ?? new Uint8Array()));
+        syncIdHashes.push(
+          bytesToUtf8String(call.request.syncIds(i)?.syncIdHashArray() ?? new Uint8Array())._unsafeUnwrap()
+        );
       }
 
       const result = await engine.getAllMessagesBySyncIds(syncIdHashes);
@@ -140,7 +143,7 @@ export const syncImplementation = (engine: Engine, syncEngine: SyncEngine) => {
       call: grpc.ServerUnaryCall<flatbuffers.GetTrieNodesByPrefixRequest, flatbuffers.TrieNodeMetadataResponse>,
       callback: grpc.sendUnaryData<flatbuffers.TrieNodeMetadataResponse>
     ) => {
-      const prefix = new TextDecoder().decode(call.request.prefixArray() ?? new Uint8Array());
+      const prefix = bytesToUtf8String(call.request.prefixArray() ?? new Uint8Array())._unsafeUnwrap();
       const result = syncEngine.getTrieNodeMetadata(prefix);
       if (result) {
         callback(null, toTrieNodeMetadataResponse(result));
@@ -154,7 +157,7 @@ export const syncImplementation = (engine: Engine, syncEngine: SyncEngine) => {
       call: grpc.ServerUnaryCall<flatbuffers.GetTrieNodesByPrefixRequest, flatbuffers.TrieNodeSnapshotResponse>,
       callback: grpc.sendUnaryData<flatbuffers.TrieNodeSnapshotResponse>
     ) => {
-      const prefix = new TextDecoder().decode(call.request.prefixArray() ?? new Uint8Array());
+      const prefix = bytesToUtf8String(call.request.prefixArray() ?? new Uint8Array())._unsafeUnwrap();
       const result = syncEngine.getSnapshotByPrefix(prefix);
       const rootHash = syncEngine.trie.rootHash;
       if (result) {


### PR DESCRIPTION
## Motivation

Encode everything as little endian for transport over flatbuffers

## Change Summary

- Prefixes and hashes are encoded little endian over RPC in flatbuffers
- Update tests

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

## Additional Context
