### PR TITLE
fix: Some removed messages weren't getting removed in the Trie

### DIFF
--- a/apps/hub/src/storage/stores/ampStore.ts
+++ b/apps/hub/src/storage/stores/ampStore.ts
@@ -333,6 +333,8 @@ class AmpStore extends SequentialMergeStore {
     ampId: Uint8Array,
     message: AmpAddModel | AmpRemoveModel
   ): Promise<{ tsx: Transaction | undefined; removedAmps: AmpAddModel[] }> {
+    const removedAmps: AmpAddModel[] = [];
+
     // Look up the remove tsHash for this amp
     const ampRemoveTsHash = await ResultAsync.fromPromise(
       this._db.get(AmpStore.ampRemovesKey(message.fid(), ampId)),
@@ -353,6 +355,7 @@ class AmpStore extends SequentialMergeStore {
           ampRemoveTsHash.value
         );
         tsx = this.deleteAmpRemoveTransaction(tsx, existingRemove);
+        removedAmps.push(existingRemove);
       }
     }
 
@@ -362,7 +365,6 @@ class AmpStore extends SequentialMergeStore {
       () => undefined
     );
 
-    const removedAmps: AmpAddModel[] = [];
     if (ampAddTsHash.isOk()) {
       if (this.ampMessageCompare(MessageType.AmpAdd, ampAddTsHash.value, message.type(), message.tsHash()) >= 0) {
         // If the existing add has the same or higher order than the new message, no-op


### PR DESCRIPTION
## Motivation

Some messages that were removed (as a part of `resolveMergeConflicts` methods weren't getting removed from the SyncTrie

## Change Summary

- Keep track of deleted messages and remove them from the Sync Trie.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
