### PR TITLE
refactor: remove _unsafeWrap usage from Eip712Signer constructor

### DIFF
--- a/app/src/signers/eip712Signer.ts
+++ b/app/src/signers/eip712Signer.ts
@@ -13,8 +13,11 @@ class Eip712Signer extends Signer {
 
   constructor(privateKey: Uint8Array) {
     const wallet = new Wallet(privateKey);
-    const signerKey = hexStringToBytes(wallet.address.toLowerCase())._unsafeUnwrap();
-    super(SignatureScheme.Eip712, privateKey, signerKey);
+    const signerKey = hexStringToBytes(wallet.address.toLowerCase());
+    if (signerKey.isErr()) {
+      throw signerKey.error;
+    }
+    super(SignatureScheme.Eip712, privateKey, signerKey.value);
     this.wallet = wallet;
   }
 


### PR DESCRIPTION
## Motivation

`_unsafeWrap` should not be called outside of tests.

## Change Summary

Remove `_unsafeWrap` usage from `Eip712Signer` constructor. Behavior stays the same.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)

## Additional Context

Are there any thoughts by the core team on throwing in the constructor re #213?