### PR TITLE
fix: Sort messages during sync to reduce refetching

### DIFF
--- a/app/src/network/sync/merkleTrie.ts
+++ b/app/src/network/sync/merkleTrie.ts
@@ -42,15 +42,15 @@ class MerkleTrie {
 
   public insert(id: SyncId): boolean {
     // TODO(aditya): We should insert Uint8Array instead of string
-    return this._root.insert(id.toString());
+    return this._root.insert(id.idString());
   }
 
   public delete(id: SyncId): boolean {
-    return this._root.delete(id.toString());
+    return this._root.delete(id.idString());
   }
 
   public exists(id: SyncId): boolean {
-    return this._root.exists(id.toString());
+    return this._root.exists(id.idString());
   }
 
   // A snapshot captures the state of the trie excluding the nodes

--- a/app/src/network/sync/syncEngine.test.ts
+++ b/app/src/network/sync/syncEngine.test.ts
@@ -124,7 +124,7 @@ describe('SyncEngine', () => {
     const id = new SyncId(castRemove);
     expect(syncEngine.trie.exists(id)).toBeTruthy();
 
-    const allMessages = await engine.getAllMessagesBySyncIds([id.toString()]);
+    const allMessages = await engine.getAllMessagesBySyncIds([id.idString()]);
     expect(allMessages.isOk()).toBeTruthy();
     expect(allMessages._unsafeUnwrap()[0]?.type()).toEqual(MessageType.CastRemove);
 

--- a/app/src/network/sync/syncEngine.ts
+++ b/app/src/network/sync/syncEngine.ts
@@ -86,7 +86,7 @@ class SyncEngine {
       const missingIds = await this.fetchMissingHashesByPrefix(divergencePrefix, rpcClient);
       log.info({ missingCount: missingIds.length }, 'Fetched missing hashes');
 
-      // TODO: sort missingIds by timestamp and fetch messages in batches
+      // TODO: fetch messages in batches
       await this.fetchAndMergeMessages(missingIds, rpcClient);
       log.info(`Sync complete`);
     } catch (e) {
@@ -108,6 +108,9 @@ class SyncEngine {
     await messages.match(
       async (msgs) => {
         const mergeResults = [];
+        // First, sort the messages by timestamp to reduce thrashing and refetching
+        msgs.sort((a, b) => a.timestamp() - b.timestamp());
+
         // Merge messages sequentially, so we can handle missing users.
         // TODO: Optimize by collecting all failures and retrying them in a batch
         for (const msg of msgs) {

--- a/app/src/network/sync/syncId.ts
+++ b/app/src/network/sync/syncId.ts
@@ -35,10 +35,6 @@ class SyncId {
     return timestampString + buf.toString('hex');
   }
 
-  public toString(): string {
-    return this.idString();
-  }
-
   static pkFromIdString(idString: string): Buffer {
     // The first 10 bytes are the timestamp, so we skip them
     const pk = idString.slice(TIMESTAMP_LENGTH);

--- a/app/src/network/sync/trieNode.test.ts
+++ b/app/src/network/sync/trieNode.test.ts
@@ -32,7 +32,7 @@ describe('TrieNode', () => {
       expect(root.items).toEqual(0);
       expect(root.hash).toEqual('');
 
-      root.insert(id.toString());
+      root.insert(id.idString());
 
       expect(root.items).toEqual(1);
       expect(root.hash).toBeTruthy();
@@ -42,10 +42,10 @@ describe('TrieNode', () => {
       const root = new TrieNode();
       const id = await Factories.SyncId.create();
 
-      root.insert(id.toString());
+      root.insert(id.idString());
       expect(root.items).toEqual(1);
       const previousHash = root.hash;
-      root.insert(id.toString());
+      root.insert(id.idString());
 
       expect(root.hash).toEqual(previousHash);
       expect(root.items).toEqual(1);
@@ -55,7 +55,7 @@ describe('TrieNode', () => {
       const root = new TrieNode();
       const id = await Factories.SyncId.create();
 
-      root.insert(id.toString());
+      root.insert(id.idString());
       let node = root;
       // Timestamp portion of the key is not collapsed, but the hash portion is
       for (let i = 0; i < TIMESTAMP_LENGTH; i++) {
@@ -75,19 +75,19 @@ describe('TrieNode', () => {
       const id1 = await Factories.SyncId.create(undefined, {
         transient: { date: sharedDate, hash: sharedPrefixHashA, fid },
       });
-      const hash1 = id1.toString();
+      const hash1 = id1.idString();
 
       const id2 = await Factories.SyncId.create(undefined, {
         transient: { date: sharedDate, hash: sharedPrefixHashB, fid },
       });
-      const hash2 = id2.toString();
+      const hash2 = id2.idString();
 
       // The node at which the trie splits should be the first character that differs between the two hashes
       const firstDiffPos = hash1.split('').findIndex((c, i) => c !== hash2[i]);
 
       const root = new TrieNode();
-      root.insert(id1.toString());
-      root.insert(id2.toString());
+      root.insert(id1.idString());
+      root.insert(id2.idString());
 
       const splitNode = traverse(root);
       expect(splitNode.items).toEqual(2);
@@ -111,10 +111,10 @@ describe('TrieNode', () => {
       const root = new TrieNode();
       const id = await Factories.SyncId.create();
 
-      root.insert(id.toString());
+      root.insert(id.idString());
       expect(root.items).toEqual(1);
 
-      root.delete(id.toString());
+      root.delete(id.idString());
       expect(root.items).toEqual(0);
       expect(root.hash).toEqual(emptyHash);
     });
@@ -124,14 +124,14 @@ describe('TrieNode', () => {
       const id1 = await Factories.SyncId.create(undefined, { transient: { date: sharedDate } });
       const id2 = await Factories.SyncId.create(undefined, { transient: { date: sharedDate } });
 
-      root.insert(id1.toString());
+      root.insert(id1.idString());
       const previousHash = root.hash;
-      root.insert(id2.toString());
+      root.insert(id2.idString());
       expect(root.items).toEqual(2);
 
-      root.delete(id2.toString());
+      root.delete(id2.idString());
       expect(root.items).toEqual(1);
-      expect(root.exists(id2.toString())).toBeFalsy();
+      expect(root.exists(id2.idString())).toBeFalsy();
       expect(root.hash).toEqual(previousHash);
     });
 
@@ -144,14 +144,14 @@ describe('TrieNode', () => {
       });
 
       const root = new TrieNode();
-      root.insert(id1.toString());
+      root.insert(id1.idString());
       const previousRootHash = root.hash;
       const leafNode = traverse(root);
-      root.insert(id2.toString());
+      root.insert(id2.idString());
 
       expect(root.hash).not.toEqual(previousRootHash);
 
-      root.delete(id2.toString());
+      root.delete(id2.idString());
 
       const newLeafNode = traverse(root);
       expect(newLeafNode).toEqual(leafNode);
@@ -164,21 +164,21 @@ describe('TrieNode', () => {
       const root = new TrieNode();
       const id = await Factories.SyncId.create();
 
-      root.insert(id.toString());
+      root.insert(id.idString());
       expect(root.items).toEqual(1);
 
-      expect(root.exists(id.toString())).toBeTruthy();
+      expect(root.exists(id.idString())).toBeTruthy();
     });
 
     test('getting an item after deleting it returns undefined', async () => {
       const root = new TrieNode();
       const id = await Factories.SyncId.create();
 
-      root.insert(id.toString());
+      root.insert(id.idString());
       expect(root.items).toEqual(1);
 
-      root.delete(id.toString());
-      expect(root.exists(id.toString())).toBeFalsy();
+      root.delete(id.idString());
+      expect(root.exists(id.idString())).toBeFalsy();
       expect(root.items).toEqual(0);
     });
 
@@ -191,10 +191,10 @@ describe('TrieNode', () => {
       });
 
       const root = new TrieNode();
-      root.insert(id1.toString());
+      root.insert(id1.idString());
 
       // id2 shares the same prefix, but doesn't exist, so it should return undefined
-      expect(root.exists(id2.toString())).toBeFalsy();
+      expect(root.exists(id2.idString())).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
## Motivation

When fetching messages during syncing, sort them before merging. This causes the messages to be merged in 'correct' order - Like `SignerAdd` first, `Add*` before `Remove*` etc..., which reduces the need to refetch messages

## Change Summary

- Sort messages by timestamp just before merging them sequentially. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

## Additional Context
