### PR TITLE
feat: add getIdRegistryEvent and getNameRegistryEvent in @farcaster/js

### DIFF
--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -99,3 +99,26 @@ export type UserDataBody = {
   type: flatbuffers.UserDataType;
   value: string;
 };
+
+export type IdRegistryEvent = {
+  blockNumber: number;
+  blockHash: string; // Hex string
+  transactionHash: string; // Hex string
+  logIndex: number;
+  fid: number;
+  to: string; // Hex string
+  type: flatbuffers.IdRegistryEventType;
+  from: string; // Hex string
+};
+
+export type NameRegistryEvent = {
+  blockNumber: number;
+  blockHash: string; // Hex string
+  transactionHash: string; // Hex string
+  logIndex: number;
+  fname: string;
+  to: string; // Hex string
+  type: flatbuffers.NameRegistryEventType;
+  from: string; // Hex string
+  expiry: number;
+};

--- a/packages/js/src/utils.test.ts
+++ b/packages/js/src/utils.test.ts
@@ -7,7 +7,15 @@ import {
   VerificationAddEthAddressBody,
   VerificationRemoveBody,
 } from '@farcaster/flatbuffers';
-import { bytesToHexString, bytesToNumber, Factories, hexStringToBytes } from '@farcaster/utils';
+import {
+  bytesToHexString,
+  bytesToNumber,
+  bytesToUtf8String,
+  Factories,
+  hexStringToBytes,
+  utf8StringToBytes,
+} from '@farcaster/utils';
+import { ok } from 'neverthrow';
 import * as types from './types';
 import * as utils from './utils';
 
@@ -30,6 +38,20 @@ describe('serializeFid', () => {
       expect(utils.serializeFid(input)._unsafeUnwrap()).toEqual(output);
     });
   }
+});
+
+describe('deserializeFname', () => {
+  const fname = Factories.Fname.build();
+  test(`succeeds`, () => {
+    expect(utils.deserializeFname(fname)).toEqual(ok(bytesToUtf8String(fname)._unsafeUnwrap()));
+  });
+});
+
+describe('serializeFname', () => {
+  const fname = faker.random.alpha(5);
+  test(`succeeds`, () => {
+    expect(utils.serializeFname(fname)).toEqual(ok(utf8StringToBytes(fname)._unsafeUnwrap()));
+  });
 });
 
 const ethWallet = Factories.Eip712Signer.build();

--- a/packages/utils/src/factories.ts
+++ b/packages/utils/src/factories.ts
@@ -31,7 +31,7 @@ const FnameFactory = Factory.define<Uint8Array>(() => {
   const builder = new Builder(8);
   // Add 8 random alphabets as the fname
   for (let i = 0; i < 8; i++) {
-    builder.addInt8(faker.datatype.number({ min: 65, max: 90 }));
+    builder.addInt8(faker.datatype.number({ min: 97, max: 122 }));
   }
   return builder.asUint8Array();
 });

--- a/packages/utils/src/validations.test.ts
+++ b/packages/utils/src/validations.test.ts
@@ -1,7 +1,8 @@
 import { faker } from '@faker-js/faker';
 import * as flatbuffers from '@farcaster/flatbuffers';
 import { Builder, ByteBuffer } from 'flatbuffers';
-import { hexStringToBytes } from './bytes';
+import { err, ok } from 'neverthrow';
+import { bytesToUtf8String, hexStringToBytes } from './bytes';
 import { HubError } from './errors';
 import { Factories } from './factories';
 import { getFarcasterTime } from './time';
@@ -39,6 +40,39 @@ describe('validateFid', () => {
   test('fails with padded little endian byte array', () => {
     expect(validations.validateFid(new Uint8Array([1, 0]))._unsafeUnwrapErr()).toEqual(
       new HubError('bad_request.validation_failure', 'fid is padded')
+    );
+  });
+});
+
+describe('validateFname', () => {
+  test('succeeds', () => {
+    const fname = bytesToUtf8String(Factories.Fname.build())._unsafeUnwrap();
+    expect(validations.validateFname(fname)).toEqual(ok(fname));
+  });
+
+  test('fails with empty array', () => {
+    expect(validations.validateFname('')).toEqual(
+      err(new HubError('bad_request.validation_failure', 'fname is missing'))
+    );
+  });
+
+  test('fails when greater than 32 characters', () => {
+    const fname = faker.random.alpha(33);
+    expect(validations.validateFname(fname)).toEqual(
+      err(new HubError('bad_request.validation_failure', 'fname > 32 characters'))
+    );
+  });
+
+  test('fails when undefined', () => {
+    expect(validations.validateFname(undefined)).toEqual(
+      err(new HubError('bad_request.validation_failure', 'fname is missing'))
+    );
+  });
+
+  test('fails with invalid characters', () => {
+    const fname = '@fname';
+    expect(validations.validateFname(fname)).toEqual(
+      err(new HubError('bad_request.validation_failure', `fname doesn't match ${validations.FNAME_REGEX}`))
     );
   });
 });


### PR DESCRIPTION
## Motivation

Adds `getIdRegistryEvent` and `getNameRegistryEvent` to the @farcaster/js Client, closes #403.

## Change Summary

- adds `getIdRegistryEvent` and `getNameRegistryEvent` to the @farcaster/js Client
- adds `validateFname` and use it in `validateMessage`
- reorganized `utils`, grouping serialization functions by scalars, message body, message, and registry events

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged