### PR TITLE
fix: docker builds are broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,6 @@ coverage/
 
 # Turborepo
 .turbo
+out
 
 dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,28 +2,46 @@
 # https://github.com/goldbergyoni/nodebestpractices/blob/master/sections/docker/multi_stage_builds.md
 
 ###############################################################################
-############## Stage 1: Build the code using a full node image ################
+############## Stage 1: Create pruned version of monorepo #####################
+###############################################################################
+
+FROM node:18 AS prune
+
+USER node
+RUN mkdir /home/node/app
+WORKDIR /home/node/app
+
+# Run turbo prune to create a pruned version of monorepo
+RUN yarn global add turbo
+COPY --chown=node:node . .
+RUN /home/node/.yarn/bin/turbo prune --scope=@farcaster/hub --docker
+
+###############################################################################
+############## Stage 2: Build the code using a full node image ################
 ###############################################################################
 
 FROM node:18 AS build
 
 USER node
+RUN mkdir /home/node/app
 WORKDIR /home/node/app
 
 # Copy dependency information and install all dependencies
-COPY --chown=node:node tsconfig.json package.json yarn.lock ./
+COPY --chown=node:node --from=prune /home/node/app/out/json/ .
+COPY --chown=node:node --from=prune /home/node/app/out/yarn.lock ./yarn.lock
 
 RUN yarn install --frozen-lockfile --network-timeout 1800000
 
 # Copy source code (and all other relevant files)
-COPY --chown=node:node src ./src
-COPY --chown=node:node .config ./.config
+COPY --chown=node:node --from=prune /home/node/app/out/full/ .
+# turbo prune doesn't include global tsconfig.json (https://github.com/vercel/turbo/issues/2177)
+COPY --chown=node:node tsconfig.json tsconfig.json
 
 # Build code
 RUN yarn build
 
 ###############################################################################
-########## Stage 2: Copy over the built code to a leaner alpine image #########
+########## Stage 3: Copy over the built code to a leaner alpine image #########
 ###############################################################################
 
 FROM node:18-alpine
@@ -37,22 +55,26 @@ EXPOSE 8080
 # Many npm packages use this to trigger production optimized behaviors
 ENV NODE_ENV production
 
+RUN mkdir /home/node/app
 WORKDIR /home/node/app
 
 # Copy dependency information and install dependencies
-COPY --chown=node:node tsconfig.json package.json yarn.lock ./
+COPY --chown=node:node --from=prune /home/node/app/out/json/ .
+COPY --chown=node:node --from=prune /home/node/app/out/yarn.lock ./yarn.lock
 
 RUN yarn install --frozen-lockfile --production --network-timeout 1800000
 
 # Copy results from previous stage
-COPY --chown=node:node --from=build /home/node/app/build ./build
-COPY --chown=node:node --from=build /home/node/app/.config ./.config
+COPY --chown=node:node --from=build /home/node/app/packages/flatbuffers/dist ./packages/flatbuffers/dist
+COPY --chown=node:node --from=build /home/node/app/packages/grpc/dist ./packages/grpc/dist
+COPY --chown=node:node --from=build /home/node/app/packages/utils/dist ./packages/utils/dist
+COPY --chown=node:node tsconfig.json tsconfig.json
 
-# TODO: determine if this can be removed while using tsx (or find alternative) 
+# TODO: determine if this can be removed while using tsx (or find alternative)
 # since we should be able to run with just the compiled javascript in build/
-COPY --chown=node:node --from=build /home/node/app/src ./src
+COPY --chown=node:node ./apps/hub ./apps/hub
 
 # TODO: load identity from some secure store instead of generating a new one
-RUN yarn identity create
+RUN yarn --cwd=apps/hub identity create
 
-CMD ["yarn", "tsx", "src/cli.ts", "start", "--rpc-port", "8080", "--gossip-port", "9090" ]
+CMD ["yarn", "--cwd=apps/hub", "start", "--rpc-port", "8080", "--gossip-port", "9090" ]


### PR DESCRIPTION
## Motivation

Fix #347 broken docker builds

## Change Summary

- Update Dockerfile according to monorepo structure
- Use `turbo prune` to optimize docker build

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)

## Additional Context

Currently, the Docker build attempt to run `yarn build`, which compiles Typescript files into Javascript. But in the last stage of the Dockerfile, TS code of the hub is copied into the image and it is run with `tsx` instead of the JS compiled files.

I believed it is done in this way because the hub uses tsconfig's path aliases (i.e. `compilerOptions.paths`) to map `~` to the project root but this mapping isn't carried into the JS files generated by `tsc`. Therefore, the compiled JS files of hub can't be run directly with node because node can't resolve the imports.

I tried to add wrapper scripts to override the default module resolution to follow tsx behavior. It works but the code is more complex than I would prefer. So, this PR keeps the existing behavior (i.e. using tsx).
