### PR TITLE
feat: Add getInfo RPC to get peer version and roothash

### DIFF
--- a/app/src/cli.ts
+++ b/app/src/cli.ts
@@ -6,7 +6,7 @@ import { existsSync } from 'fs';
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import { dirname, resolve } from 'path';
 import { exit } from 'process';
-import { Hub, HubOptions } from '~/hub';
+import { APP_VERSION, Hub, HubOptions } from '~/hub';
 import { logger } from '~/utils/logger';
 import { addressInfoFromParts, ipMultiAddrStrFromAddressInfo } from '~/utils/p2p';
 
@@ -19,10 +19,7 @@ const DEFAULT_PEER_ID_FILENAME = `default_${PEER_ID_FILENAME}`;
 const DEFAULT_PEER_ID_LOCATION = `${DEFAULT_PEER_ID_DIR}/${DEFAULT_PEER_ID_FILENAME}`;
 
 const app = new Command();
-app
-  .name('hub')
-  .description('Farcaster Hub')
-  .version(process.env['npm_package_version'] ?? '1.0.0');
+app.name('hub').description('Farcaster Hub').version(APP_VERSION);
 
 app
   .command('start')

--- a/app/src/hub.ts
+++ b/app/src/hub.ts
@@ -33,6 +33,9 @@ import { RevokeSignerJobQueue, RevokeSignerJobScheduler } from '~/storage/jobs/r
 import { idRegistryEventToLog, logger, messageToLog, nameRegistryEventToLog } from '~/utils/logger';
 import { addressInfoFromGossip, ipFamilyToString, p2pMultiAddrStr } from '~/utils/p2p';
 
+export const APP_VERSION = process.env['npm_package_version'] ?? '1.0.0';
+export const APP_NICKNAME = 'Farcaster Hub';
+
 export interface HubOptions {
   /** The PeerId of this Hub */
   peerId?: PeerId;

--- a/app/src/network/sync/syncEngine.ts
+++ b/app/src/network/sync/syncEngine.ts
@@ -57,6 +57,10 @@ class SyncEngine {
     log.info({ processedMessages }, 'Sync engine initialized');
   }
 
+  public isSyncing(): boolean {
+    return this._isSyncing;
+  }
+
   /** ---------------------------------------------------------------------------------- */
   /**                                      Sync Methods                                  */
   /** ---------------------------------------------------------------------------------- */

--- a/app/src/rpc/client/serviceRequests/syncRequests.ts
+++ b/app/src/rpc/client/serviceRequests/syncRequests.ts
@@ -1,4 +1,5 @@
 import {
+  Empty,
   GetAllMessagesByFidRequest,
   GetAllMessagesByFidRequestT,
   GetAllMessagesBySyncIdsRequest,
@@ -10,6 +11,10 @@ import {
 import { Builder, ByteBuffer } from 'flatbuffers';
 
 export const syncRequests = {
+  getInfoRequest: (): Empty => {
+    return new Empty();
+  },
+
   createSyncRequest: (fid: Uint8Array): GetAllMessagesByFidRequest => {
     const builder = new Builder(1);
     const requestT = new GetAllMessagesByFidRequestT(Array.from(fid));

--- a/app/src/rpc/server/serviceImplementations/syncImplementation.ts
+++ b/app/src/rpc/server/serviceImplementations/syncImplementation.ts
@@ -5,6 +5,7 @@ import * as flatbuffers from '@hub/flatbuffers';
 import { Builder, ByteBuffer } from 'flatbuffers';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import * as types from '~/flatbuffers/models/types';
+import { APP_NICKNAME, APP_VERSION } from '~/hub';
 import SyncEngine from '~/network/sync/syncEngine';
 import {
   toMessagesResponse,
@@ -17,6 +18,21 @@ import Engine from '~/storage/engine';
 
 export const syncImplementation = (engine: Engine, syncEngine: SyncEngine) => {
   return {
+    getInfo: async (
+      call: grpc.ServerUnaryCall<flatbuffers.Empty, flatbuffers.HubInfoResponse>,
+      callback: grpc.sendUnaryData<flatbuffers.HubInfoResponse>
+    ) => {
+      const infoT = new flatbuffers.HubInfoResponseT(
+        APP_VERSION,
+        syncEngine.isSyncing(),
+        APP_NICKNAME,
+        syncEngine.trie.rootHash
+      );
+      const builder = new Builder(1);
+      builder.finish(infoT.pack(builder));
+      const response = flatbuffers.HubInfoResponse.getRootAsHubInfoResponse(new ByteBuffer(builder.asUint8Array()));
+      callback(null, response);
+    },
     getAllCastMessagesByFid: async (
       call: grpc.ServerUnaryCall<flatbuffers.GetAllMessagesByFidRequest, flatbuffers.MessagesResponse>,
       callback: grpc.sendUnaryData<flatbuffers.MessagesResponse>

--- a/app/src/rpc/serviceDefinitions/syncDefinition.ts
+++ b/app/src/rpc/serviceDefinitions/syncDefinition.ts
@@ -16,6 +16,16 @@ const defaultSyncMethod = () => {
 
 export const syncDefinition = () => {
   return {
+    getInfo: {
+      ...defaultMethod,
+      requestDeserialize: (buffer: Buffer): flatbuffers.Empty => {
+        return flatbuffers.Empty.getRootAsEmpty(toByteBuffer(buffer));
+      },
+      responseDeserialize: (buffer: Buffer): flatbuffers.HubInfoResponse => {
+        return flatbuffers.HubInfoResponse.getRootAsHubInfoResponse(toByteBuffer(buffer));
+      },
+      path: '/getInfo',
+    },
     getAllCastMessagesByFid: {
       ...defaultSyncMethod(),
       path: '/getAllCastMessagesByFid',

--- a/packages/flatbuffers/src/generated/rpc_generated.ts
+++ b/packages/flatbuffers/src/generated/rpc_generated.ts
@@ -12,6 +12,174 @@ export enum EventType {
   MergeNameRegistryEvent = 4
 }
 
+export class Empty implements flatbuffers.IUnpackableObject<EmptyT> {
+  bb: flatbuffers.ByteBuffer|null = null;
+  bb_pos = 0;
+  __init(i:number, bb:flatbuffers.ByteBuffer):Empty {
+  this.bb_pos = i;
+  this.bb = bb;
+  return this;
+}
+
+static getRootAsEmpty(bb:flatbuffers.ByteBuffer, obj?:Empty):Empty {
+  return (obj || new Empty()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+static getSizePrefixedRootAsEmpty(bb:flatbuffers.ByteBuffer, obj?:Empty):Empty {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new Empty()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+static startEmpty(builder:flatbuffers.Builder) {
+  builder.startObject(0);
+}
+
+static endEmpty(builder:flatbuffers.Builder):flatbuffers.Offset {
+  const offset = builder.endObject();
+  return offset;
+}
+
+static createEmpty(builder:flatbuffers.Builder):flatbuffers.Offset {
+  Empty.startEmpty(builder);
+  return Empty.endEmpty(builder);
+}
+
+unpack(): EmptyT {
+  return new EmptyT();
+}
+
+
+unpackTo(_o: EmptyT): void {}
+}
+
+export class EmptyT implements flatbuffers.IGeneratedObject {
+constructor(){}
+
+
+pack(builder:flatbuffers.Builder): flatbuffers.Offset {
+  return Empty.createEmpty(builder);
+}
+}
+
+export class HubInfoResponse implements flatbuffers.IUnpackableObject<HubInfoResponseT> {
+  bb: flatbuffers.ByteBuffer|null = null;
+  bb_pos = 0;
+  __init(i:number, bb:flatbuffers.ByteBuffer):HubInfoResponse {
+  this.bb_pos = i;
+  this.bb = bb;
+  return this;
+}
+
+static getRootAsHubInfoResponse(bb:flatbuffers.ByteBuffer, obj?:HubInfoResponse):HubInfoResponse {
+  return (obj || new HubInfoResponse()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+static getSizePrefixedRootAsHubInfoResponse(bb:flatbuffers.ByteBuffer, obj?:HubInfoResponse):HubInfoResponse {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new HubInfoResponse()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+version():string|null
+version(optionalEncoding:flatbuffers.Encoding):string|Uint8Array|null
+version(optionalEncoding?:any):string|Uint8Array|null {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.__string(this.bb_pos + offset, optionalEncoding) : null;
+}
+
+synced():boolean {
+  const offset = this.bb!.__offset(this.bb_pos, 6);
+  return offset ? !!this.bb!.readInt8(this.bb_pos + offset) : false;
+}
+
+nickname():string|null
+nickname(optionalEncoding:flatbuffers.Encoding):string|Uint8Array|null
+nickname(optionalEncoding?:any):string|Uint8Array|null {
+  const offset = this.bb!.__offset(this.bb_pos, 8);
+  return offset ? this.bb!.__string(this.bb_pos + offset, optionalEncoding) : null;
+}
+
+rootHash():string|null
+rootHash(optionalEncoding:flatbuffers.Encoding):string|Uint8Array|null
+rootHash(optionalEncoding?:any):string|Uint8Array|null {
+  const offset = this.bb!.__offset(this.bb_pos, 10);
+  return offset ? this.bb!.__string(this.bb_pos + offset, optionalEncoding) : null;
+}
+
+static startHubInfoResponse(builder:flatbuffers.Builder) {
+  builder.startObject(4);
+}
+
+static addVersion(builder:flatbuffers.Builder, versionOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(0, versionOffset, 0);
+}
+
+static addSynced(builder:flatbuffers.Builder, synced:boolean) {
+  builder.addFieldInt8(1, +synced, +false);
+}
+
+static addNickname(builder:flatbuffers.Builder, nicknameOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(2, nicknameOffset, 0);
+}
+
+static addRootHash(builder:flatbuffers.Builder, rootHashOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(3, rootHashOffset, 0);
+}
+
+static endHubInfoResponse(builder:flatbuffers.Builder):flatbuffers.Offset {
+  const offset = builder.endObject();
+  return offset;
+}
+
+static createHubInfoResponse(builder:flatbuffers.Builder, versionOffset:flatbuffers.Offset, synced:boolean, nicknameOffset:flatbuffers.Offset, rootHashOffset:flatbuffers.Offset):flatbuffers.Offset {
+  HubInfoResponse.startHubInfoResponse(builder);
+  HubInfoResponse.addVersion(builder, versionOffset);
+  HubInfoResponse.addSynced(builder, synced);
+  HubInfoResponse.addNickname(builder, nicknameOffset);
+  HubInfoResponse.addRootHash(builder, rootHashOffset);
+  return HubInfoResponse.endHubInfoResponse(builder);
+}
+
+unpack(): HubInfoResponseT {
+  return new HubInfoResponseT(
+    this.version(),
+    this.synced(),
+    this.nickname(),
+    this.rootHash()
+  );
+}
+
+
+unpackTo(_o: HubInfoResponseT): void {
+  _o.version = this.version();
+  _o.synced = this.synced();
+  _o.nickname = this.nickname();
+  _o.rootHash = this.rootHash();
+}
+}
+
+export class HubInfoResponseT implements flatbuffers.IGeneratedObject {
+constructor(
+  public version: string|Uint8Array|null = null,
+  public synced: boolean = false,
+  public nickname: string|Uint8Array|null = null,
+  public rootHash: string|Uint8Array|null = null
+){}
+
+
+pack(builder:flatbuffers.Builder): flatbuffers.Offset {
+  const version = (this.version !== null ? builder.createString(this.version!) : 0);
+  const nickname = (this.nickname !== null ? builder.createString(this.nickname!) : 0);
+  const rootHash = (this.rootHash !== null ? builder.createString(this.rootHash!) : 0);
+
+  return HubInfoResponse.createHubInfoResponse(builder,
+    version,
+    this.synced,
+    nickname,
+    rootHash
+  );
+}
+}
+
 export class MessageBytes implements flatbuffers.IUnpackableObject<MessageBytesT> {
   bb: flatbuffers.ByteBuffer|null = null;
   bb_pos = 0;

--- a/packages/flatbuffers/src/schemas/rpc.fbs
+++ b/packages/flatbuffers/src/schemas/rpc.fbs
@@ -12,7 +12,18 @@ enum EventType: uint8 {
   MergeNameRegistryEvent = 4
 }
 
+table Empty {
+}
+
 // Responses
+
+table HubInfoResponse {
+  version: string;
+  synced: bool;
+  nickname: string;
+  root_hash: string;
+}
+
 table MessageBytes {
   message_bytes: [ubyte] (nested_flatbuffer: "Farcaster.Message", required);
 }
@@ -46,6 +57,7 @@ table TrieNodeSnapshotResponse {
 }
 
 // Cast Requests
+
 table GetCastRequest {
   fid: [ubyte] (required);
   ts_hash: [ubyte] (required);


### PR DESCRIPTION
## Motivation

Add a new `getInfo` RPC to get information about Hub peers, including version and rootHash. 

## Change Summary

- new `getInfo` RPC that returns Hub version, name, rootHash and other info

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

## Additional Context

