### PR TITLE
test: Add multi-peer gossip test

### DIFF
--- a/app/src/network/p2p/multiPeerGossip.test.ts
+++ b/app/src/network/p2p/multiPeerGossip.test.ts
@@ -1,0 +1,132 @@
+import { Factories } from '@hub/utils';
+import { createEd25519PeerId } from '@libp2p/peer-id-factory';
+import { Multiaddr } from '@multiformats/multiaddr';
+import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
+import MessageModel from '~/flatbuffers/models/messageModel';
+import { SignerAddModel } from '~/flatbuffers/models/types';
+import { Hub } from '~/hub';
+import HubRpcClient from '~/rpc/client';
+import Engine from '~/storage/engine';
+import { sleep } from '~/utils/crypto';
+
+const TEST_TIMEOUT_LONG = 60 * 60 * 1000;
+const PROPAGATION_DELAY = 3 * 1000; // between 2 and 3 full heartbeat ticks
+
+const fid = Factories.FID.build();
+const ethSigner = Factories.Eip712Signer.build();
+const signer = Factories.Ed25519Signer.build();
+
+let custodyEvent: IdRegistryEventModel;
+let signerAdd: SignerAddModel;
+
+beforeAll(async () => {
+  custodyEvent = new IdRegistryEventModel(
+    await Factories.IdRegistryEvent.create({ to: Array.from(ethSigner.signerKey), fid: Array.from(fid) })
+  );
+
+  const signerAddData = await Factories.SignerAddData.create({
+    body: Factories.SignerBody.build({ signer: Array.from(signer.signerKey) }),
+    fid: Array.from(fid),
+  });
+  signerAdd = new MessageModel(
+    await Factories.Message.create({ data: Array.from(signerAddData.bb?.bytes() ?? []) }, { transient: { ethSigner } })
+  ) as SignerAddModel;
+});
+
+describe('Multi peer gossip', () => {
+  const getRootHashFromClient = async (client: HubRpcClient): Promise<string> => {
+    return (await client.getSyncTrieNodeSnapshotByPrefix(''))._unsafeUnwrap().rootHash;
+  };
+
+  const addMessagesWithTimestamps = async (engine: Engine, timestamps: number[]) => {
+    return await Promise.all(
+      timestamps.map(async (t) => {
+        const addData = await Factories.CastAddData.create({ fid: Array.from(fid), timestamp: t });
+        const addMessage = await Factories.Message.create(
+          { data: Array.from(addData.bb?.bytes() ?? []) },
+          { transient: { signer } }
+        );
+        const addMessageModel = new MessageModel(addMessage);
+
+        const result = await engine.mergeMessage(addMessageModel);
+        expect(result.isOk()).toBeTruthy();
+        return Promise.resolve(addMessageModel);
+      })
+    );
+  };
+
+  // Engine 1 is where we add events, and see if engine 2 will sync them
+  let peerId1, peerId2;
+  let hub1: Hub;
+  let hub2: Hub;
+
+  let clientForServer1: HubRpcClient;
+  let clientForServer2: HubRpcClient;
+
+  beforeEach(async () => {
+    peerId1 = await createEd25519PeerId();
+    peerId2 = await createEd25519PeerId();
+
+    const hubOptions1 = {
+      peerId: peerId1,
+      localIpAddrsOnly: true,
+    };
+
+    hub1 = new Hub(hubOptions1);
+    await hub1.start();
+    clientForServer1 = new HubRpcClient(hub1.rpcAddress._unsafeUnwrap());
+
+    const hubOptions2 = {
+      peerId: peerId2,
+      localIpAddrsOnly: true,
+    };
+
+    hub2 = new Hub(hubOptions2);
+    await hub2.start();
+    clientForServer2 = new HubRpcClient(hub2.rpcAddress._unsafeUnwrap());
+  });
+
+  afterEach(async () => {
+    // Cleanup
+    clientForServer1.close();
+    clientForServer2.close();
+
+    await hub1.stop();
+    await hub2.stop();
+  });
+
+  test(
+    'peers should gossip messages',
+    async () => {
+      // Connect the two hubs
+      expect((await hub1.connectAddress(hub2.gossipAddresses[0] as Multiaddr)).isOk).toBeTruthy();
+      await sleep(PROPAGATION_DELAY);
+
+      // Add a custody event to both hub1 and hub2, to simulate both hubs having custody of the same event
+      await hub1.submitIdRegistryEvent(custodyEvent);
+      await hub2.submitIdRegistryEvent(custodyEvent);
+
+      expect(await getRootHashFromClient(clientForServer1)).toEqual('');
+      expect(await getRootHashFromClient(clientForServer2)).toEqual('');
+
+      // Submit signer add, which shouls be gossiped to hub2
+      await hub1.submitMessage(signerAdd);
+
+      // sleep 5 heartbeat ticks
+      await sleep(PROPAGATION_DELAY);
+
+      // Make sure root hash is same
+      expect(await getRootHashFromClient(clientForServer2)).toEqual(await getRootHashFromClient(clientForServer1));
+
+      // Now add cast messages
+      await addMessagesWithTimestamps(hub1.engine, [30662167, 30662169, 30662172]);
+
+      // sleep 5 heartbeat ticks
+      await sleep(PROPAGATION_DELAY);
+
+      // Make sure root hash is same after adding messages
+      expect(await getRootHashFromClient(clientForServer2)).toEqual(await getRootHashFromClient(clientForServer1));
+    },
+    TEST_TIMEOUT_LONG
+  );
+});

--- a/app/src/network/utils/factories.test.ts
+++ b/app/src/network/utils/factories.test.ts
@@ -1,7 +1,9 @@
 import * as flatbuffers from '@hub/flatbuffers';
+import { MessageBytesT } from '@hub/flatbuffers';
 import { Factories } from '@hub/utils';
 import { isPeerId } from '@libp2p/interface-peer-id';
 import { peerIdFromBytes } from '@libp2p/peer-id';
+import MessageModel from '~/flatbuffers/models/messageModel';
 import { GOSSIP_PROTOCOL_VERSION } from '~/network/p2p/protocol';
 import { NetworkFactories } from '~/network/utils/factories';
 
@@ -12,19 +14,19 @@ describe('GossipMessageFactory', () => {
   beforeAll(async () => {
     content = await Factories.Message.create();
     message = await NetworkFactories.GossipMessage.create({
-      contentType: flatbuffers.GossipContent.Message,
-      content: content.unpack(),
+      contentType: flatbuffers.GossipContent.MessageBytes,
+      content: new MessageBytesT(Array.from(new MessageModel(content).toBytes())),
     });
   });
 
   test('creates with arguments', () => {
-    expect(message.unpack().content).toEqual(content.unpack());
+    expect(message.unpack().content).toEqual(new MessageBytesT(Array.from(new MessageModel(content).toBytes())));
   });
 
   test('creates a FC Message by default', async () => {
     const other = await NetworkFactories.GossipMessage.create();
     expect(other).toBeDefined();
-    expect(other.contentType()).toEqual(flatbuffers.GossipContent.Message);
+    expect(other.contentType()).toEqual(flatbuffers.GossipContent.MessageBytes);
     expect(other.unpack().content).not.toEqual(content.unpack());
   });
 

--- a/app/src/network/utils/factories.ts
+++ b/app/src/network/utils/factories.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import * as flatbuffers from '@hub/flatbuffers';
+import { MessageBytesT } from '@hub/flatbuffers';
 import { Factories, hexStringToBytes } from '@hub/utils';
 import { PeerId } from '@libp2p/interface-peer-id';
 import { createEd25519PeerId } from '@libp2p/peer-id-factory';
@@ -50,7 +51,12 @@ const GossipMessageFactory = Factory.define<flatbuffers.GossipMessageT, { peerId
       return flatbuffers.GossipMessage.getRootAsGossipMessage(new ByteBuffer(builder.asUint8Array()));
     });
 
-    return new flatbuffers.GossipMessageT(flatbuffers.GossipContent.Message, Factories.Message.build(), [
+    const messageT = Factories.Message.build();
+    const builder = new Builder(1);
+    builder.finish(messageT.pack(builder));
+    const messagesBytes = new MessageBytesT(Array.from(builder.asUint8Array()));
+
+    return new flatbuffers.GossipMessageT(flatbuffers.GossipContent.MessageBytes, messagesBytes, [
       NETWORK_TOPIC_PRIMARY,
     ]);
   }

--- a/app/src/utils/logger.ts
+++ b/app/src/utils/logger.ts
@@ -37,6 +37,7 @@ const defaultOptions: Pino.LoggerOptions = {};
 
 // Disable logging in tests and CI to reduce noise
 if (process.env['NODE_ENV'] === 'test' || process.env['CI']) {
+  // defaultOptions.level = 'debug';
   defaultOptions.level = 'silent';
 }
 

--- a/packages/flatbuffers/src/generated/gossip_generated.ts
+++ b/packages/flatbuffers/src/generated/gossip_generated.ts
@@ -3,7 +3,7 @@
 import * as flatbuffers from 'flatbuffers';
 
 import {IdRegistryEvent as IdRegistryEvent, IdRegistryEventT as IdRegistryEventT} from './id_registry_event_generated.js';
-import {Message as Message, MessageT as MessageT} from './message_generated.js';
+import {MessageBytes as MessageBytes, MessageBytesT as MessageBytesT} from './message_generated.js';
 
 export enum GossipVersion {
   V1 = 1
@@ -11,18 +11,18 @@ export enum GossipVersion {
 
 export enum GossipContent {
   NONE = 0,
-  Message = 1,
+  MessageBytes = 1,
   IdRegistryEvent = 2,
   ContactInfoContent = 3
 }
 
 export function unionToGossipContent(
   type: GossipContent,
-  accessor: (obj:ContactInfoContent|IdRegistryEvent|Message) => ContactInfoContent|IdRegistryEvent|Message|null
-): ContactInfoContent|IdRegistryEvent|Message|null {
+  accessor: (obj:ContactInfoContent|IdRegistryEvent|MessageBytes) => ContactInfoContent|IdRegistryEvent|MessageBytes|null
+): ContactInfoContent|IdRegistryEvent|MessageBytes|null {
   switch(GossipContent[type]) {
     case 'NONE': return null; 
-    case 'Message': return accessor(new Message())! as Message;
+    case 'MessageBytes': return accessor(new MessageBytes())! as MessageBytes;
     case 'IdRegistryEvent': return accessor(new IdRegistryEvent())! as IdRegistryEvent;
     case 'ContactInfoContent': return accessor(new ContactInfoContent())! as ContactInfoContent;
     default: return null;
@@ -31,12 +31,12 @@ export function unionToGossipContent(
 
 export function unionListToGossipContent(
   type: GossipContent, 
-  accessor: (index: number, obj:ContactInfoContent|IdRegistryEvent|Message) => ContactInfoContent|IdRegistryEvent|Message|null, 
+  accessor: (index: number, obj:ContactInfoContent|IdRegistryEvent|MessageBytes) => ContactInfoContent|IdRegistryEvent|MessageBytes|null, 
   index: number
-): ContactInfoContent|IdRegistryEvent|Message|null {
+): ContactInfoContent|IdRegistryEvent|MessageBytes|null {
   switch(GossipContent[type]) {
     case 'NONE': return null; 
-    case 'Message': return accessor(index, new Message())! as Message;
+    case 'MessageBytes': return accessor(index, new MessageBytes())! as MessageBytes;
     case 'IdRegistryEvent': return accessor(index, new IdRegistryEvent())! as IdRegistryEvent;
     case 'ContactInfoContent': return accessor(index, new ContactInfoContent())! as ContactInfoContent;
     default: return null;
@@ -433,7 +433,7 @@ unpackTo(_o: GossipMessageT): void {
 export class GossipMessageT implements flatbuffers.IGeneratedObject {
 constructor(
   public contentType: GossipContent = GossipContent.NONE,
-  public content: ContactInfoContentT|IdRegistryEventT|MessageT|null = null,
+  public content: ContactInfoContentT|IdRegistryEventT|MessageBytesT|null = null,
   public topics: (string)[] = [],
   public peerId: (number)[] = [],
   public version: GossipVersion = GossipVersion.V1

--- a/packages/flatbuffers/src/generated/message_generated.ts
+++ b/packages/flatbuffers/src/generated/message_generated.ts
@@ -1640,3 +1640,95 @@ pack(builder:flatbuffers.Builder): flatbuffers.Offset {
 }
 }
 
+export class MessageBytes implements flatbuffers.IUnpackableObject<MessageBytesT> {
+  bb: flatbuffers.ByteBuffer|null = null;
+  bb_pos = 0;
+  __init(i:number, bb:flatbuffers.ByteBuffer):MessageBytes {
+  this.bb_pos = i;
+  this.bb = bb;
+  return this;
+}
+
+static getRootAsMessageBytes(bb:flatbuffers.ByteBuffer, obj?:MessageBytes):MessageBytes {
+  return (obj || new MessageBytes()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+static getSizePrefixedRootAsMessageBytes(bb:flatbuffers.ByteBuffer, obj?:MessageBytes):MessageBytes {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new MessageBytes()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+}
+
+messageBytes(index: number):number|null {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.readUint8(this.bb!.__vector(this.bb_pos + offset) + index) : 0;
+}
+
+messageBytesLength():number {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
+}
+
+messageBytesArray():Uint8Array|null {
+  const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? new Uint8Array(this.bb!.bytes().buffer, this.bb!.bytes().byteOffset + this.bb!.__vector(this.bb_pos + offset), this.bb!.__vector_len(this.bb_pos + offset)) : null;
+}
+
+static startMessageBytes(builder:flatbuffers.Builder) {
+  builder.startObject(1);
+}
+
+static addMessageBytes(builder:flatbuffers.Builder, messageBytesOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(0, messageBytesOffset, 0);
+}
+
+static createMessageBytesVector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset {
+  builder.startVector(1, data.length, 1);
+  for (let i = data.length - 1; i >= 0; i--) {
+    builder.addInt8(data[i]!);
+  }
+  return builder.endVector();
+}
+
+static startMessageBytesVector(builder:flatbuffers.Builder, numElems:number) {
+  builder.startVector(1, numElems, 1);
+}
+
+static endMessageBytes(builder:flatbuffers.Builder):flatbuffers.Offset {
+  const offset = builder.endObject();
+  builder.requiredField(offset, 4) // message_bytes
+  return offset;
+}
+
+static createMessageBytes(builder:flatbuffers.Builder, messageBytesOffset:flatbuffers.Offset):flatbuffers.Offset {
+  MessageBytes.startMessageBytes(builder);
+  MessageBytes.addMessageBytes(builder, messageBytesOffset);
+  return MessageBytes.endMessageBytes(builder);
+}
+
+unpack(): MessageBytesT {
+  return new MessageBytesT(
+    this.bb!.createScalarList<number>(this.messageBytes.bind(this), this.messageBytesLength())
+  );
+}
+
+
+unpackTo(_o: MessageBytesT): void {
+  _o.messageBytes = this.bb!.createScalarList<number>(this.messageBytes.bind(this), this.messageBytesLength());
+}
+}
+
+export class MessageBytesT implements flatbuffers.IGeneratedObject {
+constructor(
+  public messageBytes: (number)[] = []
+){}
+
+
+pack(builder:flatbuffers.Builder): flatbuffers.Offset {
+  const messageBytes = MessageBytes.createMessageBytesVector(builder, this.messageBytes);
+
+  return MessageBytes.createMessageBytes(builder,
+    messageBytes
+  );
+}
+}
+

--- a/packages/flatbuffers/src/generated/rpc_generated.ts
+++ b/packages/flatbuffers/src/generated/rpc_generated.ts
@@ -2,7 +2,7 @@
 
 import * as flatbuffers from 'flatbuffers';
 
-import {CastId as CastId, CastIdT as CastIdT, ReactionType as ReactionType, UserDataType as UserDataType, UserId as UserId, UserIdT as UserIdT} from './message_generated.js';
+import {CastId as CastId, CastIdT as CastIdT, MessageBytes as MessageBytes, MessageBytesT as MessageBytesT, ReactionType as ReactionType, UserDataType as UserDataType, UserId as UserId, UserIdT as UserIdT} from './message_generated.js';
 
 export enum EventType {
   MergeMessage = 0,
@@ -176,98 +176,6 @@ pack(builder:flatbuffers.Builder): flatbuffers.Offset {
     this.synced,
     nickname,
     rootHash
-  );
-}
-}
-
-export class MessageBytes implements flatbuffers.IUnpackableObject<MessageBytesT> {
-  bb: flatbuffers.ByteBuffer|null = null;
-  bb_pos = 0;
-  __init(i:number, bb:flatbuffers.ByteBuffer):MessageBytes {
-  this.bb_pos = i;
-  this.bb = bb;
-  return this;
-}
-
-static getRootAsMessageBytes(bb:flatbuffers.ByteBuffer, obj?:MessageBytes):MessageBytes {
-  return (obj || new MessageBytes()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
-}
-
-static getSizePrefixedRootAsMessageBytes(bb:flatbuffers.ByteBuffer, obj?:MessageBytes):MessageBytes {
-  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
-  return (obj || new MessageBytes()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
-}
-
-messageBytes(index: number):number|null {
-  const offset = this.bb!.__offset(this.bb_pos, 4);
-  return offset ? this.bb!.readUint8(this.bb!.__vector(this.bb_pos + offset) + index) : 0;
-}
-
-messageBytesLength():number {
-  const offset = this.bb!.__offset(this.bb_pos, 4);
-  return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
-}
-
-messageBytesArray():Uint8Array|null {
-  const offset = this.bb!.__offset(this.bb_pos, 4);
-  return offset ? new Uint8Array(this.bb!.bytes().buffer, this.bb!.bytes().byteOffset + this.bb!.__vector(this.bb_pos + offset), this.bb!.__vector_len(this.bb_pos + offset)) : null;
-}
-
-static startMessageBytes(builder:flatbuffers.Builder) {
-  builder.startObject(1);
-}
-
-static addMessageBytes(builder:flatbuffers.Builder, messageBytesOffset:flatbuffers.Offset) {
-  builder.addFieldOffset(0, messageBytesOffset, 0);
-}
-
-static createMessageBytesVector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset {
-  builder.startVector(1, data.length, 1);
-  for (let i = data.length - 1; i >= 0; i--) {
-    builder.addInt8(data[i]!);
-  }
-  return builder.endVector();
-}
-
-static startMessageBytesVector(builder:flatbuffers.Builder, numElems:number) {
-  builder.startVector(1, numElems, 1);
-}
-
-static endMessageBytes(builder:flatbuffers.Builder):flatbuffers.Offset {
-  const offset = builder.endObject();
-  builder.requiredField(offset, 4) // message_bytes
-  return offset;
-}
-
-static createMessageBytes(builder:flatbuffers.Builder, messageBytesOffset:flatbuffers.Offset):flatbuffers.Offset {
-  MessageBytes.startMessageBytes(builder);
-  MessageBytes.addMessageBytes(builder, messageBytesOffset);
-  return MessageBytes.endMessageBytes(builder);
-}
-
-unpack(): MessageBytesT {
-  return new MessageBytesT(
-    this.bb!.createScalarList<number>(this.messageBytes.bind(this), this.messageBytesLength())
-  );
-}
-
-
-unpackTo(_o: MessageBytesT): void {
-  _o.messageBytes = this.bb!.createScalarList<number>(this.messageBytes.bind(this), this.messageBytesLength());
-}
-}
-
-export class MessageBytesT implements flatbuffers.IGeneratedObject {
-constructor(
-  public messageBytes: (number)[] = []
-){}
-
-
-pack(builder:flatbuffers.Builder): flatbuffers.Offset {
-  const messageBytes = MessageBytes.createMessageBytesVector(builder, this.messageBytes);
-
-  return MessageBytes.createMessageBytes(builder,
-    messageBytes
   );
 }
 }

--- a/packages/flatbuffers/src/schemas/gossip.fbs
+++ b/packages/flatbuffers/src/schemas/gossip.fbs
@@ -33,7 +33,7 @@ table ContactInfoContent {
 }
 
 union GossipContent {
-  Message,
+  MessageBytes,
   IdRegistryEvent,
   ContactInfoContent,
 }

--- a/packages/flatbuffers/src/schemas/message.fbs
+++ b/packages/flatbuffers/src/schemas/message.fbs
@@ -125,4 +125,8 @@ table Message {
   signer: [ubyte] (required);
 }
 
+table MessageBytes {
+  message_bytes: [ubyte] (nested_flatbuffer: "Farcaster.Message", required);
+}
+
 root_type Message;

--- a/packages/flatbuffers/src/schemas/rpc.fbs
+++ b/packages/flatbuffers/src/schemas/rpc.fbs
@@ -24,10 +24,6 @@ table HubInfoResponse {
   root_hash: string;
 }
 
-table MessageBytes {
-  message_bytes: [ubyte] (nested_flatbuffer: "Farcaster.Message", required);
-}
-
 table MessagesResponse {
   messages: [MessageBytes];
 }


### PR DESCRIPTION
## Motivation

Add a multi-peer test that starts 2 full hubs and tests gossip over localhost tcp.

## Change Summary

- New multi-peer test
- Switch to using `MessageBytes` instead of using a nested `Message` flatbufffer.
- rename 'Node' to `GossipNode`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)


## Additional Context

