### PR TITLE
feat: Merge returns false if it is a no-op, true otherwise

### DIFF
--- a/app/src/flatbuffers/models/types.ts
+++ b/app/src/flatbuffers/models/types.ts
@@ -148,7 +148,7 @@ export type StorePruneOptions = {
 export type HubSubmitSource = 'gossip' | 'rpc' | 'eth-provider';
 
 export interface HubInterface {
-  submitMessage(message: MessageModel, source?: HubSubmitSource): HubAsyncResult<void>;
+  submitMessage(message: MessageModel, source?: HubSubmitSource): HubAsyncResult<boolean>;
   submitIdRegistryEvent(event: IdRegistryEventModel, source?: HubSubmitSource): HubAsyncResult<void>;
   submitNameRegistryEvent(event: NameRegistryEventModel, source?: HubSubmitSource): HubAsyncResult<void>;
   getHubState(): HubAsyncResult<HubStateModel>;

--- a/app/src/hub.ts
+++ b/app/src/hub.ts
@@ -211,7 +211,7 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
     const contentType = gossipMessage.contentType();
     if (contentType === GossipContent.Message) {
       const message: Message = gossipMessage.content(contentType);
-      return this.submitMessage(new MessageModel(message), 'gossip');
+      return (await this.submitMessage(new MessageModel(message), 'gossip')).map(() => undefined);
     } else if (contentType === GossipContent.IdRegistryEvent) {
       const event = new IdRegistryEventModel(gossipMessage.content(contentType) as IdRegistryEvent);
       return this.submitIdRegistryEvent(event, 'gossip');
@@ -398,7 +398,7 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
   /*                               RPC Handler API                              */
   /* -------------------------------------------------------------------------- */
 
-  async submitMessage(message: MessageModel, source?: HubSubmitSource): HubAsyncResult<void> {
+  async submitMessage(message: MessageModel, source?: HubSubmitSource): HubAsyncResult<boolean> {
     log.info({ ...messageToLog(message), source }, 'submitMessage');
 
     // push this message into the storage engine

--- a/app/src/network/sync/syncEngine.ts
+++ b/app/src/network/sync/syncEngine.ts
@@ -234,7 +234,7 @@ class SyncEngine {
     return Math.floor(currentTimeInSeconds / SYNC_THRESHOLD_IN_SECONDS) * SYNC_THRESHOLD_IN_SECONDS;
   }
 
-  private async syncUserAndRetryMessage(message: MessageModel, rpcClient: HubRpcClient): Promise<HubResult<void>> {
+  private async syncUserAndRetryMessage(message: MessageModel, rpcClient: HubRpcClient): Promise<HubResult<boolean>> {
     const fid = message.data.fidArray();
     if (!fid) {
       return err(new HubError('bad_request.invalid_param', 'Invalid fid'));

--- a/app/src/rpc/test/userDataService.test.ts
+++ b/app/src/rpc/test/userDataService.test.ts
@@ -87,8 +87,8 @@ describe('getUserData', () => {
   });
 
   test('succeeds', async () => {
-    expect(await engine.mergeMessage(pfpAdd)).toEqual(ok(undefined));
-    expect(await engine.mergeMessage(locationAdd)).toEqual(ok(undefined));
+    expect(await engine.mergeMessage(pfpAdd)).toEqual(ok(true));
+    expect(await engine.mergeMessage(locationAdd)).toEqual(ok(true));
 
     const pfp = await client.getUserData(fid, UserDataType.Pfp);
     expect(pfp._unsafeUnwrap()).toEqual(pfpAdd.message);
@@ -103,7 +103,7 @@ describe('getUserData', () => {
     const model = new NameRegistryEventModel(nameRegistryEvent);
     await model.put(db);
 
-    expect(await engine.mergeMessage(addFname)).toEqual(ok(undefined));
+    expect(await engine.mergeMessage(addFname)).toEqual(ok(true));
     const fnameData = await client.getUserData(fid, UserDataType.Fname);
     expect(fnameData._unsafeUnwrap()).toEqual(addFname.message);
   });

--- a/app/src/storage/engine/index.test.ts
+++ b/app/src/storage/engine/index.test.ts
@@ -187,7 +187,7 @@ describe('mergeMessage', () => {
 
     describe('CastAdd', () => {
       test('succeeds', async () => {
-        await expect(engine.mergeMessage(castAdd)).resolves.toEqual(ok(undefined));
+        await expect(engine.mergeMessage(castAdd)).resolves.toEqual(ok(true));
         await expect(castStore.getCastAdd(fid, castAdd.tsHash())).resolves.toEqual(castAdd);
         expect(mergedMessages).toEqual([signerAdd, castAdd]);
       });
@@ -195,7 +195,7 @@ describe('mergeMessage', () => {
 
     describe('AmpAdd', () => {
       test('succeeds', async () => {
-        await expect(engine.mergeMessage(ampAdd)).resolves.toEqual(ok(undefined));
+        await expect(engine.mergeMessage(ampAdd)).resolves.toEqual(ok(true));
         await expect(ampStore.getAmpAdd(fid, ampAdd.body().user()?.fidArray() ?? new Uint8Array())).resolves.toEqual(
           ampAdd
         );
@@ -205,7 +205,7 @@ describe('mergeMessage', () => {
 
     describe('ReactionAdd', () => {
       test('succeeds', async () => {
-        await expect(engine.mergeMessage(reactionAdd)).resolves.toEqual(ok(undefined));
+        await expect(engine.mergeMessage(reactionAdd)).resolves.toEqual(ok(true));
         await expect(
           reactionStore.getReactionAdd(
             fid,
@@ -219,7 +219,7 @@ describe('mergeMessage', () => {
 
     describe('VerificationAddEthAddress', () => {
       test('succeeds', async () => {
-        await expect(engine.mergeMessage(verificationAdd)).resolves.toEqual(ok(undefined));
+        await expect(engine.mergeMessage(verificationAdd)).resolves.toEqual(ok(true));
         await expect(
           verificationStore.getVerificationAdd(fid, verificationAdd.body().addressArray() ?? new Uint8Array())
         ).resolves.toEqual(verificationAdd);
@@ -229,7 +229,7 @@ describe('mergeMessage', () => {
 
     describe('UserDataAdd', () => {
       test('succeeds', async () => {
-        await expect(engine.mergeMessage(userDataAdd)).resolves.toEqual(ok(undefined));
+        await expect(engine.mergeMessage(userDataAdd)).resolves.toEqual(ok(true));
         await expect(userDataStore.getUserDataAdd(fid, userDataAdd.body().type())).resolves.toEqual(userDataAdd);
         expect(mergedMessages).toEqual([signerAdd, userDataAdd]);
       });
@@ -237,7 +237,7 @@ describe('mergeMessage', () => {
 
     describe('SignerRemove', () => {
       test('succeeds ', async () => {
-        await expect(engine.mergeMessage(signerRemove)).resolves.toEqual(ok(undefined));
+        await expect(engine.mergeMessage(signerRemove)).resolves.toEqual(ok(true));
         await expect(signerStore.getSignerRemove(fid, signer.signerKey)).resolves.toEqual(signerRemove);
         expect(mergedMessages).toEqual([signerAdd, signerRemove]);
       });
@@ -302,7 +302,7 @@ describe('mergeMessages', () => {
     test('succeeds', async () => {
       await expect(
         engine.mergeMessages([castAdd, ampAdd, reactionAdd, verificationAdd, userDataAdd, signerRemove])
-      ).resolves.toEqual([ok(undefined), ok(undefined), ok(undefined), ok(undefined), ok(undefined), ok(undefined)]);
+      ).resolves.toEqual([ok(true), ok(true), ok(true), ok(true), ok(true), ok(true)]);
       expect(mergedMessages).toEqual([
         signerAdd,
         castAdd,

--- a/app/src/storage/engine/index.ts
+++ b/app/src/storage/engine/index.ts
@@ -41,15 +41,15 @@ class Engine {
     this._userDataStore = new UserDataStore(db, this.eventHandler);
   }
 
-  async mergeMessages(messages: MessageModel[]): Promise<Array<HubResult<void>>> {
-    const results: HubResult<void>[] = [];
+  async mergeMessages(messages: MessageModel[]): Promise<Array<HubResult<boolean>>> {
+    const results: HubResult<boolean>[] = [];
     for (const message of messages) {
       results.push(await this.mergeMessage(message));
     }
     return results;
   }
 
-  async mergeMessage(message: MessageModel): HubAsyncResult<void> {
+  async mergeMessage(message: MessageModel): HubAsyncResult<boolean> {
     const validatedMessage = await this.validateMessage(message);
     if (validatedMessage.isErr()) {
       return err(validatedMessage.error);

--- a/app/src/storage/stores/ampStore.test.ts
+++ b/app/src/storage/stores/ampStore.test.ts
@@ -168,13 +168,14 @@ describe('merge', () => {
 
   describe('AmpAdd', () => {
     test('succeeds', async () => {
-      await expect(store.merge(ampAdd)).resolves.toEqual(undefined);
+      await expect(store.merge(ampAdd)).resolves.toBeTruthy();
       await assertAmpAddWins(ampAdd);
     });
 
     test('succeeds once, even if merged twice', async () => {
-      await expect(store.merge(ampAdd)).resolves.toEqual(undefined);
-      await expect(store.merge(ampAdd)).resolves.toEqual(undefined);
+      await expect(store.merge(ampAdd)).resolves.toBeTruthy();
+      // It succeeds again, but doesn't change anything, so it returns false.
+      await expect(store.merge(ampAdd)).resolves.toBeFalsy();
 
       await assertAmpAddWins(ampAdd);
     });
@@ -195,7 +196,7 @@ describe('merge', () => {
 
       test('succeeds with a later timestamp', async () => {
         await store.merge(ampAdd);
-        await expect(store.merge(ampAddLater)).resolves.toEqual(undefined);
+        await expect(store.merge(ampAddLater)).resolves.toBeTruthy();
 
         await assertAmpDoesNotExist(ampAdd);
         await assertAmpAddWins(ampAddLater);
@@ -203,7 +204,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier timestamp', async () => {
         await store.merge(ampAddLater);
-        await expect(store.merge(ampAdd)).resolves.toEqual(undefined);
+        // It succeeds again, but doesn't change anything, so it returns false.
+        await expect(store.merge(ampAdd)).resolves.toBeFalsy();
 
         await assertAmpDoesNotExist(ampAdd);
         await assertAmpAddWins(ampAddLater);
@@ -228,7 +230,7 @@ describe('merge', () => {
 
       test('succeeds with a later hash', async () => {
         await store.merge(ampAdd);
-        await expect(store.merge(ampAddLater)).resolves.toEqual(undefined);
+        await expect(store.merge(ampAddLater)).resolves.toBeTruthy();
 
         await assertAmpDoesNotExist(ampAdd);
         await assertAmpAddWins(ampAddLater);
@@ -236,7 +238,7 @@ describe('merge', () => {
 
       test('no-ops with an earlier hash', async () => {
         await store.merge(ampAddLater);
-        await expect(store.merge(ampAdd)).resolves.toEqual(undefined);
+        await expect(store.merge(ampAdd)).resolves.toBeFalsy();
 
         await assertAmpDoesNotExist(ampAdd);
         await assertAmpAddWins(ampAddLater);
@@ -257,7 +259,7 @@ describe('merge', () => {
         const ampRemoveEarlier = new MessageModel(removeMessage) as AmpRemoveModel;
 
         await store.merge(ampRemoveEarlier);
-        await expect(store.merge(ampAdd)).resolves.toEqual(undefined);
+        await expect(store.merge(ampAdd)).resolves.toBeTruthy();
 
         await assertAmpAddWins(ampAdd);
         await assertAmpDoesNotExist(ampRemoveEarlier);
@@ -265,7 +267,7 @@ describe('merge', () => {
 
       test('no-ops with an earlier timestamp', async () => {
         await store.merge(ampRemove);
-        await expect(store.merge(ampAdd)).resolves.toEqual(undefined);
+        await expect(store.merge(ampAdd)).resolves.toBeFalsy();
 
         await assertAmpRemoveWins(ampRemove);
         await assertAmpDoesNotExist(ampAdd);
@@ -287,7 +289,7 @@ describe('merge', () => {
         const ampRemoveLater = new MessageModel(removeMessage) as AmpRemoveModel;
 
         await store.merge(ampRemoveLater);
-        await expect(store.merge(ampAdd)).resolves.toEqual(undefined);
+        await expect(store.merge(ampAdd)).resolves.toBeFalsy();
 
         await assertAmpRemoveWins(ampRemoveLater);
         await assertAmpDoesNotExist(ampAdd);
@@ -310,7 +312,7 @@ describe('merge', () => {
         const ampRemoveEarlier = new MessageModel(removeMessage) as AmpRemoveModel;
 
         await store.merge(ampRemoveEarlier);
-        await expect(store.merge(ampAdd)).resolves.toEqual(undefined);
+        await expect(store.merge(ampAdd)).resolves.toBeFalsy();
 
         await assertAmpDoesNotExist(ampAdd);
         await assertAmpRemoveWins(ampRemoveEarlier);
@@ -320,14 +322,15 @@ describe('merge', () => {
 
   describe('AmpRemove', () => {
     test('succeeds', async () => {
-      await expect(store.merge(ampRemove)).resolves.toEqual(undefined);
+      await expect(store.merge(ampRemove)).resolves.toBeTruthy();
 
       await assertAmpRemoveWins(ampRemove);
     });
 
     test('succeeds once, even if merged twice', async () => {
-      await expect(store.merge(ampRemove)).resolves.toEqual(undefined);
-      await expect(store.merge(ampRemove)).resolves.toEqual(undefined);
+      await expect(store.merge(ampRemove)).resolves.toBeTruthy();
+      // It succeeds again, but doesn't change anything, so it returns false.
+      await expect(store.merge(ampRemove)).resolves.toBeFalsy();
 
       await assertAmpRemoveWins(ampRemove);
     });
@@ -348,7 +351,7 @@ describe('merge', () => {
 
       test('succeeds with a later timestamp', async () => {
         await store.merge(ampRemove);
-        await expect(store.merge(ampRemoveLater)).resolves.toEqual(undefined);
+        await expect(store.merge(ampRemoveLater)).resolves.toBeTruthy();
 
         await assertAmpDoesNotExist(ampRemove);
         await assertAmpRemoveWins(ampRemoveLater);
@@ -356,7 +359,7 @@ describe('merge', () => {
 
       test('no-ops with an earlier timestamp', async () => {
         await store.merge(ampRemoveLater);
-        await expect(store.merge(ampRemove)).resolves.toEqual(undefined);
+        await expect(store.merge(ampRemove)).resolves.toBeFalsy();
 
         await assertAmpDoesNotExist(ampRemove);
         await assertAmpRemoveWins(ampRemoveLater);
@@ -381,7 +384,7 @@ describe('merge', () => {
 
       test('succeeds with a later hash', async () => {
         await store.merge(ampRemove);
-        await expect(store.merge(ampRemoveLater)).resolves.toEqual(undefined);
+        await expect(store.merge(ampRemoveLater)).resolves.toBeTruthy();
 
         await assertAmpDoesNotExist(ampRemove);
         await assertAmpRemoveWins(ampRemoveLater);
@@ -389,7 +392,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier hash', async () => {
         await store.merge(ampRemoveLater);
-        await expect(store.merge(ampRemove)).resolves.toEqual(undefined);
+        // It succeeds again, but doesn't change anything, so it returns false.
+        await expect(store.merge(ampRemove)).resolves.toBeFalsy();
 
         await assertAmpDoesNotExist(ampRemove);
         await assertAmpRemoveWins(ampRemoveLater);
@@ -399,7 +403,7 @@ describe('merge', () => {
     describe('with conflicting AmpAdd with different timestamps', () => {
       test('succeeds with a later timestamp', async () => {
         await store.merge(ampAdd);
-        await expect(store.merge(ampRemove)).resolves.toEqual(undefined);
+        await expect(store.merge(ampRemove)).resolves.toBeTruthy();
         await assertAmpRemoveWins(ampRemove);
         await assertAmpDoesNotExist(ampAdd);
       });
@@ -415,7 +419,7 @@ describe('merge', () => {
         });
         const ampAddLater = new MessageModel(addMessage) as AmpAddModel;
         await store.merge(ampAddLater);
-        await expect(store.merge(ampRemove)).resolves.toEqual(undefined);
+        await expect(store.merge(ampRemove)).resolves.toBeFalsy();
         await assertAmpAddWins(ampAddLater);
         await assertAmpDoesNotExist(ampRemove);
       });
@@ -435,7 +439,7 @@ describe('merge', () => {
         const ampAddLater = new MessageModel(addMessage) as AmpAddModel;
 
         await store.merge(ampAddLater);
-        await expect(store.merge(ampRemove)).resolves.toEqual(undefined);
+        await expect(store.merge(ampRemove)).resolves.toBeTruthy();
 
         await assertAmpDoesNotExist(ampAddLater);
         await assertAmpRemoveWins(ampRemove);
@@ -454,7 +458,7 @@ describe('merge', () => {
         const ampRemoveEarlier = new MessageModel(removeMessage) as AmpRemoveModel;
 
         await store.merge(ampRemoveEarlier);
-        await expect(store.merge(ampRemove)).resolves.toEqual(undefined);
+        await expect(store.merge(ampRemove)).resolves.toBeTruthy();
 
         await assertAmpDoesNotExist(ampRemoveEarlier);
         await assertAmpRemoveWins(ampRemove);

--- a/app/src/storage/stores/castStore.test.ts
+++ b/app/src/storage/stores/castStore.test.ts
@@ -214,13 +214,14 @@ describe('merge', () => {
 
   describe('CastAdd', () => {
     test('succeeds', async () => {
-      await expect(store.merge(castAdd)).resolves.toEqual(undefined);
+      await expect(store.merge(castAdd)).resolves.toBeTruthy();
       await assertCastAddWins(castAdd);
     });
 
     test('succeeds once, even if merged twice', async () => {
-      await expect(store.merge(castAdd)).resolves.toEqual(undefined);
-      await expect(store.merge(castAdd)).resolves.toEqual(undefined);
+      await expect(store.merge(castAdd)).resolves.toBeTruthy();
+      // Second merge should be a no-op, so we expect it to return false.
+      await expect(store.merge(castAdd)).resolves.toBeFalsy();
 
       await assertCastAddWins(castAdd);
     });
@@ -239,7 +240,8 @@ describe('merge', () => {
         const castRemoveEarlier = new MessageModel(removeMessage) as CastRemoveModel;
 
         await store.merge(castRemoveEarlier);
-        await expect(store.merge(castAdd)).resolves.toEqual(undefined);
+        // Second merge should be a no-op, so we expect it to return false.
+        await expect(store.merge(castAdd)).resolves.toBeFalsy();
 
         await assertCastRemoveWins(castRemoveEarlier);
         await assertCastDoesNotExist(castAdd);
@@ -247,7 +249,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier timestamp', async () => {
         await store.merge(castRemove);
-        await expect(store.merge(castAdd)).resolves.toEqual(undefined);
+        // Second merge should be a no-op, so we expect it to return false.
+        await expect(store.merge(castAdd)).resolves.toBeFalsy();
 
         await assertCastRemoveWins(castRemove);
         await assertCastDoesNotExist(castAdd);
@@ -269,7 +272,8 @@ describe('merge', () => {
         const castRemoveEarlier = new MessageModel(removeMessage) as CastRemoveModel;
 
         await store.merge(castRemoveEarlier);
-        await expect(store.merge(castAdd)).resolves.toEqual(undefined);
+        // Merge should be a no-op, so we expect it to return false.
+        await expect(store.merge(castAdd)).resolves.toBeFalsy();
 
         await assertCastRemoveWins(castRemoveEarlier);
         await assertCastDoesNotExist(castAdd);
@@ -289,7 +293,8 @@ describe('merge', () => {
         const castRemoveLater = new MessageModel(removeMessage) as CastRemoveModel;
 
         await store.merge(castRemoveLater);
-        await expect(store.merge(castAdd)).resolves.toEqual(undefined);
+        // Merge should be a no-op, so we expect it to return false.
+        await expect(store.merge(castAdd)).resolves.toBeFalsy();
 
         await assertCastRemoveWins(castRemoveLater);
         await assertCastDoesNotExist(castAdd);
@@ -300,15 +305,15 @@ describe('merge', () => {
   describe('CastRemove', () => {
     test('succeeds', async () => {
       await store.merge(castAdd);
-      await expect(store.merge(castRemove)).resolves.toEqual(undefined);
+      await expect(store.merge(castRemove)).resolves.toBeTruthy();
 
       await assertCastRemoveWins(castRemove);
       await assertCastDoesNotExist(castAdd);
     });
 
     test('succeeds once, even if merged twice', async () => {
-      await expect(store.merge(castRemove)).resolves.toEqual(undefined);
-      await expect(store.merge(castRemove)).resolves.toEqual(undefined);
+      await expect(store.merge(castRemove)).resolves.toBeTruthy();
+      await expect(store.merge(castRemove)).resolves.toBeFalsy();
 
       await assertCastRemoveWins(castRemove);
     });
@@ -329,7 +334,7 @@ describe('merge', () => {
 
       test('succeeds with a later timestamp', async () => {
         await store.merge(castRemove);
-        await expect(store.merge(castRemoveLater)).resolves.toEqual(undefined);
+        await expect(store.merge(castRemoveLater)).resolves.toBeTruthy();
 
         await assertCastDoesNotExist(castRemove);
         await assertCastRemoveWins(castRemoveLater);
@@ -337,7 +342,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier timestamp', async () => {
         await store.merge(castRemoveLater);
-        await expect(store.merge(castRemove)).resolves.toEqual(undefined);
+        // Second merge should be a no-op, so we expect it to return false.
+        await expect(store.merge(castRemove)).resolves.toBeFalsy();
 
         await assertCastDoesNotExist(castRemove);
         await assertCastRemoveWins(castRemoveLater);
@@ -362,7 +368,7 @@ describe('merge', () => {
 
       test('succeeds with a later hash', async () => {
         await store.merge(castRemove);
-        await expect(store.merge(castRemoveLater)).resolves.toEqual(undefined);
+        await expect(store.merge(castRemoveLater)).resolves.toBeTruthy();
 
         await assertCastDoesNotExist(castRemove);
         await assertCastRemoveWins(castRemoveLater);
@@ -370,7 +376,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier hash', async () => {
         await store.merge(castRemoveLater);
-        await expect(store.merge(castRemove)).resolves.toEqual(undefined);
+        // Second merge should be a no-op, so we expect it to return false.
+        await expect(store.merge(castRemove)).resolves.toBeFalsy();
 
         await assertCastDoesNotExist(castRemove);
         await assertCastRemoveWins(castRemoveLater);
@@ -380,7 +387,7 @@ describe('merge', () => {
     describe('with conflicting CastAdd with different timestamps', () => {
       test('succeeds with a later timestamp', async () => {
         await store.merge(castAdd);
-        await expect(store.merge(castRemove)).resolves.toEqual(undefined);
+        await expect(store.merge(castRemove)).resolves.toBeTruthy();
         await assertCastRemoveWins(castRemove);
         await assertCastDoesNotExist(castAdd);
       });
@@ -397,7 +404,7 @@ describe('merge', () => {
         const castRemoveEarlier = new MessageModel(removeMessage) as CastRemoveModel;
 
         await store.merge(castAdd);
-        await expect(store.merge(castRemoveEarlier)).resolves.toEqual(undefined);
+        await expect(store.merge(castRemoveEarlier)).resolves.toBeTruthy();
         await assertCastDoesNotExist(castAdd);
         await assertCastRemoveWins(castRemoveEarlier);
       });
@@ -417,7 +424,7 @@ describe('merge', () => {
         const castRemoveEarlier = new MessageModel(removeMessage) as CastRemoveModel;
 
         await store.merge(castAdd);
-        await expect(store.merge(castRemoveEarlier)).resolves.toEqual(undefined);
+        await expect(store.merge(castRemoveEarlier)).resolves.toBeTruthy();
 
         await assertCastDoesNotExist(castAdd);
         await assertCastRemoveWins(castRemoveEarlier);
@@ -436,7 +443,7 @@ describe('merge', () => {
         const castRemoveLater = new MessageModel(removeMessage) as CastRemoveModel;
 
         await store.merge(castAdd);
-        await expect(store.merge(castRemoveLater)).resolves.toEqual(undefined);
+        await expect(store.merge(castRemoveLater)).resolves.toBeTruthy();
 
         await assertCastDoesNotExist(castAdd);
         await assertCastRemoveWins(castRemoveLater);

--- a/app/src/storage/stores/reactionStore.test.ts
+++ b/app/src/storage/stores/reactionStore.test.ts
@@ -258,14 +258,15 @@ describe('merge', () => {
 
   describe('ReactionAdd', () => {
     test('succeeds', async () => {
-      await expect(set.merge(reactionAdd)).resolves.toEqual(undefined);
+      await expect(set.merge(reactionAdd)).resolves.toBeTruthy();
 
       await assertReactionAddWins(reactionAdd);
     });
 
     test('succeeds once, even if merged twice', async () => {
-      await expect(set.merge(reactionAdd)).resolves.toEqual(undefined);
-      await expect(set.merge(reactionAdd)).resolves.toEqual(undefined);
+      await expect(set.merge(reactionAdd)).resolves.toBeTruthy();
+      // Merge succeeds, but returns false because the message already exists
+      await expect(set.merge(reactionAdd)).resolves.toBeFalsy();
 
       await assertReactionAddWins(reactionAdd);
     });
@@ -286,7 +287,7 @@ describe('merge', () => {
 
       test('succeeds with a later timestamp', async () => {
         await set.merge(reactionAdd);
-        await expect(set.merge(reactionAddLater)).resolves.toEqual(undefined);
+        await expect(set.merge(reactionAddLater)).resolves.toBeTruthy();
 
         await assertReactionDoesNotExist(reactionAdd);
         await assertReactionAddWins(reactionAddLater);
@@ -294,7 +295,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier timestamp', async () => {
         await set.merge(reactionAddLater);
-        await expect(set.merge(reactionAdd)).resolves.toEqual(undefined);
+        // Merge succeeds, but returns false because the message already exists
+        await expect(set.merge(reactionAdd)).resolves.toBeFalsy();
 
         await assertReactionDoesNotExist(reactionAdd);
         await assertReactionAddWins(reactionAddLater);
@@ -319,7 +321,7 @@ describe('merge', () => {
 
       test('succeeds with a later hash', async () => {
         await set.merge(reactionAdd);
-        await expect(set.merge(reactionAddLater)).resolves.toEqual(undefined);
+        await expect(set.merge(reactionAddLater)).resolves.toBeTruthy();
 
         await assertReactionDoesNotExist(reactionAdd);
         await assertReactionAddWins(reactionAddLater);
@@ -327,7 +329,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier hash', async () => {
         await set.merge(reactionAddLater);
-        await expect(set.merge(reactionAdd)).resolves.toEqual(undefined);
+        // Merge succeeds, but returns false because the message already exists
+        await expect(set.merge(reactionAdd)).resolves.toBeFalsy();
 
         await assertReactionDoesNotExist(reactionAdd);
         await assertReactionAddWins(reactionAddLater);
@@ -348,7 +351,7 @@ describe('merge', () => {
         const reactionRemoveEarlier = new MessageModel(reactionRemoveMessage) as ReactionRemoveModel;
 
         await set.merge(reactionRemoveEarlier);
-        await expect(set.merge(reactionAdd)).resolves.toEqual(undefined);
+        await expect(set.merge(reactionAdd)).resolves.toBeTruthy();
 
         await assertReactionAddWins(reactionAdd);
         await assertReactionDoesNotExist(reactionRemoveEarlier);
@@ -356,7 +359,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier timestamp', async () => {
         await set.merge(reactionRemove);
-        await expect(set.merge(reactionAdd)).resolves.toEqual(undefined);
+        // Merge succeeds, but returns false because the message already exists
+        await expect(set.merge(reactionAdd)).resolves.toBeFalsy();
 
         await assertReactionRemoveWins(reactionRemove);
         await assertReactionDoesNotExist(reactionAdd);
@@ -378,7 +382,8 @@ describe('merge', () => {
         const reactionRemoveLater = new MessageModel(reactionRemoveMessage) as ReactionRemoveModel;
 
         await set.merge(reactionRemoveLater);
-        await expect(set.merge(reactionAdd)).resolves.toEqual(undefined);
+        // Merge succeeds, but returns false because the message already exists
+        await expect(set.merge(reactionAdd)).resolves.toBeFalsy();
 
         await assertReactionRemoveWins(reactionRemoveLater);
         await assertReactionDoesNotExist(reactionAdd);
@@ -398,7 +403,8 @@ describe('merge', () => {
         const reactionRemoveEarlier = new MessageModel(reactionRemoveMessage) as ReactionRemoveModel;
 
         await set.merge(reactionRemoveEarlier);
-        await expect(set.merge(reactionAdd)).resolves.toEqual(undefined);
+        // Merge succeeds, but returns false because the message already exists
+        await expect(set.merge(reactionAdd)).resolves.toBeFalsy();
 
         await assertReactionDoesNotExist(reactionAdd);
         await assertReactionRemoveWins(reactionRemoveEarlier);
@@ -408,14 +414,15 @@ describe('merge', () => {
 
   describe('ReactionRemove', () => {
     test('succeeds', async () => {
-      await expect(set.merge(reactionRemove)).resolves.toEqual(undefined);
+      await expect(set.merge(reactionRemove)).resolves.toBeTruthy();
 
       await assertReactionRemoveWins(reactionRemove);
     });
 
     test('succeeds once, even if merged twice', async () => {
-      await expect(set.merge(reactionRemove)).resolves.toEqual(undefined);
-      await expect(set.merge(reactionRemove)).resolves.toEqual(undefined);
+      await expect(set.merge(reactionRemove)).resolves.toBeTruthy();
+      // Merge succeeds, but returns false because the message already exists
+      await expect(set.merge(reactionRemove)).resolves.toBeFalsy();
 
       await assertReactionRemoveWins(reactionRemove);
     });
@@ -436,7 +443,7 @@ describe('merge', () => {
 
       test('succeeds with a later timestamp', async () => {
         await set.merge(reactionRemove);
-        await expect(set.merge(reactionRemoveLater)).resolves.toEqual(undefined);
+        await expect(set.merge(reactionRemoveLater)).resolves.toBeTruthy();
 
         await assertReactionDoesNotExist(reactionRemove);
         await assertReactionRemoveWins(reactionRemoveLater);
@@ -444,7 +451,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier timestamp', async () => {
         await set.merge(reactionRemoveLater);
-        await expect(set.merge(reactionRemove)).resolves.toEqual(undefined);
+        // Merge succeeds, but returns false because the message already exists
+        await expect(set.merge(reactionRemove)).resolves.toBeFalsy();
 
         await assertReactionDoesNotExist(reactionRemove);
         await assertReactionRemoveWins(reactionRemoveLater);
@@ -469,7 +477,7 @@ describe('merge', () => {
 
       test('succeeds with a later hash', async () => {
         await set.merge(reactionRemove);
-        await expect(set.merge(reactionRemoveLater)).resolves.toEqual(undefined);
+        await expect(set.merge(reactionRemoveLater)).resolves.toBeTruthy();
 
         await assertReactionDoesNotExist(reactionRemove);
         await assertReactionRemoveWins(reactionRemoveLater);
@@ -477,7 +485,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier hash', async () => {
         await set.merge(reactionRemoveLater);
-        await expect(set.merge(reactionRemove)).resolves.toEqual(undefined);
+        // Merge succeeds, but returns false because the message already exists
+        await expect(set.merge(reactionRemove)).resolves.toBeFalsy();
 
         await assertReactionDoesNotExist(reactionRemove);
         await assertReactionRemoveWins(reactionRemoveLater);
@@ -487,7 +496,7 @@ describe('merge', () => {
     describe('with conflicting ReactionAdd with different timestamps', () => {
       test('succeeds with a later timestamp', async () => {
         await set.merge(reactionAdd);
-        await expect(set.merge(reactionRemove)).resolves.toEqual(undefined);
+        await expect(set.merge(reactionRemove)).resolves.toBeTruthy();
         await assertReactionRemoveWins(reactionRemove);
         await assertReactionDoesNotExist(reactionAdd);
       });
@@ -503,7 +512,8 @@ describe('merge', () => {
         });
         const reactionAddLater = new MessageModel(addMessage) as ReactionAddModel;
         await set.merge(reactionAddLater);
-        await expect(set.merge(reactionRemove)).resolves.toEqual(undefined);
+        // Merge succeeds, but returns false because the message already exists
+        await expect(set.merge(reactionRemove)).resolves.toBeFalsy();
         await assertReactionAddWins(reactionAddLater);
         await assertReactionDoesNotExist(reactionRemove);
       });
@@ -523,7 +533,7 @@ describe('merge', () => {
         const reactionAddLater = new MessageModel(addMessage) as ReactionAddModel;
 
         await set.merge(reactionAddLater);
-        await expect(set.merge(reactionRemove)).resolves.toEqual(undefined);
+        await expect(set.merge(reactionRemove)).resolves.toBeTruthy();
 
         await assertReactionDoesNotExist(reactionAddLater);
         await assertReactionRemoveWins(reactionRemove);
@@ -542,7 +552,7 @@ describe('merge', () => {
         const reactionRemoveEarlier = new MessageModel(removeMessage) as ReactionRemoveModel;
 
         await set.merge(reactionRemoveEarlier);
-        await expect(set.merge(reactionRemove)).resolves.toEqual(undefined);
+        await expect(set.merge(reactionRemove)).resolves.toBeTruthy();
 
         await assertReactionDoesNotExist(reactionRemoveEarlier);
         await assertReactionRemoveWins(reactionRemove);

--- a/app/src/storage/stores/signerStore.test.ts
+++ b/app/src/storage/stores/signerStore.test.ts
@@ -301,14 +301,15 @@ describe('merge', () => {
 
   describe('SignerAdd', () => {
     test('succeeds', async () => {
-      await expect(set.merge(signerAdd)).resolves.toEqual(undefined);
+      await expect(set.merge(signerAdd)).resolves.toBeTruthy();
       await assertSignerAddWins(signerAdd);
       expect(mergedMessages).toEqual([signerAdd]);
     });
 
     test('succeeds once, even if merged twice', async () => {
-      await expect(set.merge(signerAdd)).resolves.toEqual(undefined);
-      await expect(set.merge(signerAdd)).resolves.toEqual(undefined);
+      await expect(set.merge(signerAdd)).resolves.toBeTruthy();
+      // Merge again, but is a no-op, so returns false
+      await expect(set.merge(signerAdd)).resolves.toBeFalsy();
 
       await assertSignerAddWins(signerAdd);
       expect(mergedMessages).toEqual([signerAdd]);
@@ -335,7 +336,7 @@ describe('merge', () => {
 
       test('succeeds with a later timestamp', async () => {
         await set.merge(signerAdd);
-        await expect(set.merge(signerAddLater)).resolves.toEqual(undefined);
+        await expect(set.merge(signerAddLater)).resolves.toBeTruthy();
 
         await assertSignerDoesNotExist(signerAdd);
         await assertSignerAddWins(signerAddLater);
@@ -344,7 +345,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier timestamp', async () => {
         await set.merge(signerAddLater);
-        await expect(set.merge(signerAdd)).resolves.toEqual(undefined);
+        // Merge again, but is a no-op, so returns false
+        await expect(set.merge(signerAdd)).resolves.toBeFalsy();
 
         await assertSignerDoesNotExist(signerAdd);
         await assertSignerAddWins(signerAddLater);
@@ -373,7 +375,7 @@ describe('merge', () => {
 
       test('succeeds with a later hash', async () => {
         await set.merge(signerAdd);
-        await expect(set.merge(signerAddLater)).resolves.toEqual(undefined);
+        await expect(set.merge(signerAddLater)).resolves.toBeTruthy();
 
         await assertSignerDoesNotExist(signerAdd);
         await assertSignerAddWins(signerAddLater);
@@ -382,7 +384,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier hash', async () => {
         await set.merge(signerAddLater);
-        await expect(set.merge(signerAdd)).resolves.toEqual(undefined);
+        // Merge again, but is a no-op, so returns false
+        await expect(set.merge(signerAdd)).resolves.toBeFalsy();
 
         await assertSignerDoesNotExist(signerAdd);
         await assertSignerAddWins(signerAddLater);
@@ -407,7 +410,7 @@ describe('merge', () => {
         const signerRemoveEarlier = new MessageModel(removeMessage) as SignerRemoveModel;
 
         await set.merge(signerRemoveEarlier);
-        await expect(set.merge(signerAdd)).resolves.toEqual(undefined);
+        await expect(set.merge(signerAdd)).resolves.toBeTruthy();
 
         await assertSignerAddWins(signerAdd);
         await assertSignerDoesNotExist(signerRemoveEarlier);
@@ -416,7 +419,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier timestamp', async () => {
         await set.merge(signerRemove);
-        await expect(set.merge(signerAdd)).resolves.toEqual(undefined);
+        // Merge again, but is a no-op, so returns false
+        await expect(set.merge(signerAdd)).resolves.toBeFalsy();
 
         await assertSignerRemoveWins(signerRemove);
         await assertSignerDoesNotExist(signerAdd);
@@ -442,7 +446,8 @@ describe('merge', () => {
         const signerRemoveLater = new MessageModel(removeMessage) as SignerRemoveModel;
 
         await set.merge(signerRemoveLater);
-        await expect(set.merge(signerAdd)).resolves.toEqual(undefined);
+        // Succeeds, bit it's a no-op, so returns false
+        await expect(set.merge(signerAdd)).resolves.toBeFalsy();
 
         await assertSignerRemoveWins(signerRemoveLater);
         await assertSignerDoesNotExist(signerAdd);
@@ -466,7 +471,8 @@ describe('merge', () => {
         const signerRemoveEarlier = new MessageModel(removeMessage) as SignerRemoveModel;
 
         await set.merge(signerRemoveEarlier);
-        await expect(set.merge(signerAdd)).resolves.toEqual(undefined);
+        // Succeeds, bit it's a no-op, so returns false
+        await expect(set.merge(signerAdd)).resolves.toBeFalsy();
 
         await assertSignerDoesNotExist(signerAdd);
         await assertSignerRemoveWins(signerRemoveEarlier);
@@ -477,15 +483,16 @@ describe('merge', () => {
 
   describe('SignerRemove', () => {
     test('succeeds', async () => {
-      await expect(set.merge(signerRemove)).resolves.toEqual(undefined);
+      await expect(set.merge(signerRemove)).resolves.toBeTruthy();
 
       await assertSignerRemoveWins(signerRemove);
       expect(mergedMessages).toEqual([signerRemove]);
     });
 
     test('succeeds once, even if merged twice', async () => {
-      await expect(set.merge(signerRemove)).resolves.toEqual(undefined);
-      await expect(set.merge(signerRemove)).resolves.toEqual(undefined);
+      await expect(set.merge(signerRemove)).resolves.toBeTruthy();
+      // Merge again, but is a no-op, so returns false
+      await expect(set.merge(signerRemove)).resolves.toBeFalsy();
 
       await assertSignerRemoveWins(signerRemove);
       expect(mergedMessages).toEqual([signerRemove]);
@@ -510,7 +517,7 @@ describe('merge', () => {
 
       test('succeeds with a later timestamp', async () => {
         await set.merge(signerRemove);
-        await expect(set.merge(signerRemoveLater)).resolves.toEqual(undefined);
+        await expect(set.merge(signerRemoveLater)).resolves.toBeTruthy();
 
         await assertSignerDoesNotExist(signerRemove);
         await assertSignerRemoveWins(signerRemoveLater);
@@ -519,7 +526,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier timestamp', async () => {
         await set.merge(signerRemoveLater);
-        await expect(set.merge(signerRemove)).resolves.toEqual(undefined);
+        // Merge again, but is a no-op, so returns false
+        await expect(set.merge(signerRemove)).resolves.toBeFalsy();
 
         await assertSignerDoesNotExist(signerRemove);
         await assertSignerRemoveWins(signerRemoveLater);
@@ -548,7 +556,7 @@ describe('merge', () => {
 
       test('succeeds with a later hash', async () => {
         await set.merge(signerRemove);
-        await expect(set.merge(signerRemoveLater)).resolves.toEqual(undefined);
+        await expect(set.merge(signerRemoveLater)).resolves.toBeTruthy();
 
         await assertSignerDoesNotExist(signerRemove);
         await assertSignerRemoveWins(signerRemoveLater);
@@ -557,7 +565,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier hash', async () => {
         await set.merge(signerRemoveLater);
-        await expect(set.merge(signerRemove)).resolves.toEqual(undefined);
+        // Merge again, but is a no-op, so returns false
+        await expect(set.merge(signerRemove)).resolves.toBeFalsy();
 
         await assertSignerDoesNotExist(signerRemove);
         await assertSignerRemoveWins(signerRemoveLater);
@@ -568,7 +577,7 @@ describe('merge', () => {
     describe('with conflicting SignerAdd with different timestamps', () => {
       test('succeeds with a later timestamp', async () => {
         await set.merge(signerAdd);
-        await expect(set.merge(signerRemove)).resolves.toEqual(undefined);
+        await expect(set.merge(signerRemove)).resolves.toBeTruthy();
 
         await assertSignerRemoveWins(signerRemove);
         await assertSignerDoesNotExist(signerAdd);
@@ -592,7 +601,8 @@ describe('merge', () => {
         const signerAddLater = new MessageModel(addMessage) as SignerAddModel;
 
         await set.merge(signerAddLater);
-        await expect(set.merge(signerRemove)).resolves.toEqual(undefined);
+        // Succeeds, but no-op, so return value is false
+        await expect(set.merge(signerRemove)).resolves.toBeFalsy();
 
         await assertSignerAddWins(signerAddLater);
         await assertSignerDoesNotExist(signerRemove);
@@ -617,7 +627,7 @@ describe('merge', () => {
         const signerAddLater = new MessageModel(addMessage) as SignerAddModel;
 
         await set.merge(signerAddLater);
-        await expect(set.merge(signerRemove)).resolves.toEqual(undefined);
+        await expect(set.merge(signerRemove)).resolves.toBeTruthy();
 
         await assertSignerDoesNotExist(signerAddLater);
         await assertSignerRemoveWins(signerRemove);
@@ -641,7 +651,7 @@ describe('merge', () => {
         const signerAddEarlier = new MessageModel(addMessage) as SignerAddModel;
 
         await set.merge(signerAddEarlier);
-        await expect(set.merge(signerRemove)).resolves.toEqual(undefined);
+        await expect(set.merge(signerRemove)).resolves.toBeTruthy();
 
         await assertSignerDoesNotExist(signerAddEarlier);
         await assertSignerRemoveWins(signerRemove);

--- a/app/src/storage/stores/userDataStore.test.ts
+++ b/app/src/storage/stores/userDataStore.test.ts
@@ -131,13 +131,14 @@ describe('merge', () => {
 
   describe('ReactionAdd', () => {
     test('succeeds', async () => {
-      await expect(set.merge(addPfp)).resolves.toEqual(undefined);
+      await expect(set.merge(addPfp)).resolves.toBeTruthy();
       await assertUserDataAddWins(addPfp);
     });
 
     test('succeeds once, even if merged twice', async () => {
-      await expect(set.merge(addPfp)).resolves.toEqual(undefined);
-      await expect(set.merge(addPfp)).resolves.toEqual(undefined);
+      await expect(set.merge(addPfp)).resolves.toBeTruthy();
+      // Succeeds, but it's a no-op, so returns false
+      await expect(set.merge(addPfp)).resolves.toBeFalsy();
 
       await assertUserDataAddWins(addPfp);
     });
@@ -165,7 +166,7 @@ describe('merge', () => {
 
       test('succeeds with a later timestamp', async () => {
         await set.merge(addPfp);
-        await expect(set.merge(addPfpLater)).resolves.toEqual(undefined);
+        await expect(set.merge(addPfpLater)).resolves.toBeTruthy();
 
         await assertUserDataDoesNotExist(addPfp);
         await assertUserDataAddWins(addPfpLater);
@@ -173,7 +174,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier timestamp', async () => {
         await set.merge(addPfpLater);
-        await expect(set.merge(addPfp)).resolves.toEqual(undefined);
+        // Succeeds, but it's a no-op, so returns false
+        await expect(set.merge(addPfp)).resolves.toBeFalsy();
 
         await assertUserDataDoesNotExist(addPfp);
         await assertUserDataAddWins(addPfpLater);
@@ -198,7 +200,7 @@ describe('merge', () => {
 
       test('succeeds with a later hash', async () => {
         await set.merge(addPfp);
-        await expect(set.merge(addPfpLater)).resolves.toEqual(undefined);
+        await expect(set.merge(addPfpLater)).resolves.toBeTruthy();
 
         await assertUserDataDoesNotExist(addPfp);
         await assertUserDataAddWins(addPfpLater);
@@ -206,7 +208,8 @@ describe('merge', () => {
 
       test('no-ops with an earlier hash', async () => {
         await set.merge(addPfpLater);
-        await expect(set.merge(addPfp)).resolves.toEqual(undefined);
+        // Succeeds, but it's a no-op, so returns false
+        await expect(set.merge(addPfp)).resolves.toBeFalsy();
 
         await assertUserDataDoesNotExist(addPfp);
         await assertUserDataAddWins(addPfpLater);
@@ -240,13 +243,14 @@ describe('userfname', () => {
   });
 
   test('succeeds', async () => {
-    await expect(set.merge(addFname)).resolves.toEqual(undefined);
+    await expect(set.merge(addFname)).resolves.toBeTruthy();
     await assertUserFnameAddWins(addFname);
   });
 
   test('succeeds even if merged twice', async () => {
-    await expect(set.merge(addFname)).resolves.toEqual(undefined);
-    await expect(set.merge(addFname)).resolves.toEqual(undefined);
+    await expect(set.merge(addFname)).resolves.toBeTruthy();
+    // Succeeds, but it's a no-op, so returns false
+    await expect(set.merge(addFname)).resolves.toBeFalsy();
     await assertUserFnameAddWins(addFname);
   });
 
@@ -259,7 +263,7 @@ describe('userfname', () => {
     await engine.mergeMessage(signerAdd);
 
     // First, add the fname to the first address
-    await expect(set.merge(addFname)).resolves.toEqual(undefined);
+    await expect(set.merge(addFname)).resolves.toBeTruthy();
     await assertUserFnameAddWins(addFname);
 
     // Now, generate a new address
@@ -314,22 +318,24 @@ describe('userfname', () => {
 
     test('successfully merges with a later timestamp', async () => {
       await set.merge(addFname);
-      await expect(set.merge(addFnameLater)).resolves.toEqual(undefined);
+      await expect(set.merge(addFnameLater)).resolves.toBeTruthy();
 
       await assertUserFnameAddWins(addFnameLater);
     });
 
     test('no-ops with an earlier timestamp', async () => {
       await set.merge(addFnameLater);
-      await expect(set.merge(addFname)).resolves.toEqual(undefined);
+      // Succeeds, but it's a no-op, so returns false
+      await expect(set.merge(addFname)).resolves.toBeFalsy();
 
       await assertUserFnameAddWins(addFnameLater);
     });
 
     test('no-ops with an earlier timestamp, even if merged twice', async () => {
       await set.merge(addFnameLater);
-      await expect(set.merge(addFname)).resolves.toEqual(undefined);
-      await expect(set.merge(addFname)).resolves.toEqual(undefined);
+      // Succeeds, but it's a no-op, so returns false
+      await expect(set.merge(addFname)).resolves.toBeFalsy();
+      await expect(set.merge(addFname)).resolves.toBeFalsy();
 
       await assertUserFnameAddWins(addFnameLater);
     });
@@ -353,14 +359,15 @@ describe('userfname', () => {
 
     test('succeeds with a later hash', async () => {
       await set.merge(addFname);
-      await expect(set.merge(addFnameLater)).resolves.toEqual(undefined);
+      await expect(set.merge(addFnameLater)).resolves.toBeTruthy();
 
       await assertUserFnameAddWins(addFnameLater);
     });
 
     test('no-ops with an earlier hash', async () => {
       await set.merge(addFnameLater);
-      await expect(set.merge(addFname)).resolves.toEqual(undefined);
+      // Succeeds, but it's a no-op, so returns false
+      await expect(set.merge(addFname)).resolves.toBeFalsy();
 
       await assertUserFnameAddWins(addFnameLater);
     });

--- a/app/src/storage/stores/verificationStore.test.ts
+++ b/app/src/storage/stores/verificationStore.test.ts
@@ -117,13 +117,14 @@ describe('merge', () => {
 
   describe('VerificationAddEthAddress', () => {
     test('succeeds', async () => {
-      await expect(set.merge(verificationAdd)).resolves.toEqual(undefined);
+      await expect(set.merge(verificationAdd)).resolves.toBeTruthy();
       await assertVerificationAddWins(verificationAdd);
     });
 
     test('succeeds once, even if merged twice', async () => {
-      await expect(set.merge(verificationAdd)).resolves.toEqual(undefined);
-      await expect(set.merge(verificationAdd)).resolves.toEqual(undefined);
+      await expect(set.merge(verificationAdd)).resolves.toBeTruthy();
+      // Success, but no change, so returns false
+      await expect(set.merge(verificationAdd)).resolves.toBeFalsy();
       await assertVerificationAddWins(verificationAdd);
     });
 
@@ -143,14 +144,15 @@ describe('merge', () => {
 
       test('succeeds with a later timestamp', async () => {
         await set.merge(verificationAdd);
-        await expect(set.merge(verificationAddLater)).resolves.toEqual(undefined);
+        await expect(set.merge(verificationAddLater)).resolves.toBeTruthy();
         await assertVerificationDoesNotExist(verificationAdd);
         await assertVerificationAddWins(verificationAddLater);
       });
 
       test('no-ops with an earlier timestamp', async () => {
         await set.merge(verificationAddLater);
-        await expect(set.merge(verificationAdd)).resolves.toEqual(undefined);
+        // Success, but no change, so returns false
+        await expect(set.merge(verificationAdd)).resolves.toBeFalsy();
         await assertVerificationDoesNotExist(verificationAdd);
         await assertVerificationAddWins(verificationAddLater);
       });
@@ -174,14 +176,15 @@ describe('merge', () => {
 
       test('succeeds with a later hash', async () => {
         await set.merge(verificationAdd);
-        await expect(set.merge(verificationAddLater)).resolves.toEqual(undefined);
+        await expect(set.merge(verificationAddLater)).resolves.toBeTruthy();
         await assertVerificationDoesNotExist(verificationAdd);
         await assertVerificationAddWins(verificationAddLater);
       });
 
       test('no-ops with an earlier hash', async () => {
         await set.merge(verificationAddLater);
-        await expect(set.merge(verificationAdd)).resolves.toEqual(undefined);
+        // Success, but no change, so returns false
+        await expect(set.merge(verificationAdd)).resolves.toBeFalsy();
         await assertVerificationDoesNotExist(verificationAdd);
         await assertVerificationAddWins(verificationAddLater);
       });
@@ -200,14 +203,14 @@ describe('merge', () => {
 
         const verificationRemoveEarlier = new MessageModel(removeMessage) as VerificationRemoveModel;
         await set.merge(verificationRemoveEarlier);
-        await expect(set.merge(verificationAdd)).resolves.toEqual(undefined);
+        await expect(set.merge(verificationAdd)).resolves.toBeTruthy();
         await assertVerificationAddWins(verificationAdd);
         await assertVerificationDoesNotExist(verificationRemoveEarlier);
       });
 
       test('no-ops with an earlier timestamp', async () => {
         await set.merge(verificationRemove);
-        await expect(set.merge(verificationAdd)).resolves.toEqual(undefined);
+        await expect(set.merge(verificationAdd)).resolves.toBeFalsy();
         await assertVerificationRemoveWins(verificationRemove);
         await assertVerificationDoesNotExist(verificationAdd);
       });
@@ -227,7 +230,8 @@ describe('merge', () => {
 
         const verificationRemoveLater = new MessageModel(removeMessage) as VerificationRemoveModel;
         await set.merge(verificationRemoveLater);
-        await expect(set.merge(verificationAdd)).resolves.toEqual(undefined);
+        // Success, but no change, so returns false
+        await expect(set.merge(verificationAdd)).resolves.toBeFalsy();
         await assertVerificationRemoveWins(verificationRemoveLater);
         await assertVerificationDoesNotExist(verificationAdd);
       });
@@ -245,7 +249,8 @@ describe('merge', () => {
 
         const verificationRemoveEarlier = new MessageModel(removeMessage) as VerificationRemoveModel;
         await set.merge(verificationRemoveEarlier);
-        await expect(set.merge(verificationAdd)).resolves.toEqual(undefined);
+        // Success, but no change, so returns false
+        await expect(set.merge(verificationAdd)).resolves.toBeFalsy();
         await assertVerificationRemoveWins(verificationRemoveEarlier);
         await assertVerificationDoesNotExist(verificationAdd);
       });
@@ -254,13 +259,14 @@ describe('merge', () => {
 
   describe('VerificationRemove', () => {
     test('succeeds', async () => {
-      await expect(set.merge(verificationRemove)).resolves.toEqual(undefined);
+      await expect(set.merge(verificationRemove)).resolves.toBeTruthy();
       await assertVerificationRemoveWins(verificationRemove);
     });
 
     test('succeeds once, even if merged twice', async () => {
-      await expect(set.merge(verificationRemove)).resolves.toEqual(undefined);
-      await expect(set.merge(verificationRemove)).resolves.toEqual(undefined);
+      await expect(set.merge(verificationRemove)).resolves.toBeTruthy();
+      // Success, but no change, so returns false
+      await expect(set.merge(verificationRemove)).resolves.toBeFalsy();
       await assertVerificationRemoveWins(verificationRemove);
     });
 
@@ -280,14 +286,15 @@ describe('merge', () => {
 
       test('succeeds with a later timestamp', async () => {
         await set.merge(verificationRemove);
-        await expect(set.merge(verificationRemoveLater)).resolves.toEqual(undefined);
+        await expect(set.merge(verificationRemoveLater)).resolves.toBeTruthy();
         await assertVerificationDoesNotExist(verificationRemove);
         await assertVerificationRemoveWins(verificationRemoveLater);
       });
 
       test('no-ops with an earlier timestamp', async () => {
         await set.merge(verificationRemoveLater);
-        await expect(set.merge(verificationRemove)).resolves.toEqual(undefined);
+        // Success, but no change, so returns false
+        await expect(set.merge(verificationRemove)).resolves.toBeFalsy();
         await assertVerificationDoesNotExist(verificationRemove);
         await assertVerificationRemoveWins(verificationRemoveLater);
       });
@@ -309,14 +316,15 @@ describe('merge', () => {
 
       test('succeeds with a later hash', async () => {
         await set.merge(verificationRemove);
-        await expect(set.merge(verificationRemoveLater)).resolves.toEqual(undefined);
+        await expect(set.merge(verificationRemoveLater)).resolves.toBeTruthy();
         await assertVerificationDoesNotExist(verificationRemove);
         await assertVerificationRemoveWins(verificationRemoveLater);
       });
 
       test('no-ops with an earlier hash', async () => {
         await set.merge(verificationRemoveLater);
-        await expect(set.merge(verificationRemove)).resolves.toEqual(undefined);
+        // Success, but no change, so returns false
+        await expect(set.merge(verificationRemove)).resolves.toBeFalsy();
         await assertVerificationDoesNotExist(verificationRemove);
         await assertVerificationRemoveWins(verificationRemoveLater);
       });
@@ -325,7 +333,7 @@ describe('merge', () => {
     describe('with conflicting VerificationAddEthAddress with different timestamps', () => {
       test('succeeds with a later timestamp', async () => {
         await set.merge(verificationAdd);
-        await expect(set.merge(verificationRemove)).resolves.toEqual(undefined);
+        await expect(set.merge(verificationRemove)).resolves.toBeTruthy();
         await assertVerificationRemoveWins(verificationRemove);
         await assertVerificationDoesNotExist(verificationAdd);
       });
@@ -342,7 +350,8 @@ describe('merge', () => {
 
         const verificationAddLater = new MessageModel(addMessage) as VerificationAddEthAddressModel;
         await set.merge(verificationAddLater);
-        await expect(set.merge(verificationRemove)).resolves.toEqual(undefined);
+        // Success, but no change, so returns false
+        await expect(set.merge(verificationRemove)).resolves.toBeFalsy();
         await assertVerificationAddWins(verificationAddLater);
         await assertVerificationDoesNotExist(verificationRemove);
       });
@@ -362,7 +371,7 @@ describe('merge', () => {
         const verificationAddLater = new MessageModel(addMessage) as VerificationAddEthAddressModel;
 
         await set.merge(verificationAddLater);
-        await expect(set.merge(verificationRemove)).resolves.toEqual(undefined);
+        await expect(set.merge(verificationRemove)).resolves.toBeTruthy();
         await assertVerificationDoesNotExist(verificationAddLater);
         await assertVerificationRemoveWins(verificationRemove);
       });
@@ -380,7 +389,7 @@ describe('merge', () => {
 
         const verificationRemoveEarlier = new MessageModel(addMessage) as VerificationRemoveModel;
         await set.merge(verificationRemoveEarlier);
-        await expect(set.merge(verificationRemove)).resolves.toEqual(undefined);
+        await expect(set.merge(verificationRemove)).resolves.toBeTruthy();
         await assertVerificationDoesNotExist(verificationRemoveEarlier);
         await assertVerificationRemoveWins(verificationRemove);
       });

--- a/app/src/test/mocks.ts
+++ b/app/src/test/mocks.ts
@@ -17,7 +17,7 @@ export class MockHub implements HubInterface {
     this.engine = engine ?? new Engine(db);
   }
 
-  async submitMessage(message: MessageModel): HubAsyncResult<void> {
+  async submitMessage(message: MessageModel): HubAsyncResult<boolean> {
     return this.engine.mergeMessage(message);
   }
 


### PR DESCRIPTION
## Motivation

Return a boolean from merge, indicating if the merge resulted in a no-op. We need this so that gossip knows if the submitted message was new, and should be gossiped out, or if it already existed, so no need to gossip out. 

## Change Summary

- `merge` methods now return boolean, depending if it was a no-op
- Update tests

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)

## Additional Context

