### PR TITLE
feat: validate network in engine

### DIFF
--- a/apps/hub/.config/hub.config.ts
+++ b/apps/hub/.config/hub.config.ts
@@ -7,12 +7,13 @@
 
 const DEFAULT_GOSSIP_PORT = 13111;
 const DEFAULT_RPC_PORT = 13112;
+const DEFAULT_NETWORK = 3; // Farcaster Devnet
 
 export const Config = {
   /** Path to a PeerId file */
   id: './.hub/default_id.protobuf',
   /** Network URL of the IdRegistry Contract */
-  // networkUrl: '',
+  // ethRpcUrl: '',
   /** Address of the IdRegistry Contract  */
   // firAddress: '',
   /** A list of MultiAddrs to use for bootstrapping */
@@ -33,4 +34,6 @@ export const Config = {
   dbName: 'rocks.hub._default',
   /** Clear the RocksDB instance before starting */
   dbReset: false,
+  /** Farcaster network */
+  network: DEFAULT_NETWORK,
 };

--- a/apps/hub/src/cli.ts
+++ b/apps/hub/src/cli.ts
@@ -24,7 +24,7 @@ app.name('hub').description('Farcaster Hub').version(APP_VERSION);
 app
   .command('start')
   .description('Start a Hub')
-  .requiredOption('-n --network-url <url>', 'RPC URL of a Goerli Ethereum Node')
+  .requiredOption('-e, --eth-rpc-url <url>', 'RPC URL of a Goerli Ethereum Node')
   .option('-c, --config <filepath>', 'Path to a config file with options', DEFAULT_CONFIG_FILE)
   .option('-f, --fir-address <address>', 'The address of the FIR contract')
   .option('-b, --bootstrap <peer-multiaddrs...>', 'A list of peer multiaddrs to bootstrap libp2p')
@@ -37,6 +37,7 @@ app
   .option('--db-name <name>', 'The name of the RocksDB instance')
   .option('--db-reset', 'Clears the database before starting')
   .option('-i, --id <filepath>', 'Path to the PeerId file')
+  .option('-n --network <network>', 'Farcaster network ID')
   .action(async (cliOptions) => {
     const teardown = async (hub: Hub) => {
       await hub.stop();
@@ -73,7 +74,8 @@ app
       announceIp: cliOptions.announceIp ?? hubConfig.announceIp,
       fetchIp: cliOptions.fetchIp ?? hubConfig.fetchIp,
       gossipPort: hubAddressInfo.value.port,
-      networkUrl: cliOptions.networkUrl ?? hubConfig.networkUrl,
+      network: cliOptions.network ?? hubConfig.network,
+      ethRpcUrl: cliOptions.ethRpcUrl ?? hubConfig.ethRpcUrl,
       IdRegistryAddress: cliOptions.firAddress ?? hubConfig.firAddress,
       bootstrapAddrs: cliOptions.bootstrap ?? hubConfig.bootstrap,
       allowedPeers: cliOptions.allowedPeers ?? hubConfig.allowedPeers,

--- a/apps/hub/src/eth/ethEventsProvider.test.ts
+++ b/apps/hub/src/eth/ethEventsProvider.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { Event } from '@ethersproject/contracts';
 import { BaseProvider, Block, TransactionReceipt, TransactionResponse } from '@ethersproject/providers';
-import { IdRegistryEventType, NameRegistryEventType } from '@farcaster/flatbuffers';
+import { FarcasterNetwork, IdRegistryEventType, NameRegistryEventType } from '@farcaster/flatbuffers';
 import { bytesToHexString, Factories, hexStringToBytes } from '@farcaster/utils';
 import { BigNumber, Contract } from 'ethers';
 import { Result } from 'ethers/lib/utils';
@@ -14,7 +14,7 @@ import Engine from '~/storage/engine';
 import { MockHub } from '~/test/mocks';
 
 const db = jestRocksDB('flatbuffers.ethEventsProvider.test');
-const engine = new Engine(db);
+const engine = new Engine(db, FarcasterNetwork.Testnet);
 const hub = new MockHub(db, engine);
 
 const fid = Factories.FID.build();

--- a/apps/hub/src/eth/ethEventsProvider.ts
+++ b/apps/hub/src/eth/ethEventsProvider.ts
@@ -98,12 +98,12 @@ export class EthEventsProvider {
    */
   public static makeWithGoerli(
     hub: HubInterface,
-    networkUrl: string,
+    ethRpcUrl: string,
     IdRegistryAddress: string,
     NameRegistryAddress: string
   ): EthEventsProvider {
     // Setup provider and the contracts
-    const jsonRpcProvider = new providers.JsonRpcProvider(networkUrl);
+    const jsonRpcProvider = new providers.JsonRpcProvider(ethRpcUrl);
 
     const idRegistryContract = new Contract(IdRegistryAddress, IdRegistry.abi, jsonRpcProvider);
     const nameRegistryContract = new Contract(NameRegistryAddress, NameRegistry.abi, jsonRpcProvider);
@@ -147,7 +147,7 @@ export class EthEventsProvider {
     if (latestBlockResult.isErr()) {
       log.error(
         { err: latestBlockResult.error },
-        'failed to connect to ethereum node. Check your network URL (e.g. --network-url)'
+        'failed to connect to ethereum node. Check your eth RPC URL (e.g. --eth-rpc-url)'
       );
       return;
     }

--- a/apps/hub/src/hub.ts
+++ b/apps/hub/src/hub.ts
@@ -1,6 +1,7 @@
 import {
   ContactInfoContent,
   ContactInfoContentT,
+  FarcasterNetwork,
   GossipAddressInfo,
   GossipAddressInfoT,
   GossipContent,
@@ -40,6 +41,9 @@ export const APP_VERSION = process.env['npm_package_version'] ?? '1.0.0';
 export const APP_NICKNAME = 'Farcaster Hub';
 
 export interface HubOptions {
+  /** Farcaster network */
+  network: FarcasterNetwork;
+
   /** The PeerId of this Hub */
   peerId?: PeerId;
 
@@ -65,7 +69,7 @@ export interface HubOptions {
   rpcPort?: number;
 
   /** Network URL of the IdRegistry Contract */
-  networkUrl?: string;
+  ethRpcUrl?: string;
 
   /** Address of the IdRegistry contract  */
   IdRegistryAddress?: string;
@@ -129,7 +133,7 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
     this.options = options;
     this.rocksDB = new BinaryRocksDB(options.rocksDBName ? options.rocksDBName : randomDbName());
     this.gossipNode = new GossipNode();
-    this.engine = new Engine(this.rocksDB);
+    this.engine = new Engine(this.rocksDB, options.network);
     this.syncEngine = new SyncEngine(this.engine);
 
     this.rpcServer = new Server(this, this.engine, this.syncEngine);
@@ -137,7 +141,7 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
     // Create the ETH registry provider, which will fetch ETH events and push them into the engine.
     this.ethRegistryProvider = EthEventsProvider.makeWithGoerli(
       this,
-      options.networkUrl ?? '',
+      options.ethRpcUrl ?? '',
       GoerliEthConstants.IdRegistryAddress,
       GoerliEthConstants.NameRegistryAddress
     );

--- a/apps/hub/src/network/p2p/multiPeerGossip.test.ts
+++ b/apps/hub/src/network/p2p/multiPeerGossip.test.ts
@@ -1,3 +1,4 @@
+import { FarcasterNetwork } from '@farcaster/flatbuffers';
 import { Factories } from '@farcaster/utils';
 import { createEd25519PeerId } from '@libp2p/peer-id-factory';
 import { Multiaddr } from '@multiformats/multiaddr';
@@ -70,6 +71,7 @@ describe('Multi peer gossip', () => {
     const defaultHubOptions = {
       localIpAddrsOnly: true,
       fetchIp: false,
+      network: FarcasterNetwork.Testnet,
     };
 
     const hubOptions1 = {

--- a/apps/hub/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hub/src/network/sync/multiPeerSyncEngine.test.ts
@@ -1,4 +1,4 @@
-import { Message } from '@farcaster/flatbuffers';
+import { FarcasterNetwork, Message } from '@farcaster/flatbuffers';
 import { Factories } from '@farcaster/utils';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
@@ -92,7 +92,7 @@ describe('Multi peer sync engine', () => {
 
   beforeEach(async () => {
     // Engine 1 is where we add events, and see if engine 2 will sync them
-    engine1 = new Engine(testDb1);
+    engine1 = new Engine(testDb1, FarcasterNetwork.Testnet);
     hub1 = new MockHub(testDb1, engine1);
     syncEngine1 = new SyncEngine(engine1);
     syncEngine1.initialize();
@@ -151,7 +151,7 @@ describe('Multi peer sync engine', () => {
       // Add messages to engine 1
       await addMessagesWithTimestamps(engine1, [30662167, 30662169, 30662172]);
 
-      const engine2 = new Engine(testDb2);
+      const engine2 = new Engine(testDb2, FarcasterNetwork.Testnet);
       const syncEngine2 = new SyncEngine(engine2);
 
       // Engine 2 should sync with engine1
@@ -200,7 +200,7 @@ describe('Multi peer sync engine', () => {
     // Add a cast to engine1
     const castAdd = (await addMessagesWithTimestamps(engine1, [30662167]))[0] as MessageModel;
 
-    const engine2 = new Engine(testDb2);
+    const engine2 = new Engine(testDb2, FarcasterNetwork.Testnet);
     const syncEngine2 = new SyncEngine(engine2);
     // Sync engine 2 with engine 1
     await syncEngine2.performSync([], clientForServer1);
@@ -311,7 +311,7 @@ describe('Multi peer sync engine', () => {
         totalMessages += batchSize;
       }
 
-      const engine2 = new Engine(testDb2);
+      const engine2 = new Engine(testDb2, FarcasterNetwork.Testnet);
       const syncEngine2 = new SyncEngine(engine2);
       syncEngine2.initialize();
 

--- a/apps/hub/src/network/sync/syncEngine.test.ts
+++ b/apps/hub/src/network/sync/syncEngine.test.ts
@@ -1,4 +1,4 @@
-import { MessageType } from '@farcaster/flatbuffers';
+import { FarcasterNetwork, MessageType } from '@farcaster/flatbuffers';
 import { Factories, getFarcasterTime } from '@farcaster/utils';
 import { ok } from 'neverthrow';
 import { anyString, instance, mock, when } from 'ts-mockito';
@@ -47,7 +47,7 @@ describe('SyncEngine', () => {
 
   beforeEach(async () => {
     await testDb.clear();
-    engine = new Engine(testDb);
+    engine = new Engine(testDb, FarcasterNetwork.Testnet);
     syncEngine = new SyncEngine(engine);
   });
 

--- a/apps/hub/src/rpc/test/ampService.test.ts
+++ b/apps/hub/src/rpc/test/ampService.test.ts
@@ -1,4 +1,4 @@
-import { UserIdT } from '@farcaster/flatbuffers';
+import { FarcasterNetwork, UserIdT } from '@farcaster/flatbuffers';
 import { Factories, HubError } from '@farcaster/utils';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
@@ -12,7 +12,7 @@ import { MockHub } from '~/test/mocks';
 import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.ampService.test');
-const engine = new Engine(db);
+const engine = new Engine(db, FarcasterNetwork.Testnet);
 const hub = new MockHub(db, engine);
 
 let server: Server;

--- a/apps/hub/src/rpc/test/bulkService.test.ts
+++ b/apps/hub/src/rpc/test/bulkService.test.ts
@@ -1,4 +1,4 @@
-import { Message } from '@farcaster/flatbuffers';
+import { FarcasterNetwork, Message } from '@farcaster/flatbuffers';
 import { Factories, HubResult } from '@farcaster/utils';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
@@ -24,7 +24,7 @@ import { MockHub } from '~/test/mocks';
 import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.syncService.test');
-const engine = new Engine(db);
+const engine = new Engine(db, FarcasterNetwork.Testnet);
 const hub = new MockHub(db, engine);
 
 let server: Server;

--- a/apps/hub/src/rpc/test/castService.test.ts
+++ b/apps/hub/src/rpc/test/castService.test.ts
@@ -1,4 +1,4 @@
-import { CastId, CastIdT, UserIdT } from '@farcaster/flatbuffers';
+import { CastId, CastIdT, FarcasterNetwork, UserIdT } from '@farcaster/flatbuffers';
 import { Factories, HubError } from '@farcaster/utils';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
@@ -12,7 +12,7 @@ import { MockHub } from '~/test/mocks';
 import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.castService.test');
-const engine = new Engine(db);
+const engine = new Engine(db, FarcasterNetwork.Testnet);
 const hub = new MockHub(db, engine);
 
 let server: Server;

--- a/apps/hub/src/rpc/test/concurrency.test.ts
+++ b/apps/hub/src/rpc/test/concurrency.test.ts
@@ -10,7 +10,7 @@ import { MockHub } from '~/test/mocks';
 import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.concurrency.test');
-const engine = new Engine(db);
+const engine = new Engine(db, flatbuffers.FarcasterNetwork.Testnet);
 const hub = new MockHub(db, engine);
 
 let server: Server;

--- a/apps/hub/src/rpc/test/eventService.test.ts
+++ b/apps/hub/src/rpc/test/eventService.test.ts
@@ -1,4 +1,4 @@
-import { EventResponse, EventType } from '@farcaster/flatbuffers';
+import { EventResponse, EventType, FarcasterNetwork } from '@farcaster/flatbuffers';
 import { Factories } from '@farcaster/utils';
 import { ClientReadableStream } from '@grpc/grpc-js';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
@@ -15,7 +15,7 @@ import { sleep } from '~/utils/crypto';
 import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.eventService.test');
-const engine = new Engine(db);
+const engine = new Engine(db, FarcasterNetwork.Testnet);
 const hub = new MockHub(db, engine);
 
 let server: Server;

--- a/apps/hub/src/rpc/test/reactionService.test.ts
+++ b/apps/hub/src/rpc/test/reactionService.test.ts
@@ -1,4 +1,4 @@
-import { CastId, CastIdT, ReactionType } from '@farcaster/flatbuffers';
+import { CastId, CastIdT, FarcasterNetwork, ReactionType } from '@farcaster/flatbuffers';
 import { Factories, HubError } from '@farcaster/utils';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
@@ -12,7 +12,7 @@ import { MockHub } from '~/test/mocks';
 import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.reactionService.test');
-const engine = new Engine(db);
+const engine = new Engine(db, FarcasterNetwork.Testnet);
 const hub = new MockHub(db, engine);
 
 let server: Server;

--- a/apps/hub/src/rpc/test/signerService.test.ts
+++ b/apps/hub/src/rpc/test/signerService.test.ts
@@ -1,3 +1,4 @@
+import { FarcasterNetwork } from '@farcaster/flatbuffers';
 import { Factories, HubError } from '@farcaster/utils';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
@@ -11,7 +12,7 @@ import { MockHub } from '~/test/mocks';
 import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.signerService.test');
-const engine = new Engine(db);
+const engine = new Engine(db, FarcasterNetwork.Testnet);
 const hub = new MockHub(db, engine);
 
 let server: Server;

--- a/apps/hub/src/rpc/test/submitService.test.ts
+++ b/apps/hub/src/rpc/test/submitService.test.ts
@@ -1,4 +1,4 @@
-import { IdRegistryEventType, NameRegistryEventType } from '@farcaster/flatbuffers';
+import { FarcasterNetwork, IdRegistryEventType, NameRegistryEventType } from '@farcaster/flatbuffers';
 import { Factories, HubError } from '@farcaster/utils';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
@@ -13,7 +13,7 @@ import { MockHub } from '~/test/mocks';
 import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.submitService.test');
-const engine = new Engine(db);
+const engine = new Engine(db, FarcasterNetwork.Testnet);
 const hub = new MockHub(db, engine);
 
 let server: Server;

--- a/apps/hub/src/rpc/test/userDataService.test.ts
+++ b/apps/hub/src/rpc/test/userDataService.test.ts
@@ -1,4 +1,4 @@
-import { UserDataType } from '@farcaster/flatbuffers';
+import { FarcasterNetwork, UserDataType } from '@farcaster/flatbuffers';
 import { Factories, HubError } from '@farcaster/utils';
 import { ok } from 'neverthrow';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
@@ -14,7 +14,7 @@ import { MockHub } from '~/test/mocks';
 import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.userDataService.test');
-const engine = new Engine(db);
+const engine = new Engine(db, FarcasterNetwork.Testnet);
 const hub = new MockHub(db, engine);
 
 let server: Server;

--- a/apps/hub/src/rpc/test/verificationService.test.ts
+++ b/apps/hub/src/rpc/test/verificationService.test.ts
@@ -1,3 +1,4 @@
+import { FarcasterNetwork } from '@farcaster/flatbuffers';
 import { Factories, HubError } from '@farcaster/utils';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
@@ -11,7 +12,7 @@ import { MockHub } from '~/test/mocks';
 import { addressInfoFromParts } from '~/utils/p2p';
 
 const db = jestRocksDB('flatbuffers.rpc.verificationService.test');
-const engine = new Engine(db);
+const engine = new Engine(db, FarcasterNetwork.Testnet);
 const hub = new MockHub(db, engine);
 
 let server: Server;

--- a/apps/hub/src/storage/engine/index.test.ts
+++ b/apps/hub/src/storage/engine/index.test.ts
@@ -1,4 +1,4 @@
-import { CastId, IdRegistryEventType, NameRegistryEventType } from '@farcaster/flatbuffers';
+import { CastId, FarcasterNetwork, IdRegistryEventType, NameRegistryEventType } from '@farcaster/flatbuffers';
 import { Factories, HubError } from '@farcaster/utils';
 import { err, ok } from 'neverthrow';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
@@ -15,7 +15,7 @@ import UserDataStore from '~/storage/stores/userDataStore';
 import VerificationStore from '~/storage/stores/verificationStore';
 
 const db = jestRocksDB('flatbuffers.engine.test');
-const engine = new Engine(db);
+const engine = new Engine(db, FarcasterNetwork.Testnet);
 
 // init stores for checking state changes from engine
 const signerStore = new SignerStore(db, engine.eventHandler);
@@ -263,6 +263,12 @@ describe('mergeMessage', () => {
     test('with CastAdd', () => {
       message = castAdd;
     });
+  });
+
+  test('fails with mismatched farcaster network', async () => {
+    const mainnetEngine = new Engine(db, FarcasterNetwork.Mainnet);
+    const result = await mainnetEngine.mergeMessage(castAdd);
+    expect(result).toEqual(err(new HubError('bad_request.validation_failure', 'incorrect network')));
   });
 });
 

--- a/apps/hub/src/storage/jobs/pruneMessagesJob.test.ts
+++ b/apps/hub/src/storage/jobs/pruneMessagesJob.test.ts
@@ -1,3 +1,4 @@
+import { FarcasterNetwork } from '@farcaster/flatbuffers';
 import { Ed25519Signer, Factories } from '@farcaster/utils';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { AmpAddModel, CastAddModel } from '~/flatbuffers/models/types';
@@ -8,7 +9,7 @@ import { PruneMessagesJobScheduler } from './pruneMessagesJob';
 
 const db = jestRocksDB('jobs.pruneMessagesJob.test');
 
-const engine = new Engine(db);
+const engine = new Engine(db, FarcasterNetwork.Testnet);
 const scheduler = new PruneMessagesJobScheduler(engine);
 
 // Use farcaster timestamp

--- a/apps/hub/src/storage/jobs/revokeSignerJob.test.ts
+++ b/apps/hub/src/storage/jobs/revokeSignerJob.test.ts
@@ -1,4 +1,4 @@
-import { RevokeSignerJobPayload } from '@farcaster/flatbuffers';
+import { FarcasterNetwork, RevokeSignerJobPayload } from '@farcaster/flatbuffers';
 import { Factories, HubError } from '@farcaster/utils';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import { AmpAddModel, CastAddModel, VerificationRemoveModel } from '~/flatbuffers/models/types';
@@ -15,7 +15,7 @@ import { JobFactories } from '~/storage/jobs/utils/factories';
 const db = jestRocksDB('jobs.revokeSignerJob.test');
 
 const queue = new RevokeSignerJobQueue(db);
-const engine = new Engine(db);
+const engine = new Engine(db, FarcasterNetwork.Testnet);
 const scheduler = new RevokeSignerJobScheduler(queue, engine);
 
 // Test payloads

--- a/apps/hub/src/storage/stores/sequentialMergeStore.test.ts
+++ b/apps/hub/src/storage/stores/sequentialMergeStore.test.ts
@@ -6,7 +6,7 @@ import { seedSigner } from '~/storage/engine/seed';
 import Engine from '../engine';
 
 const db = jestRocksDB('stores.sequentialMergeStore.test');
-const engine = new Engine(db);
+const engine = new Engine(db, flatbuffers.FarcasterNetwork.Testnet);
 
 const fid = Factories.FID.build();
 const signer = Factories.Ed25519Signer.build();

--- a/apps/hub/src/storage/stores/userDataStore.test.ts
+++ b/apps/hub/src/storage/stores/userDataStore.test.ts
@@ -1,4 +1,4 @@
-import { NameRegistryEventType, UserDataType } from '@farcaster/flatbuffers';
+import { FarcasterNetwork, NameRegistryEventType, UserDataType } from '@farcaster/flatbuffers';
 import { bytesIncrement, Factories, getFarcasterTime, HubError } from '@farcaster/utils';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
@@ -252,7 +252,7 @@ describe('userfname', () => {
 
   test('fails with a different custody address', async () => {
     // Merging it via the engine will fail validation
-    const engine = new Engine(db);
+    const engine = new Engine(db, FarcasterNetwork.Testnet);
 
     await engine.mergeIdRegistryEvent(custody1Event);
     await engine.mergeNameRegistryEvent(nameRegistryModelEvent);

--- a/apps/hub/src/test/mocks.ts
+++ b/apps/hub/src/test/mocks.ts
@@ -1,3 +1,4 @@
+import { FarcasterNetwork } from '@farcaster/flatbuffers';
 import { HubAsyncResult, HubError } from '@farcaster/utils';
 import { ResultAsync } from 'neverthrow';
 import HubStateModel from '~/flatbuffers/models/hubStateModel';
@@ -14,7 +15,7 @@ export class MockHub implements HubInterface {
 
   constructor(db: RocksDB, engine: Engine) {
     this.db = db;
-    this.engine = engine ?? new Engine(db);
+    this.engine = engine ?? new Engine(db, FarcasterNetwork.Testnet);
   }
 
   async submitMessage(message: MessageModel): HubAsyncResult<void> {


### PR DESCRIPTION
## Motivation

Farcaster messages include a farcaster network (testnet, devnet, mainnet) in the message data. The engine should validate that messages being merged match their own network. Closes #321 

## Change Summary

* Update cli to accept `--network` for farcaster network (mainnet = 1, testnet = 2, devnet = 3)
* Move cli eth RPC url argument from `--network-url` to `--eth-rpc-url` 
* Add check for network in engine's `validateMessage` method

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
