### PR TITLE
feat: Fetch public IP to announce to peers

### DIFF
--- a/apps/hub/.config/hub.config.ts
+++ b/apps/hub/.config/hub.config.ts
@@ -5,6 +5,9 @@
  * Note: CLI options take precedence over the options specified in a config file
  */
 
+const DEFAULT_GOSSIP_PORT = 13111;
+const DEFAULT_RPC_PORT = 13112;
+
 export const Config = {
   /** Path to a PeerId file */
   id: './.hub/default_id.protobuf',
@@ -18,10 +21,14 @@ export const Config = {
   // allowedPeers: [],
   /** The IP address libp2p should listen on. */
   ip: '127.0.0.1',
+  /** The IP address that libp2p should announce to peers */
+  announceIp: '',
+  /** Fetch the IP address from an external service? */
+  fetchIp: false,
   /** The TCP port libp2p should listen on. */
-  gossipPort: 0,
+  gossipPort: DEFAULT_GOSSIP_PORT,
   /** The RPC port to use. */
-  rpcPort: 0,
+  rpcPort: DEFAULT_RPC_PORT,
   /** The name of the RocksDB instance */
   dbName: 'rocks.hub._default',
   /** Clear the RocksDB instance before starting */

--- a/apps/hub/src/cli.ts
+++ b/apps/hub/src/cli.ts
@@ -30,8 +30,10 @@ app
   .option('-b, --bootstrap <peer-multiaddrs...>', 'A list of peer multiaddrs to bootstrap libp2p')
   .option('-a, --allowed-peers <peerIds...>', 'An allow-list of peer ids permitted to connect to the hub')
   .option('--ip <ip-address>', 'The IP address libp2p should listen on. (default: "127.0.0.1")')
-  .option('-g, --gossip-port <port>', 'The tcp port libp2p should gossip over. (default: random port)')
-  .option('-r, --rpc-port <port>', 'The tcp port that the rpc server should listen on.  (default: random port)')
+  .option('--announce-ip <ip-address>', 'The IP address libp2p should announce to other peers')
+  .option('--no-fetch-ip', 'Do not fetch the IP address from an external service (default: false)')
+  .option('-g, --gossip-port <port>', 'The tcp port libp2p should gossip over. (default: 13111)')
+  .option('-r, --rpc-port <port>', 'The tcp port that the rpc server should listen on.  (default: 13112)')
   .option('--db-name <name>', 'The name of the RocksDB instance')
   .option('--db-reset', 'Clears the database before starting')
   .option('-i, --id <filepath>', 'Path to the PeerId file')
@@ -68,6 +70,8 @@ app
     const options: HubOptions = {
       peerId,
       ipMultiAddr: ipMultiAddrResult.value,
+      announceIp: cliOptions.announceIp ?? hubConfig.announceIp,
+      fetchIp: cliOptions.fetchIp ?? hubConfig.fetchIp,
       gossipPort: hubAddressInfo.value.port,
       networkUrl: cliOptions.networkUrl ?? hubConfig.networkUrl,
       IdRegistryAddress: cliOptions.firAddress ?? hubConfig.firAddress,

--- a/apps/hub/src/network/p2p/multiPeerGossip.test.ts
+++ b/apps/hub/src/network/p2p/multiPeerGossip.test.ts
@@ -67,9 +67,14 @@ describe('Multi peer gossip', () => {
     peerId1 = await createEd25519PeerId();
     peerId2 = await createEd25519PeerId();
 
-    const hubOptions1 = {
-      peerId: peerId1,
+    const defaultHubOptions = {
       localIpAddrsOnly: true,
+      fetchIp: false,
+    };
+
+    const hubOptions1 = {
+      ...defaultHubOptions,
+      peerId: peerId1,
     };
 
     hub1 = new Hub(hubOptions1);
@@ -77,8 +82,8 @@ describe('Multi peer gossip', () => {
     clientForServer1 = new HubRpcClient(hub1.rpcAddress._unsafeUnwrap());
 
     const hubOptions2 = {
+      ...defaultHubOptions,
       peerId: peerId2,
-      localIpAddrsOnly: true,
     };
 
     hub2 = new Hub(hubOptions2);


### PR DESCRIPTION
## Motivation

When announcing out a node's address, we need to announce the node's public IP. We can either get this from an external service or have the user specify it

## Change Summary

- `--announce-ip` config option to let the user tell us what the public IP is
- If not provided, fetch public IP from external service
- New `--no-fetch-ip` to prevent contacting external service.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
