### PR TITLE
fix: Interpret fname Uint8Array as littleEndian

### DIFF
--- a/apps/hub/src/rpc/test/userDataService.test.ts
+++ b/apps/hub/src/rpc/test/userDataService.test.ts
@@ -1,5 +1,5 @@
 import { FarcasterNetwork, UserDataType } from '@farcaster/flatbuffers';
-import { Factories, HubError } from '@farcaster/utils';
+import { bytesToUtf8String, Factories, HubError } from '@farcaster/utils';
 import { ok } from 'neverthrow';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
@@ -73,7 +73,7 @@ beforeAll(async () => {
 
   const addNameData = await Factories.UserDataAddData.create({
     fid: Array.from(fid),
-    body: Factories.UserDataBody.build({ type: UserDataType.Fname, value: new TextDecoder().decode(fname) }),
+    body: Factories.UserDataBody.build({ type: UserDataType.Fname, value: bytesToUtf8String(fname)._unsafeUnwrap() }),
   });
   addFname = new MessageModel(
     await Factories.Message.create({ data: Array.from(addNameData.bb?.bytes() ?? []) }, { transient: { signer } })

--- a/apps/hub/src/storage/engine/index.ts
+++ b/apps/hub/src/storage/engine/index.ts
@@ -1,5 +1,13 @@
 import * as flatbuffers from '@farcaster/flatbuffers';
-import { bytesCompare, bytesToNumber, HubAsyncResult, HubError, HubResult, validations } from '@farcaster/utils';
+import {
+  bytesCompare,
+  bytesToNumber,
+  HubAsyncResult,
+  HubError,
+  HubResult,
+  utf8StringToBytes,
+  validations,
+} from '@farcaster/utils';
 import { err, errAsync, ok, ResultAsync } from 'neverthrow';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel, { FID_BYTES } from '~/flatbuffers/models/messageModel';
@@ -522,7 +530,7 @@ class Engine {
     // 4. For fname add UserDataAdd messages, check that the user actually owns the fname
     if (isUserDataAdd(message) && message.body().type() == flatbuffers.UserDataType.Fname) {
       // For fname messages, check if the user actually owns the fname.
-      const fname = new TextEncoder().encode(message.body().value() ?? '');
+      const fname = utf8StringToBytes(message.body().value() ?? '')._unsafeUnwrap();
 
       // Users are allowed to set fname = '' to remove their fname, so check to see if fname is set
       // before validating the custody address

--- a/apps/hub/src/storage/stores/userDataStore.test.ts
+++ b/apps/hub/src/storage/stores/userDataStore.test.ts
@@ -1,5 +1,5 @@
 import { FarcasterNetwork, NameRegistryEventType, UserDataType } from '@farcaster/flatbuffers';
-import { bytesIncrement, Factories, getFarcasterTime, HubError } from '@farcaster/utils';
+import { bytesIncrement, bytesToUtf8String, Factories, getFarcasterTime, HubError } from '@farcaster/utils';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
 import MessageModel from '~/flatbuffers/models/messageModel';
 import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel';
@@ -64,7 +64,7 @@ beforeAll(async () => {
 
   const addNameData = await Factories.UserDataAddData.create({
     fid: Array.from(fid),
-    body: Factories.UserDataBody.build({ type: UserDataType.Fname, value: new TextDecoder().decode(fname) }),
+    body: Factories.UserDataBody.build({ type: UserDataType.Fname, value: bytesToUtf8String(fname)._unsafeUnwrap() }),
   });
   addFname = new MessageModel(
     await Factories.Message.create({ data: Array.from(addNameData.bb?.bytes() ?? []) }, { transient: { signer } })

--- a/packages/utils/src/validations.test.ts
+++ b/packages/utils/src/validations.test.ts
@@ -58,7 +58,7 @@ describe('validateFname', () => {
   test('fails when greater than 16 characters', () => {
     const fname = faker.random.alpha(17);
     expect(validations.validateFname(fname)).toEqual(
-      err(new HubError('bad_request.validation_failure', 'fname > 16 characters'))
+      err(new HubError('bad_request.validation_failure', `fname "${fname}" > 16 characters`))
     );
   });
 
@@ -78,7 +78,7 @@ describe('validateFname', () => {
   test('fails with invalid characters', () => {
     const fname = '@fname';
     expect(validations.validateFname(fname)).toEqual(
-      err(new HubError('bad_request.validation_failure', `fname doesn't match ${validations.FNAME_REGEX}`))
+      err(new HubError('bad_request.validation_failure', `fname "${fname}" doesn't match ${validations.FNAME_REGEX}`))
     );
   });
 });

--- a/packages/utils/src/validations.ts
+++ b/packages/utils/src/validations.ts
@@ -468,12 +468,12 @@ export const validateFname = <T extends string | Uint8Array>(fnameP?: T | null):
   }
 
   if (fname.length > 16) {
-    return err(new HubError('bad_request.validation_failure', 'fname > 16 characters'));
+    return err(new HubError('bad_request.validation_failure', `fname "${fname}" > 16 characters`));
   }
 
   const hasValidChars = FNAME_REGEX.test(fname);
   if (hasValidChars === false) {
-    return err(new HubError('bad_request.validation_failure', `fname doesn't match ${FNAME_REGEX}`));
+    return err(new HubError('bad_request.validation_failure', `fname "${fname}" doesn't match ${FNAME_REGEX}`));
   }
 
   return ok(fnameP);


### PR DESCRIPTION
## Motivation
Fix a bug where the the fname Uint8Array was not being interpreted as little endian.

Switch to using a plain Uint8Array.

## Change Summary
- Uint8Array as little endian string.
- Show the actual fname in error messages that was failing validation

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
