### PR TITLE
fix: Merge queue would get deadlocked

### DIFF
--- a/apps/hub/src/storage/stores/sequentialMergeStore.ts
+++ b/apps/hub/src/storage/stores/sequentialMergeStore.ts
@@ -64,7 +64,7 @@ abstract class SequentialMergeStore extends TypedEmitter<MergeProcessingEvents> 
     });
   }
 
-  protected async processMerges(): HubAsyncResult<void> {
+  private async processMerges(): HubAsyncResult<void> {
     this._mergeIsProcessing = true;
 
     while (this._mergeIdsQueue.length > 0) {
@@ -82,7 +82,7 @@ abstract class SequentialMergeStore extends TypedEmitter<MergeProcessingEvents> 
     return ok(undefined);
   }
 
-  protected async processMergeId(nextMergeId?: string): HubAsyncResult<void> {
+  private async processMergeId(nextMergeId?: string): HubAsyncResult<void> {
     // If mergeId is missing, return not found
     if (!nextMergeId) {
       return err(new HubError('not_found', 'next mergeId not found'));
@@ -91,13 +91,13 @@ abstract class SequentialMergeStore extends TypedEmitter<MergeProcessingEvents> 
     // Get message for next mergeId
     const nextMessage = this._mergeIdsStore.get(nextMergeId);
 
-    // Delete processed merge from store immediately, so it doesn't leak memory if the merge is cancelled
-    this._mergeIdsStore.delete(nextMergeId);
-
     // If message is missing, it means the merge was cancelled, so no-op
     if (!nextMessage) {
       return ok(undefined);
     }
+
+    // Delete processed merge from store immediately, so it doesn't leak memory if the merge is cancelled
+    this._mergeIdsStore.delete(nextMergeId);
 
     // Process merge and emit event with result
     const mergeResult = await ResultAsync.fromPromise(this.mergeFromSequentialQueue(nextMessage), (e) => e as HubError);


### PR DESCRIPTION
## Motivation

The merge queue would sometimes get deadlocked when processing bad messages (i.e., Messages that would return errors when merged).

Two related issues: 
1. When a Message that returns an error when merged is submitted, it fails to merge as expected, but doesn't get removed from the merge queue, so all subsequent messages get stuck behind this failed message
2. If the `processNextMerge` fails, the `processMerges` returns but doesn't set the `mergeIsProcessing` to false, causing a deadlock which prevents any further messages from being merged. 


## Change Summary

- Deque mergeIds from the merge queue before processing
- Set `mergeIsProcessing` to false when returning with error

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)

