### PR TITLE
fix: validate fid as part of validateMessage

### DIFF
--- a/app/src/flatbuffers/models/validations.test.ts
+++ b/app/src/flatbuffers/models/validations.test.ts
@@ -103,6 +103,14 @@ describe('validateMessage', () => {
       new HubError('bad_request.validation_failure', 'timestamp more than 10 mins in the future')
     );
   });
+
+  test('fails with padded fid', async () => {
+    const paddedFid = new Uint8Array([...Factories.FID.build(), 0]);
+    const data = await Factories.MessageData.create({ fid: Array.from(paddedFid) });
+    const message = new MessageModel(await Factories.Message.create({ data: Array.from(data.bb?.bytes() ?? []) }));
+    const result = await validations.validateMessage(message);
+    expect(result._unsafeUnwrapErr()).toEqual(new HubError('bad_request.validation_failure', 'fid is padded'));
+  });
 });
 
 describe('validateFid', () => {

--- a/app/src/flatbuffers/models/validations.ts
+++ b/app/src/flatbuffers/models/validations.ts
@@ -71,6 +71,12 @@ export const validateMessage = async (message: MessageModel): HubAsyncResult<Mes
     return err(new HubError('bad_request.validation_failure', 'timestamp more than 10 mins in the future'));
   }
 
+  // 4. Verify fid
+  const validatedFid = validateFid(message.fid());
+  if (validatedFid.isErr()) {
+    return err(validatedFid.error);
+  }
+
   if (typeguards.isCastAdd(message)) {
     return validateCastAddMessage(message);
   } else if (typeguards.isCastRemove(message)) {


### PR DESCRIPTION
## Motivation

`validateMessage` should validate all attributes of the message, not just the signatures and hashes.

## Change Summary

* Call `validateFid` as part of `validateMessage` method

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
