### PR TITLE
fix: force messages to be merged sequentially in stores

### DIFF
--- a/apps/hub/src/rpc/test/concurrency.test.ts
+++ b/apps/hub/src/rpc/test/concurrency.test.ts
@@ -1,7 +1,5 @@
 import * as flatbuffers from '@farcaster/flatbuffers';
-import { makeMessageFromFlatbuffer, types } from '@farcaster/js';
 import { Factories, toTsHash } from '@farcaster/utils';
-import MessageModel from '~/flatbuffers/models/messageModel';
 import SyncEngine from '~/network/sync/syncEngine';
 import HubRpcClient from '~/rpc/client';
 import Server from '~/rpc/server';
@@ -40,23 +38,7 @@ const signer1 = Factories.Ed25519Signer.build();
 const signer2 = Factories.Ed25519Signer.build();
 
 describe('submitMessage', () => {
-  let mergedMessages: [number, types.Message][];
-
-  const mergeListener = (message: MessageModel) => {
-    const json = makeMessageFromFlatbuffer(message.message)._unsafeUnwrap();
-    mergedMessages.push([Date.now(), json]);
-  };
-
-  beforeAll(() => {
-    engine.eventHandler.on('mergeMessage', mergeListener);
-  });
-
-  afterAll(() => {
-    engine.eventHandler.off('mergeMessage', mergeListener);
-  });
-
   beforeEach(async () => {
-    mergedMessages = [];
     await seedSigner(engine, fid, signer1.signerKey);
     await seedSigner(engine, fid, signer2.signerKey);
   });
@@ -112,7 +94,6 @@ describe('submitMessage', () => {
     ]);
 
     expect(results.every((result) => result.isOk())).toBeTruthy();
-    // expect(moreResults.every((result) => result.isOk())).toBeTruthy();
     const messages = await engine.getAllReactionMessagesByFid(fid);
     expect(messages._unsafeUnwrap().length).toEqual(1);
   });

--- a/apps/hub/src/rpc/test/concurrency.test.ts
+++ b/apps/hub/src/rpc/test/concurrency.test.ts
@@ -91,8 +91,28 @@ describe('submitMessage', () => {
       client3.submitMessage(like1),
       client3.submitMessage(like2),
       client3.submitMessage(removeLike2),
+      client1.submitMessage(like1),
+      client1.submitMessage(like2),
+      client1.submitMessage(removeLike2),
+      client2.submitMessage(like1),
+      client2.submitMessage(like2),
+      client2.submitMessage(removeLike2),
+      client3.submitMessage(like1),
+      client3.submitMessage(like2),
+      client3.submitMessage(removeLike2),
+      client1.submitMessage(like1),
+      client1.submitMessage(like2),
+      client1.submitMessage(removeLike2),
+      client2.submitMessage(like1),
+      client2.submitMessage(like2),
+      client2.submitMessage(removeLike2),
+      client3.submitMessage(like1),
+      client3.submitMessage(like2),
+      client3.submitMessage(removeLike2),
     ]);
+
     expect(results.every((result) => result.isOk())).toBeTruthy();
+    // expect(moreResults.every((result) => result.isOk())).toBeTruthy();
     const messages = await engine.getAllReactionMessagesByFid(fid);
     expect(messages._unsafeUnwrap().length).toEqual(1);
   });

--- a/apps/hub/src/rpc/test/concurrency.test.ts
+++ b/apps/hub/src/rpc/test/concurrency.test.ts
@@ -11,7 +11,7 @@ import { seedSigner } from '~/storage/engine/seed';
 import { MockHub } from '~/test/mocks';
 import { addressInfoFromParts } from '~/utils/p2p';
 
-const db = jestRocksDB('flatbuffers.rpc.reactionService.test');
+const db = jestRocksDB('flatbuffers.rpc.concurrency.test');
 const engine = new Engine(db);
 const hub = new MockHub(db, engine);
 

--- a/apps/hub/src/rpc/test/concurrency.test.ts
+++ b/apps/hub/src/rpc/test/concurrency.test.ts
@@ -1,0 +1,136 @@
+import * as flatbuffers from '@farcaster/flatbuffers';
+import { makeMessageFromFlatbuffer, types } from '@farcaster/js';
+import { Factories, toTsHash } from '@farcaster/utils';
+import MessageModel from '~/flatbuffers/models/messageModel';
+import SyncEngine from '~/network/sync/syncEngine';
+import HubRpcClient from '~/rpc/client';
+import Server from '~/rpc/server';
+import { jestRocksDB } from '~/storage/db/jestUtils';
+import Engine from '~/storage/engine';
+import { seedSigner } from '~/storage/engine/seed';
+import { MockHub } from '~/test/mocks';
+import { addressInfoFromParts } from '~/utils/p2p';
+
+const db = jestRocksDB('flatbuffers.rpc.reactionService.test');
+const engine = new Engine(db);
+const hub = new MockHub(db, engine);
+
+let server: Server;
+let client1: HubRpcClient;
+let client2: HubRpcClient;
+let client3: HubRpcClient;
+
+beforeAll(async () => {
+  server = new Server(hub, engine, new SyncEngine(engine));
+  const port = await server.start();
+  client1 = new HubRpcClient(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
+  client2 = new HubRpcClient(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
+  client3 = new HubRpcClient(addressInfoFromParts('127.0.0.1', port)._unsafeUnwrap());
+});
+
+afterAll(async () => {
+  client1.close();
+  client2.close();
+  client3.close();
+  await server.stop();
+});
+
+const fid = Factories.FID.build();
+const signer1 = Factories.Ed25519Signer.build();
+const signer2 = Factories.Ed25519Signer.build();
+
+describe('submitMessage', () => {
+  let mergedMessages: [number, types.Message][];
+
+  const mergeListener = (message: MessageModel) => {
+    const json = makeMessageFromFlatbuffer(message.message)._unsafeUnwrap();
+    mergedMessages.push([Date.now(), json]);
+  };
+
+  beforeAll(() => {
+    engine.eventHandler.on('mergeMessage', mergeListener);
+  });
+
+  afterAll(() => {
+    engine.eventHandler.off('mergeMessage', mergeListener);
+  });
+
+  beforeEach(async () => {
+    mergedMessages = [];
+    await seedSigner(engine, fid, signer1.signerKey);
+    await seedSigner(engine, fid, signer2.signerKey);
+  });
+
+  test('succeeds with concurrent, conflicting reaction messages', async () => {
+    const castId = Factories.CastId.build();
+    const body = Factories.ReactionBody.build({ type: flatbuffers.ReactionType.Like, target: castId });
+    const addData = await Factories.ReactionAddData.create({ fid: Array.from(fid), body });
+    const removeData = await Factories.ReactionRemoveData.create({ fid: Array.from(fid), body });
+
+    const like1 = await Factories.Message.create(
+      { data: Array.from(addData.bb?.bytes() ?? []) },
+      { transient: { signer: signer1 } }
+    );
+    const like2 = await Factories.Message.create(
+      { data: Array.from(addData.bb?.bytes() ?? []) },
+      { transient: { signer: signer2 } }
+    );
+
+    const removeLike2 = await Factories.Message.create(
+      { data: Array.from(removeData.bb?.bytes() ?? []) },
+      { transient: { signer: signer2 } }
+    );
+
+    const results = await Promise.all([
+      client1.submitMessage(like1),
+      client1.submitMessage(like2),
+      client1.submitMessage(removeLike2),
+      client2.submitMessage(like1),
+      client2.submitMessage(like2),
+      client2.submitMessage(removeLike2),
+      client3.submitMessage(like1),
+      client3.submitMessage(like2),
+      client3.submitMessage(removeLike2),
+    ]);
+    expect(results.every((result) => result.isOk())).toBeTruthy();
+    const messages = await engine.getAllReactionMessagesByFid(fid);
+    expect(messages._unsafeUnwrap().length).toEqual(1);
+  });
+
+  test('succeeds with concurrent, conflicting cast message', async () => {
+    const addData = await Factories.CastAddData.create({ fid: Array.from(fid) });
+    const cast1 = await Factories.Message.create(
+      { data: Array.from(addData.bb?.bytes() ?? []) },
+      { transient: { signer: signer1 } }
+    );
+    const cast2 = await Factories.Message.create(
+      { data: Array.from(addData.bb?.bytes() ?? []) },
+      { transient: { signer: signer2 } }
+    );
+
+    const castTsHash = toTsHash(addData.timestamp(), cast1.hashArray() ?? new Uint8Array())._unsafeUnwrap();
+    const removeData = await Factories.CastRemoveData.create({
+      fid: Array.from(fid),
+      body: Factories.CastRemoveBody.build({ targetTsHash: Array.from(castTsHash) }),
+    });
+    const removeCast1 = await Factories.Message.create(
+      { data: Array.from(removeData.bb?.bytes() ?? []) },
+      { transient: { signer: signer1 } }
+    );
+
+    const results = await Promise.all([
+      client1.submitMessage(cast1),
+      client1.submitMessage(cast2),
+      client1.submitMessage(removeCast1),
+      client2.submitMessage(cast1),
+      client2.submitMessage(cast2),
+      client2.submitMessage(removeCast1),
+      client3.submitMessage(cast1),
+      client3.submitMessage(cast2),
+      client3.submitMessage(removeCast1),
+    ]);
+    expect(results.every((result) => result.isOk())).toBeTruthy();
+    const messages = await engine.getAllCastMessagesByFid(fid);
+    expect(messages._unsafeUnwrap().length).toEqual(1);
+  });
+});

--- a/apps/hub/src/storage/engine/index.test.ts
+++ b/apps/hub/src/storage/engine/index.test.ts
@@ -286,21 +286,13 @@ describe('mergeMessages', () => {
     await engine.mergeMessage(signerAdd);
   });
 
-  describe('MergeMultipleMessages', () => {
-    test('succeeds', async () => {
-      await expect(
-        engine.mergeMessages([castAdd, ampAdd, reactionAdd, verificationAdd, userDataAdd, signerRemove])
-      ).resolves.toEqual([ok(undefined), ok(undefined), ok(undefined), ok(undefined), ok(undefined), ok(undefined)]);
-      expect(mergedMessages).toEqual([
-        signerAdd,
-        castAdd,
-        ampAdd,
-        reactionAdd,
-        verificationAdd,
-        userDataAdd,
-        signerRemove,
-      ]);
-    });
+  test('succeeds and merges messages in parallel', async () => {
+    await expect(
+      engine.mergeMessages([castAdd, ampAdd, reactionAdd, verificationAdd, userDataAdd, signerRemove])
+    ).resolves.toEqual([ok(undefined), ok(undefined), ok(undefined), ok(undefined), ok(undefined), ok(undefined)]);
+    expect(new Set(mergedMessages)).toEqual(
+      new Set([signerAdd, castAdd, ampAdd, reactionAdd, verificationAdd, userDataAdd, signerRemove])
+    );
   });
 });
 

--- a/apps/hub/src/storage/engine/index.ts
+++ b/apps/hub/src/storage/engine/index.ts
@@ -41,11 +41,7 @@ class Engine {
   }
 
   async mergeMessages(messages: MessageModel[]): Promise<Array<HubResult<void>>> {
-    const results: HubResult<void>[] = [];
-    for (const message of messages) {
-      results.push(await this.mergeMessage(message));
-    }
-    return results;
+    return Promise.all(messages.map((message) => this.mergeMessage(message)));
   }
 
   async mergeMessage(message: MessageModel): HubAsyncResult<void> {

--- a/apps/hub/src/storage/stores/ampStore.ts
+++ b/apps/hub/src/storage/stores/ampStore.ts
@@ -5,8 +5,8 @@ import MessageModel, { FID_BYTES, TRUE_VALUE } from '~/flatbuffers/models/messag
 import { isAmpAdd, isAmpRemove } from '~/flatbuffers/models/typeguards';
 import { AmpAddModel, AmpRemoveModel, RootPrefix, StorePruneOptions, UserPostfix } from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
+import SequentialMergeStore from '~/storage/stores/sequentialMergeStore';
 import StoreEventHandler from '~/storage/stores/storeEventHandler';
-import SequentialMergeStore from './sequentialMergeStore';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 250;
 const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 90; // 90 days

--- a/apps/hub/src/storage/stores/ampStore.ts
+++ b/apps/hub/src/storage/stores/ampStore.ts
@@ -6,6 +6,7 @@ import { isAmpAdd, isAmpRemove } from '~/flatbuffers/models/typeguards';
 import { AmpAddModel, AmpRemoveModel, RootPrefix, StorePruneOptions, UserPostfix } from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
 import StoreEventHandler from '~/storage/stores/storeEventHandler';
+import SequentialMergeStore from './sequentialMergeStore';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 250;
 const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 90; // 90 days
@@ -30,13 +31,15 @@ const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 90; // 90 days
  * 2. fid:set:targetUserFid -> fid:tsHash (Set Index)
  * 3. fid:set:targetUserFid:tsHash -> fid:tsHash (Target User Index)
  */
-class AmpStore {
+class AmpStore extends SequentialMergeStore {
   private _db: RocksDB;
   private _eventHandler: StoreEventHandler;
   private _pruneSizeLimit: number;
   private _pruneTimeLimit: number;
 
   constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
+    super();
+
     this._db = db;
     this._eventHandler = eventHandler;
     this._pruneSizeLimit = options.pruneSizeLimit ?? PRUNE_SIZE_LIMIT_DEFAULT;
@@ -140,15 +143,16 @@ class AmpStore {
 
   /** Merges a AmpAdd or AmpRemove message into the AmpStore */
   async merge(message: MessageModel): Promise<void> {
-    if (isAmpRemove(message)) {
-      return this.mergeRemove(message);
+    if (!isAmpRemove(message) && !isAmpAdd(message)) {
+      throw new HubError('bad_request.validation_failure', 'invalid amp message');
     }
 
-    if (isAmpAdd(message)) {
-      return this.mergeAdd(message);
+    const mergeResult = await this.mergeSequential(message);
+    if (mergeResult.isErr()) {
+      throw mergeResult.error;
     }
 
-    throw new HubError('bad_request.validation_failure', 'invalid amp message');
+    return mergeResult.value;
   }
 
   async revokeMessagesBySigner(fid: Uint8Array, signer: Uint8Array): HubAsyncResult<void> {
@@ -240,6 +244,16 @@ class AmpStore {
     }
 
     return ok(undefined);
+  }
+
+  protected async mergeFromSequentialQueue(message: MessageModel): Promise<void> {
+    if (isAmpAdd(message)) {
+      return this.mergeAdd(message);
+    } else if (isAmpRemove(message)) {
+      return this.mergeRemove(message);
+    } else {
+      throw new HubError('bad_request.validation_failure', 'invalid message type');
+    }
   }
 
   /* -------------------------------------------------------------------------- */

--- a/apps/hub/src/storage/stores/castStore.ts
+++ b/apps/hub/src/storage/stores/castStore.ts
@@ -5,8 +5,8 @@ import MessageModel, { FID_BYTES, TRUE_VALUE } from '~/flatbuffers/models/messag
 import { isCastAdd, isCastRemove } from '~/flatbuffers/models/typeguards';
 import { CastAddModel, CastRemoveModel, RootPrefix, StorePruneOptions, UserPostfix } from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
+import SequentialMergeStore from '~/storage/stores/sequentialMergeStore';
 import StoreEventHandler from '~/storage/stores/storeEventHandler';
-import SynchronousStore from './sequentialMergeStore';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 10_000;
 const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 365; // 1 year
@@ -39,7 +39,7 @@ const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 365; // 1 year
  * 4. parentFid:parentTsHash:fid:tsHash -> fid:tsHash (Child Set Index)
  * 5. mentionFid:fid:tsHash -> fid:tsHash (Mentions Set Index)
  */
-class CastStore extends SynchronousStore {
+class CastStore extends SequentialMergeStore {
   private _db: RocksDB;
   private _eventHandler: StoreEventHandler;
   private _pruneSizeLimit: number;

--- a/apps/hub/src/storage/stores/reactionStore.ts
+++ b/apps/hub/src/storage/stores/reactionStore.ts
@@ -5,8 +5,8 @@ import MessageModel, { FID_BYTES, TARGET_KEY_BYTES, TRUE_VALUE } from '~/flatbuf
 import { isReactionAdd, isReactionRemove } from '~/flatbuffers/models/typeguards';
 import * as types from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
+import SequentialMergeStore from '~/storage/stores/sequentialMergeStore';
 import StoreEventHandler from '~/storage/stores/storeEventHandler';
-import SynchronousStore from './sequentialMergeStore';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 5_000;
 const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 90; // 90 days
@@ -33,7 +33,7 @@ const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 90; // 90 days
  * 2. fid:set:targetCastTsHash:reactionType -> fid:tsHash (Set Index)
  * 3. reactionTarget:reactionType:targetCastTsHash -> fid:tsHash (Target Index)
  */
-class ReactionStore extends SynchronousStore {
+class ReactionStore extends SequentialMergeStore {
   private _db: RocksDB;
   private _eventHandler: StoreEventHandler;
   private _pruneSizeLimit: number;

--- a/apps/hub/src/storage/stores/reactionStore.ts
+++ b/apps/hub/src/storage/stores/reactionStore.ts
@@ -6,6 +6,7 @@ import { isReactionAdd, isReactionRemove } from '~/flatbuffers/models/typeguards
 import * as types from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
 import StoreEventHandler from '~/storage/stores/storeEventHandler';
+import SynchronousStore from './sequentialMergeStore';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 5_000;
 const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 90; // 90 days
@@ -32,17 +33,25 @@ const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 90; // 90 days
  * 2. fid:set:targetCastTsHash:reactionType -> fid:tsHash (Set Index)
  * 3. reactionTarget:reactionType:targetCastTsHash -> fid:tsHash (Target Index)
  */
-class ReactionStore {
+class ReactionStore extends SynchronousStore {
   private _db: RocksDB;
   private _eventHandler: StoreEventHandler;
   private _pruneSizeLimit: number;
   private _pruneTimeLimit: number;
 
   constructor(db: RocksDB, eventHandler: StoreEventHandler, options: types.StorePruneOptions = {}) {
+    super();
+
     this._db = db;
     this._eventHandler = eventHandler;
     this._pruneSizeLimit = options.pruneSizeLimit ?? PRUNE_SIZE_LIMIT_DEFAULT;
     this._pruneTimeLimit = options.pruneTimeLimit ?? PRUNE_TIME_LIMIT_DEFAULT;
+
+    this._mergeLastTimestamp = Date.now();
+    this._mergeLastNonce = 1;
+    this._mergeIdsQueue = [];
+    this._mergeIdsStore = new Map();
+    this._mergeIsProcessing = false;
   }
 
   /**
@@ -226,15 +235,16 @@ class ReactionStore {
 
   /** Merges a ReactionAdd or ReactionRemove message into the ReactionStore */
   async merge(message: MessageModel): Promise<void> {
-    if (isReactionAdd(message)) {
-      return this.mergeAdd(message);
+    if (!isReactionAdd(message) && !isReactionRemove(message)) {
+      throw new HubError('bad_request.validation_failure', 'invalid message type');
     }
 
-    if (isReactionRemove(message)) {
-      return this.mergeRemove(message);
+    const mergeResult = await this.mergeSequential(message);
+    if (mergeResult.isErr()) {
+      throw mergeResult.error;
     }
 
-    throw new HubError('bad_request.validation_failure', 'invalid message type');
+    return mergeResult.value;
   }
 
   async revokeMessagesBySigner(fid: Uint8Array, signer: Uint8Array): HubAsyncResult<void> {
@@ -336,6 +346,20 @@ class ReactionStore {
     }
 
     return ok(undefined);
+  }
+
+  /* -------------------------------------------------------------------------- */
+  /*                              Abstract Methods                              */
+  /* -------------------------------------------------------------------------- */
+
+  protected async mergeFromSequentialQueue(message: MessageModel): Promise<void> {
+    if (isReactionAdd(message)) {
+      return this.mergeAdd(message);
+    } else if (isReactionRemove(message)) {
+      return this.mergeRemove(message);
+    } else {
+      throw new HubError('bad_request.validation_failure', 'invalid message type');
+    }
   }
 
   /* -------------------------------------------------------------------------- */

--- a/apps/hub/src/storage/stores/sequentialMergeStore.test.ts
+++ b/apps/hub/src/storage/stores/sequentialMergeStore.test.ts
@@ -1,0 +1,84 @@
+import * as flatbuffers from '@farcaster/flatbuffers';
+import { Factories, toTsHash } from '@farcaster/utils';
+import MessageModel from '~/flatbuffers/models/messageModel';
+import { jestRocksDB } from '~/storage/db/jestUtils';
+import { seedSigner } from '~/storage/engine/seed';
+import Engine from '../engine';
+
+const db = jestRocksDB('stores.sequentialMergeStore.test');
+const engine = new Engine(db);
+
+const fid = Factories.FID.build();
+const signer = Factories.Ed25519Signer.build();
+
+describe('mergeSequential', () => {
+  beforeEach(async () => {
+    await seedSigner(engine, fid, signer.signerKey);
+  });
+
+  test('succeeds with concurrent, conflicting cast messages', async () => {
+    const addData = await Factories.CastAddData.create({ fid: Array.from(fid) });
+    const castAdd = await Factories.Message.create(
+      { data: Array.from(addData.bb?.bytes() ?? []) },
+      { transient: { signer } }
+    );
+    const castTsHash = toTsHash(addData.timestamp(), castAdd.hashArray() ?? new Uint8Array())._unsafeUnwrap();
+
+    const generateCastRemove = async (): Promise<flatbuffers.Message> => {
+      const removeData = await Factories.CastRemoveData.create({
+        fid: Array.from(fid),
+        body: Factories.CastRemoveBody.build({ targetTsHash: Array.from(castTsHash) }),
+      });
+      return Factories.Message.create({ data: Array.from(removeData.bb?.bytes() ?? []) }, { transient: { signer } });
+    };
+
+    // Generate 10 cast removes with different timestamps
+    const castRemoves: flatbuffers.Message[] = [];
+    for (let i = 0; i < 10; i++) {
+      const castRemove = await generateCastRemove();
+      castRemoves.push(castRemove);
+    }
+
+    const messages = [castAdd, ...castRemoves, castAdd];
+
+    const promises = messages.map((message) => engine.mergeMessage(new MessageModel(message)));
+
+    const results = await Promise.all(promises);
+    expect(results.every((result) => result.isOk())).toBeTruthy();
+
+    const allMessages = await engine.getAllCastMessagesByFid(fid);
+    expect(allMessages._unsafeUnwrap().length).toEqual(1);
+  });
+
+  test('succeeds with concurrent, conflicting reaction messages', async () => {
+    const castId = Factories.CastId.build();
+    const body = Factories.ReactionBody.build({ type: flatbuffers.ReactionType.Like, target: castId });
+
+    const generateAdd = async () => {
+      const addData = await Factories.ReactionAddData.create({ fid: Array.from(fid), body });
+      return Factories.Message.create({ data: Array.from(addData.bb?.bytes() ?? []) }, { transient: { signer } });
+    };
+
+    const generateRemove = async () => {
+      const removeData = await Factories.ReactionRemoveData.create({ fid: Array.from(fid), body });
+      return Factories.Message.create({ data: Array.from(removeData.bb?.bytes() ?? []) }, { transient: { signer } });
+    };
+
+    const messages: flatbuffers.Message[] = [];
+    for (let i = 0; i < 10; i++) {
+      if (Math.random() < 0.5) {
+        messages.push(await generateAdd());
+      } else {
+        messages.push(await generateRemove());
+      }
+    }
+
+    const promises = messages.map((message) => engine.mergeMessage(new MessageModel(message)));
+
+    const results = await Promise.all(promises);
+    expect(results.every((result) => result.isOk())).toBeTruthy();
+
+    const allMessages = await engine.getAllReactionMessagesByFid(fid);
+    expect(allMessages._unsafeUnwrap().length).toEqual(1);
+  });
+});

--- a/apps/hub/src/storage/stores/sequentialMergeStore.ts
+++ b/apps/hub/src/storage/stores/sequentialMergeStore.ts
@@ -1,0 +1,126 @@
+import { HubAsyncResult, HubResult } from '@farcaster/utils';
+import { err, ok, ResultAsync } from 'neverthrow';
+import { TypedEmitter } from 'tiny-typed-emitter';
+import { HubError } from '~/../../../packages/utils/dist';
+import MessageModel from '~/flatbuffers/models/messageModel';
+
+const MIN_NONCE = 1;
+const MERGE_TIMEOUT = 2 * 1000; // 2 seconds
+
+export type MergeProcessingEvents = {
+  processed: (messageId: string, result?: HubResult<void>) => void;
+};
+
+abstract class SequentialMergeStore extends TypedEmitter<MergeProcessingEvents> {
+  protected _mergeLastTimestamp: number;
+  protected _mergeLastNonce: number;
+  protected _mergeIdsQueue: string[];
+  protected _mergeIdsStore: Map<string, MessageModel>;
+  protected _mergeIsProcessing: boolean;
+
+  protected abstract mergeFromSequentialQueue(message: MessageModel): Promise<void>;
+
+  constructor() {
+    super();
+
+    this._mergeLastTimestamp = Date.now();
+    this._mergeLastNonce = MIN_NONCE;
+    this._mergeIdsQueue = [];
+    this._mergeIdsStore = new Map();
+    this._mergeIsProcessing = false;
+  }
+
+  /**
+   * mergeSequential enqueues a given message for merging and returns a promise that will
+   * resolve once the merge has been processed
+   */
+  protected mergeSequential(message: MessageModel): HubAsyncResult<void> {
+    // Create mergeId
+    const mergeId = this.makeNewMergeId();
+
+    // Enqueue message with mergeId
+    this._mergeIdsStore.set(mergeId, message);
+    this._mergeIdsQueue.push(mergeId);
+
+    // Start processing merges if not already
+    if (!this._mergeIsProcessing) {
+      this.processMerges();
+    }
+
+    // Return promise that resolves once the merge is processed
+    return new Promise((resolve) => {
+      const listenForMerge = (mergedId: string) => {
+        if (mergedId === mergeId) {
+          clearTimeout(timeoutId);
+          resolve(ok(undefined));
+        }
+      };
+      this.on('processed', listenForMerge);
+
+      const timeoutId = setTimeout(() => {
+        // Remove listener and remove message from store, which will prevent it from being processed
+        this.off('processed', listenForMerge);
+        this._mergeIdsStore.delete(mergeId);
+      }, MERGE_TIMEOUT);
+    });
+  }
+
+  protected async processMerges(): HubAsyncResult<void> {
+    this._mergeIsProcessing = true;
+
+    while (this._mergeIdsQueue.length > 0) {
+      const result = await this.processNextMerge();
+      if (result.isErr()) {
+        return err(result.error);
+      }
+      // Move to the next mergeId in the queue
+      this._mergeIdsQueue.shift();
+    }
+
+    this._mergeIsProcessing = false;
+    return ok(undefined);
+  }
+
+  protected async processNextMerge(): HubAsyncResult<void> {
+    // Get next mergeId from queue
+    const nextMergeId = this._mergeIdsQueue[0];
+
+    // If mergeId is missing, return not found
+    if (!nextMergeId) {
+      return err(new HubError('not_found', 'next mergeId not found'));
+    }
+
+    // Get message for next mergeId
+    const nextMessage = this._mergeIdsStore.get(nextMergeId);
+
+    // If message is missing, it means the merge was cancelled, so no-op
+    if (!nextMessage) {
+      return ok(undefined);
+    }
+
+    // Process merge and emit event with result
+    const mergeResult = await ResultAsync.fromPromise(this.mergeFromSequentialQueue(nextMessage), (e) => e as HubError);
+    this.emit('processed', nextMergeId, mergeResult);
+
+    // Delete processed merge from store
+    this._mergeIdsStore.delete(nextMergeId);
+
+    return ok(undefined);
+  }
+
+  /**
+   * Generate unique mergeId using timestamp and nonce
+   */
+  private makeNewMergeId(): string {
+    const timestamp = Date.now();
+    if (timestamp === this._mergeLastTimestamp) {
+      this._mergeLastNonce += 1;
+    } else {
+      this._mergeLastTimestamp = timestamp;
+      this._mergeLastNonce = MIN_NONCE;
+    }
+    return `${this._mergeLastTimestamp}:${this._mergeLastNonce}`;
+  }
+}
+
+export default SequentialMergeStore;

--- a/apps/hub/src/storage/stores/sequentialMergeStore.ts
+++ b/apps/hub/src/storage/stores/sequentialMergeStore.ts
@@ -1,7 +1,6 @@
-import { HubAsyncResult, HubResult } from '@farcaster/utils';
+import { HubAsyncResult, HubError, HubResult } from '@farcaster/utils';
 import { err, ok, ResultAsync } from 'neverthrow';
 import { TypedEmitter } from 'tiny-typed-emitter';
-import { HubError } from '~/../../../packages/utils/dist';
 import MessageModel from '~/flatbuffers/models/messageModel';
 
 const MIN_NONCE = 1;

--- a/apps/hub/src/storage/stores/signerStore.ts
+++ b/apps/hub/src/storage/stores/signerStore.ts
@@ -6,9 +6,9 @@ import MessageModel from '~/flatbuffers/models/messageModel';
 import { isSignerAdd, isSignerRemove } from '~/flatbuffers/models/typeguards';
 import * as types from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
+import SequentialMergeStore from '~/storage/stores/sequentialMergeStore';
 import StoreEventHandler from '~/storage/stores/storeEventHandler';
 import { eventCompare } from '~/utils/contractEvent';
-import SequentialMergeStore from './sequentialMergeStore';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 100;
 

--- a/apps/hub/src/storage/stores/signerStore.ts
+++ b/apps/hub/src/storage/stores/signerStore.ts
@@ -8,6 +8,7 @@ import * as types from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
 import StoreEventHandler from '~/storage/stores/storeEventHandler';
 import { eventCompare } from '~/utils/contractEvent';
+import SequentialMergeStore from './sequentialMergeStore';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 100;
 
@@ -37,12 +38,14 @@ const PRUNE_SIZE_LIMIT_DEFAULT = 100;
  * 1. fid:tsHash -> signer message
  * 2. fid:set:signerAddress -> fid:tsHash (Set Index)
  */
-class SignerStore {
+class SignerStore extends SequentialMergeStore {
   private _db: RocksDB;
   private _eventHandler: StoreEventHandler;
   private _pruneSizeLimit: number;
 
   constructor(db: RocksDB, eventHandler: StoreEventHandler, options: types.StorePruneOptions = {}) {
+    super();
+
     this._db = db;
     this._eventHandler = eventHandler;
     this._pruneSizeLimit = options.pruneSizeLimit ?? PRUNE_SIZE_LIMIT_DEFAULT;
@@ -193,15 +196,16 @@ class SignerStore {
 
   /** Merges a SignerAdd or SignerRemove message into the SignerStore */
   async merge(message: MessageModel): Promise<void> {
-    if (isSignerRemove(message)) {
-      return this.mergeRemove(message);
+    if (!isSignerAdd(message) && !isSignerRemove(message)) {
+      throw new HubError('bad_request.validation_failure', 'invalid message type');
     }
 
-    if (isSignerAdd(message)) {
-      return this.mergeAdd(message);
+    const mergeResult = await this.mergeSequential(message);
+    if (mergeResult.isErr()) {
+      throw mergeResult.error;
     }
 
-    throw new HubError('bad_request.validation_failure', 'invalid message type');
+    return mergeResult.value;
   }
 
   async revokeMessagesBySigner(fid: Uint8Array, signer: Uint8Array): HubAsyncResult<void> {
@@ -304,6 +308,16 @@ class SignerStore {
     }
 
     return ok(undefined);
+  }
+
+  protected async mergeFromSequentialQueue(message: MessageModel): Promise<void> {
+    if (isSignerAdd(message)) {
+      return this.mergeAdd(message);
+    } else if (isSignerRemove(message)) {
+      return this.mergeRemove(message);
+    } else {
+      throw new HubError('bad_request.validation_failure', 'invalid message type');
+    }
   }
 
   /* -------------------------------------------------------------------------- */

--- a/apps/hub/src/storage/stores/userDataStore.ts
+++ b/apps/hub/src/storage/stores/userDataStore.ts
@@ -7,9 +7,9 @@ import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel'
 import { isUserDataAdd } from '~/flatbuffers/models/typeguards';
 import { StorePruneOptions, UserDataAddModel, UserPostfix } from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
+import SequentialMergeStore from '~/storage/stores/sequentialMergeStore';
 import StoreEventHandler from '~/storage/stores/storeEventHandler';
 import { eventCompare } from '~/utils/contractEvent';
-import SequentialMergeStore from './sequentialMergeStore';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 100;
 

--- a/apps/hub/src/storage/stores/verificationStore.ts
+++ b/apps/hub/src/storage/stores/verificationStore.ts
@@ -5,8 +5,8 @@ import MessageModel from '~/flatbuffers/models/messageModel';
 import { isVerificationAddEthAddress, isVerificationRemove } from '~/flatbuffers/models/typeguards';
 import * as types from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
+import SequentialMergeStore from '~/storage/stores/sequentialMergeStore';
 import StoreEventHandler from '~/storage/stores/storeEventHandler';
-import SequentialMergeStore from './sequentialMergeStore';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 50;
 


### PR DESCRIPTION
## Motivation

Closes https://github.com/farcasterxyz/hub/issues/178

## Change Summary

* Add `SequentialMergeStore` class for stores to extend which forces messages to be merged sequentially
* Add test suite for concurrent merges via gRPC and to the engine directly
* Update `mergeMessages` engine method to run merges in parallel because the stores will handle the necessary sequencing

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
