### PR TITLE
fix: make utils/bytes non-mutating

### DIFF
--- a/packages/utils/src/bytes.test.ts
+++ b/packages/utils/src/bytes.test.ts
@@ -47,6 +47,14 @@ describe('bytesIncrement', () => {
       expect(bytesIncrement(input)).toEqual(output);
     });
   }
+
+  test('input byte array is not mutated', () => {
+    const input = new Uint8Array([112, 102, 104]);
+    const inputClone = new Uint8Array([112, 102, 104]);
+
+    bytesIncrement(input);
+    expect(bytesCompare(input, inputClone)).toBe(0);
+  });
 });
 
 describe('bytesDecrement', () => {
@@ -72,6 +80,14 @@ describe('bytesDecrement', () => {
       expect(() => bytesDecrement(input)).toThrow(HubError);
     });
   }
+
+  test('input byte array is not mutated', () => {
+    const input = new Uint8Array([112, 102, 104]);
+    const inputClone = new Uint8Array([112, 102, 104]);
+
+    bytesDecrement(input);
+    expect(bytesCompare(input, inputClone)).toBe(0);
+  });
 });
 
 describe('hexStringToBytes', () => {
@@ -160,6 +176,14 @@ describe('bytesToHexString', () => {
       }
     });
   });
+
+  test('input byte array is not mutated', () => {
+    const input = new Uint8Array([112, 102, 104]);
+    const inputClone = new Uint8Array([112, 102, 104]);
+
+    bytesToHexString(input);
+    expect(bytesCompare(input, inputClone)).toBe(0);
+  });
 });
 
 describe('bytesToUtf8String', () => {
@@ -189,6 +213,14 @@ describe('bytesToUtf8String', () => {
       });
     }
   });
+
+  test('input byte array is not mutated', () => {
+    const input = new Uint8Array([112, 102, 104]);
+    const inputClone = new Uint8Array([112, 102, 104]);
+
+    bytesToUtf8String(input);
+    expect(bytesCompare(input, inputClone)).toBe(0);
+  });
 });
 
 describe('bytesToNumber', () => {
@@ -203,6 +235,14 @@ describe('bytesToNumber', () => {
   test('fails when number is larger than 48 bits', () => {
     const maxSafeInt = new Uint8Array([255, 255, 255, 255, 255, 255, 31]);
     expect(bytesToNumber(maxSafeInt)._unsafeUnwrapErr().errCode).toEqual('bad_request.invalid_param');
+  });
+
+  test('input byte array is not mutated', () => {
+    const input = new Uint8Array([112, 102, 104]);
+    const inputClone = new Uint8Array([112, 102, 104]);
+
+    bytesToNumber(input);
+    expect(bytesCompare(input, inputClone)).toBe(0);
   });
 });
 

--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -37,7 +37,9 @@ export const bytesCompare = (a: Uint8Array, b: Uint8Array): number => {
 
 // TOOD: support both big and little endian
 /* eslint-disable security/detect-object-injection */
-export const bytesIncrement = (bytes: Uint8Array): Uint8Array => {
+export const bytesIncrement = (inputBytes: Uint8Array): Uint8Array => {
+  const bytes = new Uint8Array(inputBytes); // avoid mutating input
+
   let i = bytes.length - 1;
   while (i >= 0) {
     if ((bytes[i] as number) < 255) {
@@ -52,7 +54,8 @@ export const bytesIncrement = (bytes: Uint8Array): Uint8Array => {
 };
 
 // TODO: support both big and little endian
-export const bytesDecrement = (bytes: Uint8Array): Uint8Array => {
+export const bytesDecrement = (inputBytes: Uint8Array): Uint8Array => {
+  const bytes = new Uint8Array(inputBytes); // avoid mutating input
   let i = bytes.length - 1;
   while (i >= 0) {
     if ((bytes[i] as number) > 0) {
@@ -75,7 +78,8 @@ export const toByteBuffer = (buffer: Buffer): ByteBuffer => {
   return new ByteBuffer(new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.length / Uint8Array.BYTES_PER_ELEMENT));
 };
 
-export const bytesToUtf8String = (bytes: Uint8Array, options: BytesOptions = {}): HubResult<string> => {
+export const bytesToUtf8String = (inputBytes: Uint8Array, options: BytesOptions = {}): HubResult<string> => {
+  let bytes = new Uint8Array(inputBytes); // avoid mutating input
   const endianness: Endianness = options.endianness ?? 'little';
   const decoder = new TextDecoder();
   if (endianness === 'little') {


### PR DESCRIPTION
## Motivation

Makes byte utils non-mutating.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged