### PR TITLE
chore: fix and suppress eslint warnings

### DIFF
--- a/apps/hub/src/network/sync/merkleTrie.test.ts
+++ b/apps/hub/src/network/sync/merkleTrie.test.ts
@@ -80,11 +80,13 @@ describe('MerkleTrie', () => {
       trie.insert(syncId);
       expect(trie.items).toEqual(1);
       expect(trie.rootHash).toBeTruthy();
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(trie.exists(syncId)).toBeTruthy();
 
       trie.delete(syncId);
       expect(trie.items).toEqual(0);
       expect(trie.rootHash).toEqual(EMPTY_HASH);
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(trie.exists(syncId)).toBeFalsy();
     });
 
@@ -139,13 +141,16 @@ describe('MerkleTrie', () => {
     const trie = new MerkleTrie();
     const syncId = await NetworkFactories.SyncId.create();
 
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(trie.exists(syncId)).toBeFalsy();
 
     trie.insert(syncId);
 
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(trie.exists(syncId)).toBeTruthy();
 
     const nonExistingSyncId = await NetworkFactories.SyncId.create();
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(trie.exists(nonExistingSyncId)).toBeFalsy();
   });
 

--- a/apps/hub/src/network/sync/merkleTrie.ts
+++ b/apps/hub/src/network/sync/merkleTrie.ts
@@ -50,6 +50,8 @@ class MerkleTrie {
   }
 
   public exists(id: SyncId): boolean {
+    // NOTE: eslint falsely identifies as `fs.exists`.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     return this._root.exists(id.idString());
   }
 

--- a/apps/hub/src/network/sync/merkleTrie.ts
+++ b/apps/hub/src/network/sync/merkleTrie.ts
@@ -64,6 +64,8 @@ class MerkleTrie {
   public getDivergencePrefix(prefix: string, excludedHashes: string[]): string {
     const ourExcludedHashes = this.getSnapshot(prefix).excludedHashes;
     for (let i = 0; i < prefix.length; i++) {
+      // NOTE: `i` is controlled by for loop and hence not at risk of object injection.
+      // eslint-disable-next-line security/detect-object-injection
       if (ourExcludedHashes[i] !== excludedHashes[i]) {
         return prefix.slice(0, i);
       }

--- a/apps/hub/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hub/src/network/sync/multiPeerSyncEngine.test.ts
@@ -206,7 +206,9 @@ describe('Multi peer sync engine', () => {
     await syncEngine2.performSync([], clientForServer1);
 
     // Make sure the castAdd is in the trie
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(syncEngine1.trie.exists(new SyncId(castAdd))).toBeTruthy();
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(syncEngine2.trie.exists(new SyncId(castAdd))).toBeTruthy();
 
     // Remove the cast
@@ -224,8 +226,10 @@ describe('Multi peer sync engine', () => {
     expect(result.isOk()).toBeTruthy();
 
     const castRemoveId = new SyncId(castRemove);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(syncEngine1.trie.exists(castRemoveId)).toBeTruthy();
     // The trie should not contain the castAdd anymore
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(syncEngine1.trie.exists(new SyncId(castAdd))).toBeFalsy();
 
     // Syncing engine2 --> engine1 should do nothing, even though engine2 has the castAdd and it has been removed
@@ -244,12 +248,15 @@ describe('Multi peer sync engine', () => {
     }
 
     // castRemove doesn't yet exist in engine2
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(syncEngine2.trie.exists(castRemoveId)).toBeFalsy();
 
     // Syncing engine2 with engine1 should delete the castAdd from the trie and add the castRemove
     await syncEngine2.performSync(syncEngine1.snapshot.excludedHashes, clientForServer1);
 
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(syncEngine2.trie.exists(castRemoveId)).toBeTruthy();
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(syncEngine2.trie.exists(new SyncId(castAdd))).toBeFalsy();
     expect(syncEngine2.trie.rootHash).toEqual(syncEngine1.trie.rootHash);
 

--- a/apps/hub/src/network/sync/syncEngine.test.ts
+++ b/apps/hub/src/network/sync/syncEngine.test.ts
@@ -81,6 +81,7 @@ describe('SyncEngine', () => {
 
     // Two messages (signerAdd + castAdd) was added to the trie
     expect(syncEngine.trie.items - existingItems).toEqual(2);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(syncEngine.trie.exists(new SyncId(castAdd))).toBeTruthy();
   });
 
@@ -92,6 +93,7 @@ describe('SyncEngine', () => {
 
     expect(result.isErr()).toBeTruthy();
     expect(syncEngine.trie.items).toEqual(0);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(syncEngine.trie.exists(new SyncId(castAdd))).toBeFalsy();
   });
 
@@ -116,6 +118,7 @@ describe('SyncEngine', () => {
     expect(result.isOk()).toBeTruthy();
 
     const id = new SyncId(castRemove);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(syncEngine.trie.exists(id)).toBeTruthy();
 
     const allMessages = await engine.getAllMessagesBySyncIds([id.idString()]);
@@ -123,9 +126,11 @@ describe('SyncEngine', () => {
     expect(allMessages._unsafeUnwrap()[0]?.type()).toEqual(MessageType.CastRemove);
 
     // The trie should contain the message remove
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(syncEngine.trie.exists(id)).toBeTruthy();
 
     // The trie should not contain the castAdd anymore
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(syncEngine.trie.exists(new SyncId(castAdd))).toBeFalsy();
   });
 
@@ -251,8 +256,11 @@ describe('SyncEngine', () => {
     // There might be more messages related to user creation, but it's sufficient to check for casts
     expect(syncEngine.trie.items).toBeGreaterThanOrEqual(3);
     expect(syncEngine.trie.rootHash).toBeTruthy();
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(syncEngine.trie.exists(new SyncId(messages[0] as MessageModel))).toBeTruthy();
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(syncEngine.trie.exists(new SyncId(messages[1] as MessageModel))).toBeTruthy();
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(syncEngine.trie.exists(new SyncId(messages[2] as MessageModel))).toBeTruthy();
   });
 });

--- a/apps/hub/src/network/sync/syncEngine.ts
+++ b/apps/hub/src/network/sync/syncEngine.ts
@@ -73,6 +73,8 @@ class SyncEngine {
     const ourSnapshot = this.snapshot;
     const excludedHashesMatch =
       ourSnapshot.excludedHashes.length === excludedHashes.length &&
+      // NOTE: `index` is controlled by `every` and so not at risk of object injection.
+      // eslint-disable-next-line security/detect-object-injection
       ourSnapshot.excludedHashes.every((value, index) => value === excludedHashes[index]);
 
     log.debug(`shouldSync: excluded hashes check: ${excludedHashes}`);

--- a/apps/hub/src/network/sync/trieNode.test.ts
+++ b/apps/hub/src/network/sync/trieNode.test.ts
@@ -82,6 +82,7 @@ describe('TrieNode', () => {
       const hash2 = id2.idString();
 
       // The node at which the trie splits should be the first character that differs between the two hashes
+      // eslint-disable-next-line security/detect-object-injection
       const firstDiffPos = hash1.split('').findIndex((c, i) => c !== hash2[i]);
 
       const root = new TrieNode();
@@ -95,10 +96,12 @@ describe('TrieNode', () => {
       const secondChild = children[1] as [string, TrieNode];
       expect(children.length).toEqual(2);
       // hash1 node
+      // eslint-disable-next-line security/detect-object-injection
       expect(firstChild[0]).toEqual(hash1[firstDiffPos]);
       expect(firstChild[1].isLeaf).toBeTruthy();
       expect(firstChild[1].value).toEqual(id1.idString());
       // hash2 node
+      // eslint-disable-next-line security/detect-object-injection
       expect(secondChild[0]).toEqual(hash2[firstDiffPos]);
       expect(secondChild[1].isLeaf).toBeTruthy();
       expect(secondChild[1].value).toEqual(id2.idString());
@@ -130,6 +133,7 @@ describe('TrieNode', () => {
 
       root.delete(id2.idString());
       expect(root.items).toEqual(1);
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(root.exists(id2.idString())).toBeFalsy();
       expect(root.hash).toEqual(previousHash);
     });
@@ -166,6 +170,7 @@ describe('TrieNode', () => {
       root.insert(id.idString());
       expect(root.items).toEqual(1);
 
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(root.exists(id.idString())).toBeTruthy();
     });
 
@@ -177,6 +182,7 @@ describe('TrieNode', () => {
       expect(root.items).toEqual(1);
 
       root.delete(id.idString());
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(root.exists(id.idString())).toBeFalsy();
       expect(root.items).toEqual(0);
     });
@@ -193,6 +199,7 @@ describe('TrieNode', () => {
       root.insert(id1.idString());
 
       // id2 shares the same prefix, but doesn't exist, so it should return undefined
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(root.exists(id2.idString())).toBeFalsy();
     });
   });

--- a/apps/hub/src/network/sync/trieNode.ts
+++ b/apps/hub/src/network/sync/trieNode.ts
@@ -142,6 +142,8 @@ class TrieNode {
       return false;
     }
 
+    // NOTE: eslint falsely identifies as `fs.exists`.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     return this._children.get(char)?.exists(key, current_index + 1) || false;
   }
 

--- a/apps/hub/src/storage/db/rocksdb.ts
+++ b/apps/hub/src/storage/db/rocksdb.ts
@@ -87,6 +87,8 @@ class RocksDB {
       } else {
         mkdir(this._db.location, { recursive: true }, (fsErr: Error | null) => {
           if (fsErr) reject(parseError(fsErr));
+          // NOTE: eslint falsely identifies `open(...)` as `fs.open`.
+          // eslint-disable-next-line security/detect-non-literal-fs-filename
           this._db.open({ createIfMissing: true, errorIfExists: false }, (e?: Error) => {
             if (!e) {
               this._hasOpened = true;


### PR DESCRIPTION
## Motivation

Fix #163 review and fix or suppress eslint-security warnings

## Change Summary

Suppress all eslint warnings since they are false positives. Based on PR by @TimDaub. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)

