### PR TITLE
feat: replace Eip712Signer with EthersSigner

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,7 +10,7 @@
     "@hub/flatbuffers": "1.0.0",
     "@noble/ed25519": "^1.7.1",
     "@noble/hashes": "^1.1.5",
-    "ethers": "^5.7.2",
+    "ethers": "5.7.2",
     "flatbuffers": "^22.11.23",
     "neverthrow": "^6.0.0"
   },
@@ -22,7 +22,7 @@
     "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage"
   },
   "devDependencies": {
-    "fishery": "^2.2.2",
-    "eslint-config-custom": "*"
+    "eslint-config-custom": "*",
+    "fishery": "^2.2.2"
   }
 }

--- a/packages/utils/src/signers/ed25519Signer.ts
+++ b/packages/utils/src/signers/ed25519Signer.ts
@@ -7,6 +7,7 @@ import { Signer } from './signer';
 export class Ed25519Signer extends Signer {
   /** 32-byte public key */
   public declare readonly signerKey: Uint8Array;
+  public readonly privateKey: Uint8Array;
 
   constructor(privateKey: Uint8Array) {
     const publicKeyBytes = ed25519.getPublicKeySync(privateKey);
@@ -14,7 +15,8 @@ export class Ed25519Signer extends Signer {
     if (publicKeyHex.isErr()) {
       throw publicKeyHex.error;
     }
-    super(SignatureScheme.Ed25519, privateKey, publicKeyBytes, publicKeyHex.value);
+    super(SignatureScheme.Ed25519, publicKeyBytes, publicKeyHex.value);
+    this.privateKey = privateKey;
   }
 
   /** generates 256-bit signature from an EdDSA key pair */

--- a/packages/utils/src/signers/eip712Signer.ts
+++ b/packages/utils/src/signers/eip712Signer.ts
@@ -9,6 +9,7 @@ import { Signer } from './signer';
 export class Eip712Signer extends Signer {
   /** 32-byte wallet address */
   public declare readonly signerKey: Uint8Array;
+  public readonly privateKey: Uint8Array;
   private readonly wallet: Wallet;
 
   constructor(privateKey: Uint8Array) {
@@ -18,8 +19,9 @@ export class Eip712Signer extends Signer {
     if (signerKey.isErr()) {
       throw signerKey.error;
     }
-    super(SignatureScheme.Eip712, privateKey, signerKey.value, addressHex);
+    super(SignatureScheme.Eip712, signerKey.value, addressHex);
     this.wallet = wallet;
+    this.privateKey = privateKey;
   }
 
   /** generates 256-bit signature from an Ethereum address */

--- a/packages/utils/src/signers/ethersSigner.test.ts
+++ b/packages/utils/src/signers/ethersSigner.test.ts
@@ -1,0 +1,70 @@
+import { FarcasterNetwork } from '@hub/flatbuffers';
+import { blake3 } from '@noble/hashes/blake3';
+import { BigNumber, ethers, Wallet } from 'ethers';
+import { randomBytes } from 'ethers/lib/utils';
+import { bytesToHexString, hexStringToBytes } from '../bytes';
+import { eip712 } from '../crypto';
+import { Factories } from '../factories';
+import { VerificationEthAddressClaim } from '../types';
+import { EthersSigner } from './ethersSigner';
+
+describe('EthersSigner', () => {
+  const privateKey = randomBytes(32);
+  let wallet: Wallet;
+  let signer: EthersSigner;
+
+  beforeAll(async () => {
+    wallet = new Wallet(privateKey);
+    signer = await EthersSigner.fromEthers(wallet);
+  });
+
+  describe('static methods', () => {
+    describe('constructor', () => {
+      test('sets signer key', () => {
+        expect(signer.signerKey).toEqual(hexStringToBytes(ethers.utils.computeAddress(privateKey))._unsafeUnwrap());
+      });
+    });
+  });
+
+  describe('instanceMethods', () => {
+    describe('signMessageHash', () => {
+      test('generates valid signature', async () => {
+        const bytes = randomBytes(32);
+        const hash = blake3(bytes, { dkLen: 16 });
+        const signature = await signer.signMessageHash(hash);
+        const recoveredAddress = await eip712.verifyMessageHashSignature(hash, signature._unsafeUnwrap());
+        expect(recoveredAddress._unsafeUnwrap()).toEqual(signer.signerKey);
+      });
+    });
+
+    describe('signVerificationEthAddressClaim', () => {
+      let claim: VerificationEthAddressClaim;
+      let signature: Uint8Array;
+
+      beforeAll(async () => {
+        claim = {
+          fid: BigNumber.from(Factories.FID.build()),
+          address: signer.signerKeyHex,
+          blockHash: Factories.BlockHash.build('', { transient: { case: 'mixed' } }),
+          network: FarcasterNetwork.Testnet,
+        };
+        signature = (await signer.signVerificationEthAddressClaim(claim))._unsafeUnwrap();
+      });
+
+      test('succeeds', async () => {
+        expect(signature).toBeTruthy();
+        const recoveredAddress = eip712.verifyVerificationEthAddressClaimSignature(claim, signature);
+        expect(recoveredAddress._unsafeUnwrap()).toEqual(signer.signerKey);
+      });
+
+      test('succeeds when encoding twice', async () => {
+        const claim2: VerificationEthAddressClaim = { ...claim };
+        const signature2 = await signer.signVerificationEthAddressClaim(claim2);
+        expect(signature2._unsafeUnwrap()).toEqual(signature);
+        expect(bytesToHexString(signature2._unsafeUnwrap())._unsafeUnwrap()).toEqual(
+          bytesToHexString(signature)._unsafeUnwrap()
+        );
+      });
+    });
+  });
+});

--- a/packages/utils/src/signers/ethersSigner.ts
+++ b/packages/utils/src/signers/ethersSigner.ts
@@ -1,0 +1,37 @@
+import { SignatureScheme } from '@hub/flatbuffers';
+import ethers from 'ethers';
+import { hexStringToBytes } from '../bytes';
+import { eip712 } from '../crypto';
+import { HubAsyncResult } from '../errors';
+import { VerificationEthAddressClaim } from '../types';
+import { Signer } from './signer';
+
+export class EthersSigner extends Signer {
+  /** 32-byte wallet address */
+  public declare readonly signerKey: Uint8Array;
+  private readonly ethersSigner: ethers.Signer;
+
+  static async fromEthers(ethersSigner: ethers.Signer) {
+    const address = await ethersSigner.getAddress();
+    return new EthersSigner(ethersSigner, address);
+  }
+
+  constructor(ethersSigner: ethers.Signer, address: string) {
+    const signerKeyHex = address;
+    const signerKey = hexStringToBytes(signerKeyHex);
+    if (signerKey.isErr()) {
+      throw signerKey.error;
+    }
+    super(SignatureScheme.Eip712, signerKey.value, signerKeyHex);
+    this.ethersSigner = ethersSigner;
+  }
+
+  /** generates 256-bit signature from an Ethereum address */
+  public signMessageHash(hash: Uint8Array): HubAsyncResult<Uint8Array> {
+    return eip712.signMessageHash(hash, this.ethersSigner);
+  }
+
+  public signVerificationEthAddressClaim(claim: VerificationEthAddressClaim): HubAsyncResult<Uint8Array> {
+    return eip712.signVerificationEthAddressClaim(claim, this.ethersSigner);
+  }
+}

--- a/packages/utils/src/signers/signer.ts
+++ b/packages/utils/src/signers/signer.ts
@@ -5,11 +5,9 @@ export abstract class Signer {
   public readonly scheme: SignatureScheme;
   public readonly signerKey: Uint8Array;
   public readonly signerKeyHex: string;
-  public readonly privateKey: Uint8Array;
 
-  constructor(scheme: SignatureScheme, privateKey: Uint8Array, signerKey: Uint8Array, signerKeyHex: string) {
+  constructor(scheme: SignatureScheme, signerKey: Uint8Array, signerKeyHex: string) {
     this.scheme = scheme;
-    this.privateKey = privateKey;
     this.signerKey = signerKey;
     this.signerKeyHex = signerKeyHex;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3385,7 +3385,7 @@ ethereum-cryptography@^1.1.2:
     "@scure/bip32" "1.1.0"
     "@scure/bip39" "1.1.0"
 
-ethers@^5.6.1, ethers@^5.7.2:
+ethers@5.7.2, ethers@^5.6.1:
   version "5.7.2"
   resolved "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==


### PR DESCRIPTION
## Motivation

The existing implementation of `Eip712Signer` requires using a private key. Clients using this will want to support a variety of hot and cold wallets (i.e. MetaMask, Ledger) that don't expose private keys.
 
## Change Summary

- introduce `EthersSigner` that works with an any `ethers.Signer` sub-class

Once this gets sign off I will remove `Eip712Signer` and replace usages with the EthersSigner w/ `ethers.Wallet`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged