### PR TITLE
docs: fix contributing link in app/README.md

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -6,7 +6,7 @@ Users generate messages and upload them to Hub, which propagates them to other H
 
 ## Getting Started
 
-After [setting up your environment](CONTRIBUTING.md#2-setting-up-your-development-environment) navigate to this folder from the root and run the following steps:
+After [setting up your environment](../CONTRIBUTING.md#2-setting-up-your-development-environment) navigate to this folder from the root and run the following steps:
 
 Then, run:
 


### PR DESCRIPTION
## Motivation

Fixing a markdown link I noticed that didn't work when trying out hubs.

## Change Summary

Made the `setting up your environment` link point to the correct markdown document.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] Changes to the protocol specification have been merged

## Additional Context