### PR TITLE
test: add tests for deserializeIdRegistryEvents and deserializeNameRegistryEvents

### DIFF
--- a/packages/js/src/utils.test.ts
+++ b/packages/js/src/utils.test.ts
@@ -632,3 +632,121 @@ describe('deserializeMessage', () => {
     expect(message.signer).toEqual(ed25519Signer.signerKeyHex);
   });
 });
+
+describe('deserializeNameRegistryEvent', () => {
+  let nameRegistryEventFbb: flatbuffers.NameRegistryEvent;
+  let nameRegistryEvent: types.NameRegistryEvent;
+
+  beforeAll(async () => {
+    nameRegistryEventFbb = await Factories.NameRegistryEvent.create();
+    nameRegistryEvent = utils.deserializeNameRegistryEvent(nameRegistryEventFbb)._unsafeUnwrap();
+  });
+
+  test('flatbuffer', () => {
+    expect(nameRegistryEvent.flatbuffer).toEqual(nameRegistryEventFbb);
+  });
+
+  test('blockNumber', () => {
+    expect(nameRegistryEvent.blockNumber).toEqual(nameRegistryEventFbb.blockNumber());
+  });
+
+  test('blockHash', () => {
+    expect(nameRegistryEvent.blockHash).toEqual(
+      bytesToHexString(nameRegistryEventFbb.blockHashArray() ?? new Uint8Array())._unsafeUnwrap()
+    );
+  });
+
+  test('transactionHash', () => {
+    expect(nameRegistryEvent.transactionHash).toEqual(
+      bytesToHexString(nameRegistryEventFbb.transactionHashArray() ?? new Uint8Array())._unsafeUnwrap()
+    );
+  });
+
+  test('logIndex', () => {
+    expect(nameRegistryEvent.logIndex).toEqual(nameRegistryEventFbb.logIndex());
+  });
+
+  test('fname', () => {
+    expect(nameRegistryEvent.fname).toEqual(
+      utils.deserializeFname(nameRegistryEventFbb.fnameArray() ?? new Uint8Array())._unsafeUnwrap()
+    );
+  });
+
+  test('to', () => {
+    expect(nameRegistryEvent.to).toEqual(
+      bytesToHexString(nameRegistryEventFbb.toArray() ?? new Uint8Array())._unsafeUnwrap()
+    );
+  });
+
+  test('from', () => {
+    expect(nameRegistryEvent.from).toEqual(
+      bytesToHexString(nameRegistryEventFbb.fromArray() ?? new Uint8Array())._unsafeUnwrap()
+    );
+  });
+
+  test('type', () => {
+    expect(nameRegistryEvent.type).toEqual(nameRegistryEventFbb.type());
+  });
+
+  test('expiry', () => {
+    expect(nameRegistryEvent.expiry).toEqual(
+      bytesToNumber(nameRegistryEventFbb.expiryArray() ?? new Uint8Array())._unsafeUnwrap()
+    );
+  });
+});
+
+describe('deserializeIdRegistryEvent', () => {
+  let idRegistryEventFbb: flatbuffers.IdRegistryEvent;
+  let idRegistryEvent: types.IdRegistryEvent;
+
+  beforeAll(async () => {
+    idRegistryEventFbb = await Factories.IdRegistryEvent.create();
+    idRegistryEvent = utils.deserializeIdRegistryEvent(idRegistryEventFbb)._unsafeUnwrap();
+  });
+
+  test('flatbuffer', () => {
+    expect(idRegistryEvent.flatbuffer).toEqual(idRegistryEventFbb);
+  });
+
+  test('blockNumber', () => {
+    expect(idRegistryEvent.blockNumber).toEqual(idRegistryEventFbb.blockNumber());
+  });
+
+  test('blockHash', () => {
+    expect(idRegistryEvent.blockHash).toEqual(
+      bytesToHexString(idRegistryEventFbb.blockHashArray() ?? new Uint8Array())._unsafeUnwrap()
+    );
+  });
+
+  test('transactionHash', () => {
+    expect(idRegistryEvent.transactionHash).toEqual(
+      bytesToHexString(idRegistryEventFbb.transactionHashArray() ?? new Uint8Array())._unsafeUnwrap()
+    );
+  });
+
+  test('logIndex', () => {
+    expect(idRegistryEvent.logIndex).toEqual(idRegistryEventFbb.logIndex());
+  });
+
+  test('fid', () => {
+    expect(idRegistryEvent.fid).toEqual(
+      utils.deserializeFid(idRegistryEventFbb.fidArray() ?? new Uint8Array())._unsafeUnwrap()
+    );
+  });
+
+  test('to', () => {
+    expect(idRegistryEvent.to).toEqual(
+      bytesToHexString(idRegistryEventFbb.toArray() ?? new Uint8Array())._unsafeUnwrap()
+    );
+  });
+
+  test('from', () => {
+    expect(idRegistryEvent.from).toEqual(
+      bytesToHexString(idRegistryEventFbb.fromArray() ?? new Uint8Array())._unsafeUnwrap()
+    );
+  });
+
+  test('type', () => {
+    expect(idRegistryEvent.type).toEqual(idRegistryEventFbb.type());
+  });
+});

--- a/packages/js/src/utils.test.ts
+++ b/packages/js/src/utils.test.ts
@@ -40,6 +40,60 @@ describe('serializeFid', () => {
   }
 });
 
+describe('deserializeBlockHash', () => {
+  const blockHash = Factories.BlockHash.build();
+  const blockHashBytes = hexStringToBytes(blockHash)._unsafeUnwrap();
+
+  test(`succeeds`, () => {
+    expect(utils.deserializeBlockHash(blockHashBytes)).toEqual(ok(blockHash));
+  });
+});
+
+describe('serializeBlockHash', () => {
+  const blockHash = Factories.BlockHash.build();
+  const blockHashBytes = hexStringToBytes(blockHash)._unsafeUnwrap();
+
+  test(`succeeds`, () => {
+    expect(utils.serializeBlockHash(blockHash)).toEqual(ok(blockHashBytes));
+  });
+});
+
+describe('deserializeTransactionHash', () => {
+  const transactionHash = Factories.TransactionHash.build();
+  const transactionHashBytes = hexStringToBytes(transactionHash)._unsafeUnwrap();
+
+  test(`succeeds`, () => {
+    expect(utils.deserializeTransactionHash(transactionHashBytes)).toEqual(ok(transactionHash));
+  });
+});
+
+describe('serializeEip712Signature', () => {
+  const signatureBytes = Factories.Bytes.build(undefined, { transient: { length: 65 } });
+  const signature = bytesToHexString(signatureBytes)._unsafeUnwrap();
+
+  test(`succeeds`, () => {
+    expect(utils.serializeEip712Signature(signature)).toEqual(ok(signatureBytes));
+  });
+});
+
+describe('serializeEip712Signature', () => {
+  const signatureBytes = Factories.Bytes.build(undefined, { transient: { length: 65 } });
+  const signature = bytesToHexString(signatureBytes)._unsafeUnwrap();
+
+  test(`succeeds`, () => {
+    expect(utils.deserializeEip712Signature(signatureBytes)).toEqual(ok(signature));
+  });
+});
+
+describe('deserializeEd25519Signature', () => {
+  const signatureBytes = Factories.Bytes.build(undefined, { transient: { length: 64 } });
+  const signature = bytesToHexString(signatureBytes)._unsafeUnwrap();
+
+  test(`succeeds`, () => {
+    expect(utils.deserializeEd25519Signature(signatureBytes)).toEqual(ok(signature));
+  });
+});
+
 describe('deserializeFname', () => {
   const fname = Factories.Fname.build();
   test(`succeeds`, () => {
@@ -87,7 +141,7 @@ describe('serializeEd25519PublicKey', () => {
 });
 
 const tsHash = Factories.TsHash.build();
-const tsHashHex = bytesToHexString(tsHash, { size: 40 })._unsafeUnwrap();
+const tsHashHex = utils.deserializeTsHash(tsHash)._unsafeUnwrap();
 
 describe('deserializeTsHash', () => {
   test('succeeds', () => {
@@ -145,12 +199,12 @@ describe('deserializeCastAddBody', () => {
   const embed2 = faker.internet.url();
   const mentionfid1 = Factories.FID.build();
   const mentionFid2 = Factories.FID.build();
-  const mentionFid1Number = bytesToNumber(mentionfid1)._unsafeUnwrap();
-  const mentionFid2Number = bytesToNumber(mentionFid2)._unsafeUnwrap();
+  const mentionFid1Number = utils.deserializeFid(mentionfid1)._unsafeUnwrap();
+  const mentionFid2Number = utils.deserializeFid(mentionFid2)._unsafeUnwrap();
   const parentFid = Factories.FID.build();
-  const parentFidNumber = bytesToNumber(parentFid)._unsafeUnwrap();
+  const parentFidNumber = utils.deserializeFid(parentFid)._unsafeUnwrap();
   const tsHash = Factories.TsHash.build();
-  const tsHashHex = bytesToHexString(tsHash, { size: 40 })._unsafeUnwrap();
+  const tsHashHex = utils.deserializeTsHash(tsHash)._unsafeUnwrap();
 
   beforeAll(async () => {
     serializedCastAddBody = await Factories.CastAddBody.create({
@@ -212,8 +266,8 @@ describe('deserializeMentions', () => {
   let castAddBody: CastAddBody;
   const fid1 = Factories.FID.build();
   const fid2 = Factories.FID.build();
-  const fid1Number = bytesToNumber(fid1)._unsafeUnwrap();
-  const fid2Number = bytesToNumber(fid2)._unsafeUnwrap();
+  const fid1Number = utils.deserializeFid(fid1)._unsafeUnwrap();
+  const fid2Number = utils.deserializeFid(fid2)._unsafeUnwrap();
 
   beforeAll(async () => {
     castAddBody = await Factories.CastAddBody.create({
@@ -234,9 +288,9 @@ describe('deserializeMentions', () => {
 describe('deserializeTarget', () => {
   let castAddBody: CastAddBody;
   const fid = Factories.FID.build();
-  const fidNumber = bytesToNumber(fid)._unsafeUnwrap();
+  const fidNumber = utils.deserializeFid(fid)._unsafeUnwrap();
   const tsHash = Factories.TsHash.build();
-  const tsHashHex = bytesToHexString(tsHash, { size: 40 })._unsafeUnwrap();
+  const tsHashHex = utils.deserializeTsHash(tsHash)._unsafeUnwrap();
 
   beforeAll(async () => {
     castAddBody = await Factories.CastAddBody.create({
@@ -260,12 +314,12 @@ describe('serializeCastBodyAdd', () => {
   const embed2 = faker.internet.url();
   const mentionFid1 = Factories.FID.build();
   const mentionFid2 = Factories.FID.build();
-  const mentionFid1Number = bytesToNumber(mentionFid1)._unsafeUnwrap();
-  const mentionFid2Number = bytesToNumber(mentionFid2)._unsafeUnwrap();
+  const mentionFid1Number = utils.deserializeFid(mentionFid1)._unsafeUnwrap();
+  const mentionFid2Number = utils.deserializeFid(mentionFid2)._unsafeUnwrap();
   const parentFid = Factories.FID.build();
-  const parentFidNumber = bytesToNumber(parentFid)._unsafeUnwrap();
+  const parentFidNumber = utils.deserializeFid(parentFid)._unsafeUnwrap();
   const tsHash = Factories.TsHash.build();
-  const tsHashHex = bytesToHexString(tsHash, { size: 40 })._unsafeUnwrap();
+  const tsHashHex = utils.deserializeTsHash(tsHash)._unsafeUnwrap();
   const castAddBody = utils
     .serializeCastAddBody({
       text,
@@ -303,7 +357,7 @@ describe('serializeCastBodyAdd', () => {
 describe('deserializeCastRemoveBody', () => {
   let castRemoveBody: flatbuffers.CastRemoveBody;
   const tsHash = Factories.TsHash.build();
-  const tsHashHex = bytesToHexString(tsHash, { size: 40 })._unsafeUnwrap();
+  const tsHashHex = utils.deserializeTsHash(tsHash)._unsafeUnwrap();
 
   beforeAll(async () => {
     castRemoveBody = await Factories.CastRemoveBody.create({ targetTsHash: Array.from(tsHash) });
@@ -316,7 +370,7 @@ describe('deserializeCastRemoveBody', () => {
 
 describe('serializeAmpBody', () => {
   const fid = Factories.FID.build();
-  const fidNumber = bytesToNumber(fid)._unsafeUnwrap();
+  const fidNumber = utils.deserializeFid(fid)._unsafeUnwrap();
   const body = utils
     .serializeAmpBody({
       user: fidNumber,
@@ -332,7 +386,7 @@ describe('deserializeAmpBody', () => {
   let serializedBody: flatbuffers.AmpBody;
   let body: types.AmpBody;
   const fid = Factories.FID.build();
-  const fidNumber = bytesToNumber(fid)._unsafeUnwrap();
+  const fidNumber = utils.deserializeFid(fid)._unsafeUnwrap();
   const user = Factories.UserId.build({ fid: Array.from(fid) });
 
   beforeAll(async () => {
@@ -357,7 +411,7 @@ describe('deserializeVerificationAddEthAddressBody', () => {
   let body: types.VerificationAddEthAddressBody;
   const signer = Factories.Eip712Signer.build();
   const blockHash = Factories.BlockHash.build();
-  const blockHashBytes = hexStringToBytes(blockHash)._unsafeUnwrap();
+  const blockHashBytes = utils.serializeBlockHash(blockHash)._unsafeUnwrap();
 
   beforeAll(async () => {
     serializedBody = await Factories.VerificationAddEthAddressBody.create(
@@ -375,7 +429,7 @@ describe('deserializeVerificationAddEthAddressBody', () => {
 
   test('ethSignature', () => {
     expect(body.ethSignature).toEqual(
-      bytesToHexString(serializedBody.ethSignatureArray() ?? new Uint8Array())._unsafeUnwrap()
+      utils.deserializeEip712Signature(serializedBody.ethSignatureArray() ?? new Uint8Array())._unsafeUnwrap()
     );
   });
 
@@ -398,7 +452,7 @@ describe('serializeVerificationAddEthAddressBody', () => {
       .serializeVerificationAddEthAddressBody({
         address: signer.signerKeyHex,
         blockHash,
-        ethSignature: bytesToHexString(ethSignature)._unsafeUnwrap(),
+        ethSignature: utils.deserializeEip712Signature(ethSignature)._unsafeUnwrap(),
       })
       ._unsafeUnwrap();
   });
@@ -539,9 +593,9 @@ describe('deserializeReactionBody', () => {
   let reactionBody: types.ReactionBody;
   const reactionType = Factories.ReactionType.build();
   const targetFid = Factories.FID.build();
-  const targetFidNumber = bytesToNumber(targetFid)._unsafeUnwrap();
+  const targetFidNumber = utils.deserializeFid(targetFid)._unsafeUnwrap();
   const tsHash = Factories.TsHash.build();
-  const tsHashHex = bytesToHexString(tsHash, { size: 40 })._unsafeUnwrap();
+  const tsHashHex = utils.deserializeTsHash(tsHash)._unsafeUnwrap();
 
   beforeAll(async () => {
     serializedReactionBody = await Factories.ReactionBody.create({
@@ -564,9 +618,9 @@ describe('deserializeReactionBody', () => {
 describe('serializeReactionBody', () => {
   const reactionType = Factories.ReactionType.build();
   const targetFid = Factories.FID.build();
-  const targetFidNumber = bytesToNumber(targetFid)._unsafeUnwrap();
+  const targetFidNumber = utils.deserializeFid(targetFid)._unsafeUnwrap();
   const tsHash = Factories.TsHash.build();
-  const tsHashHex = bytesToHexString(tsHash, { size: 40 })._unsafeUnwrap();
+  const tsHashHex = utils.deserializeTsHash(tsHash)._unsafeUnwrap();
   const reactionBody = utils
     .serializeReactionBody({
       target: {
@@ -607,7 +661,9 @@ describe('deserializeMessage', () => {
   });
 
   test('hash', () => {
-    expect(message.hash).toEqual(bytesToHexString(messageFb.hashArray() ?? new Uint8Array())._unsafeUnwrap());
+    expect(message.hash).toEqual(
+      utils.deserializeMessageHash(messageFb.hashArray() ?? new Uint8Array())._unsafeUnwrap()
+    );
   });
 
   test('hashScheme', () => {
@@ -620,7 +676,7 @@ describe('deserializeMessage', () => {
 
   test('signature', () => {
     expect(message.signature).toEqual(
-      bytesToHexString(messageFb.signatureArray() ?? new Uint8Array(), { size: 128 })._unsafeUnwrap()
+      utils.deserializeEd25519Signature(messageFb.signatureArray() ?? new Uint8Array())._unsafeUnwrap()
     );
   });
 
@@ -652,13 +708,13 @@ describe('deserializeNameRegistryEvent', () => {
 
   test('blockHash', () => {
     expect(nameRegistryEvent.blockHash).toEqual(
-      bytesToHexString(nameRegistryEventFbb.blockHashArray() ?? new Uint8Array())._unsafeUnwrap()
+      utils.deserializeBlockHash(nameRegistryEventFbb.blockHashArray() ?? new Uint8Array())._unsafeUnwrap()
     );
   });
 
   test('transactionHash', () => {
     expect(nameRegistryEvent.transactionHash).toEqual(
-      bytesToHexString(nameRegistryEventFbb.transactionHashArray() ?? new Uint8Array())._unsafeUnwrap()
+      utils.deserializeTransactionHash(nameRegistryEventFbb.transactionHashArray() ?? new Uint8Array())._unsafeUnwrap()
     );
   });
 
@@ -674,13 +730,13 @@ describe('deserializeNameRegistryEvent', () => {
 
   test('to', () => {
     expect(nameRegistryEvent.to).toEqual(
-      bytesToHexString(nameRegistryEventFbb.toArray() ?? new Uint8Array())._unsafeUnwrap()
+      utils.deserializeEthAddress(nameRegistryEventFbb.toArray() ?? new Uint8Array())._unsafeUnwrap()
     );
   });
 
   test('from', () => {
     expect(nameRegistryEvent.from).toEqual(
-      bytesToHexString(nameRegistryEventFbb.fromArray() ?? new Uint8Array())._unsafeUnwrap()
+      utils.deserializeEthAddress(nameRegistryEventFbb.fromArray() ?? new Uint8Array())._unsafeUnwrap()
     );
   });
 
@@ -714,13 +770,13 @@ describe('deserializeIdRegistryEvent', () => {
 
   test('blockHash', () => {
     expect(idRegistryEvent.blockHash).toEqual(
-      bytesToHexString(idRegistryEventFbb.blockHashArray() ?? new Uint8Array())._unsafeUnwrap()
+      utils.deserializeBlockHash(idRegistryEventFbb.blockHashArray() ?? new Uint8Array())._unsafeUnwrap()
     );
   });
 
   test('transactionHash', () => {
     expect(idRegistryEvent.transactionHash).toEqual(
-      bytesToHexString(idRegistryEventFbb.transactionHashArray() ?? new Uint8Array())._unsafeUnwrap()
+      utils.deserializeTransactionHash(idRegistryEventFbb.transactionHashArray() ?? new Uint8Array())._unsafeUnwrap()
     );
   });
 
@@ -736,13 +792,13 @@ describe('deserializeIdRegistryEvent', () => {
 
   test('to', () => {
     expect(idRegistryEvent.to).toEqual(
-      bytesToHexString(idRegistryEventFbb.toArray() ?? new Uint8Array())._unsafeUnwrap()
+      utils.deserializeEthAddress(idRegistryEventFbb.toArray() ?? new Uint8Array())._unsafeUnwrap()
     );
   });
 
   test('from', () => {
     expect(idRegistryEvent.from).toEqual(
-      bytesToHexString(idRegistryEventFbb.fromArray() ?? new Uint8Array())._unsafeUnwrap()
+      utils.deserializeEthAddress(idRegistryEventFbb.fromArray() ?? new Uint8Array())._unsafeUnwrap()
     );
   });
 

--- a/packages/js/src/utils.test.ts
+++ b/packages/js/src/utils.test.ts
@@ -68,7 +68,7 @@ describe('deserializeTransactionHash', () => {
 });
 
 describe('serializeEip712Signature', () => {
-  const signatureBytes = Factories.Bytes.build(undefined, { transient: { length: 65 } });
+  const signatureBytes = Factories.Eip712Signature.build();
   const signature = bytesToHexString(signatureBytes, { size: 130 })._unsafeUnwrap();
 
   test(`succeeds`, () => {
@@ -77,7 +77,7 @@ describe('serializeEip712Signature', () => {
 });
 
 describe('deserializeEip712Signature', () => {
-  const signatureBytes = Factories.Bytes.build(undefined, { transient: { length: 65 } });
+  const signatureBytes = Factories.Eip712Signature.build();
   const signature = bytesToHexString(signatureBytes, { size: 130 })._unsafeUnwrap();
 
   test(`succeeds`, () => {
@@ -86,7 +86,7 @@ describe('deserializeEip712Signature', () => {
 });
 
 describe('deserializeEd25519Signature', () => {
-  const signatureBytes = Factories.Bytes.build(undefined, { transient: { length: 64 } });
+  const signatureBytes = Factories.Ed25519Signature.build();
   const signature = bytesToHexString(signatureBytes, { size: 128 })._unsafeUnwrap();
 
   test(`succeeds`, () => {

--- a/packages/js/src/utils.test.ts
+++ b/packages/js/src/utils.test.ts
@@ -69,16 +69,16 @@ describe('deserializeTransactionHash', () => {
 
 describe('serializeEip712Signature', () => {
   const signatureBytes = Factories.Bytes.build(undefined, { transient: { length: 65 } });
-  const signature = bytesToHexString(signatureBytes)._unsafeUnwrap();
+  const signature = bytesToHexString(signatureBytes, { size: 130 })._unsafeUnwrap();
 
   test(`succeeds`, () => {
     expect(utils.serializeEip712Signature(signature)).toEqual(ok(signatureBytes));
   });
 });
 
-describe('serializeEip712Signature', () => {
+describe('deserializeEip712Signature', () => {
   const signatureBytes = Factories.Bytes.build(undefined, { transient: { length: 65 } });
-  const signature = bytesToHexString(signatureBytes)._unsafeUnwrap();
+  const signature = bytesToHexString(signatureBytes, { size: 130 })._unsafeUnwrap();
 
   test(`succeeds`, () => {
     expect(utils.deserializeEip712Signature(signatureBytes)).toEqual(ok(signature));
@@ -87,7 +87,7 @@ describe('serializeEip712Signature', () => {
 
 describe('deserializeEd25519Signature', () => {
   const signatureBytes = Factories.Bytes.build(undefined, { transient: { length: 64 } });
-  const signature = bytesToHexString(signatureBytes)._unsafeUnwrap();
+  const signature = bytesToHexString(signatureBytes, { size: 128 })._unsafeUnwrap();
 
   test(`succeeds`, () => {
     expect(utils.deserializeEd25519Signature(signatureBytes)).toEqual(ok(signature));

--- a/packages/js/src/utils.ts
+++ b/packages/js/src/utils.ts
@@ -419,8 +419,6 @@ export const serializeCastId = (castId: types.CastId): HubResult<flatbuffers.Cas
   return ok(new flatbuffers.CastIdT(Array.from(fid), Array.from(tsHash)));
 };
 
-// TODO: deserializeUserId
-
 export const serializeUserId = (userId: number): HubResult<flatbuffers.UserIdT> => {
   return serializeFid(userId).map((fid) => {
     return new flatbuffers.UserIdT(Array.from(fid));
@@ -518,13 +516,6 @@ export const deserializeTransactionHash = (bytes: Uint8Array): HubResult<string>
 };
 
 /**
- * Serializes a transaction hash from a hex string to byte array.
- */
-export const serializeTransactionHash = (hash: string): HubResult<Uint8Array> => {
-  return hexStringToBytes(hash);
-};
-
-/**
  * Deserialize an EIP-712 signature from a byte array to hex string.
  */
 export const deserializeEip712Signature = (bytes: Uint8Array): HubResult<string> => {
@@ -546,24 +537,10 @@ export const deserializeEd25519Signature = (bytes: Uint8Array): HubResult<string
 };
 
 /**
- * Serializes an Ed25519 signature from a hex string to byte array.
- */
-export const serializeEd25519Signature = (hash: string): HubResult<Uint8Array> => {
-  return hexStringToBytes(hash);
-};
-
-/**
  * Deserialize a message hash from a byte array to hex string.
  */
 export const deserializeMessageHash = (bytes: Uint8Array): HubResult<string> => {
   return bytesToHexString(bytes, { size: 32 });
-};
-
-/**
- * Serializes a message hash from a hex string to byte array.
- */
-export const serializeMessageHash = (hash: string): HubResult<Uint8Array> => {
-  return hexStringToBytes(hash);
 };
 
 export const deserializeFid = (fid: Uint8Array): HubResult<number> => {

--- a/packages/utils/src/factories.ts
+++ b/packages/utils/src/factories.ts
@@ -63,6 +63,10 @@ const BlockHashFactory = Factory.define<string>(() => {
   return faker.datatype.hexadecimal({ length: 64, case: 'lower' });
 });
 
+const TransactionHashFactory = Factory.define<string>(() => {
+  return faker.datatype.hexadecimal({ length: 64, case: 'lower' });
+});
+
 const UserIdFactory = Factory.define<flatbuffers.UserIdT, any, flatbuffers.UserId>(({ onCreate }) => {
   onCreate((params) => {
     const builder = new Builder(1);
@@ -429,6 +433,13 @@ const MessageFactory = Factory.define<
   );
 });
 
+const IdRegistryEventTypeFactory = Factory.define<flatbuffers.IdRegistryEventType>(() => {
+  return faker.helpers.arrayElement([
+    flatbuffers.IdRegistryEventType.IdRegistryRegister,
+    flatbuffers.IdRegistryEventType.IdRegistryTransfer,
+  ]);
+});
+
 const IdRegistryEventFactory = Factory.define<flatbuffers.IdRegistryEventT, any, flatbuffers.IdRegistryEvent>(
   ({ onCreate }) => {
     onCreate((params) => {
@@ -439,16 +450,23 @@ const IdRegistryEventFactory = Factory.define<flatbuffers.IdRegistryEventT, any,
 
     return new flatbuffers.IdRegistryEventT(
       faker.datatype.number({ max: 100000 }),
-      Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 64 }))._unsafeUnwrap()),
-      Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 64 }))._unsafeUnwrap()),
+      Array.from(hexStringToBytes(BlockHashFactory.build())._unsafeUnwrap()),
+      Array.from(hexStringToBytes(TransactionHashFactory.build())._unsafeUnwrap()),
       faker.datatype.number({ max: 1000 }),
       Array.from(FIDFactory.build()),
       Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 40 }))._unsafeUnwrap()),
-      flatbuffers.IdRegistryEventType.IdRegistryRegister,
+      IdRegistryEventTypeFactory.build(),
       Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 40 }))._unsafeUnwrap())
     );
   }
 );
+
+const NameRegistryEventTypeFactory = Factory.define<flatbuffers.NameRegistryEventType>(() => {
+  return faker.helpers.arrayElement([
+    flatbuffers.NameRegistryEventType.NameRegistryRenew,
+    flatbuffers.NameRegistryEventType.NameRegistryTransfer,
+  ]);
+});
 
 const NameRegistryEventFactory = Factory.define<flatbuffers.NameRegistryEventT, any, flatbuffers.NameRegistryEvent>(
   ({ onCreate }) => {
@@ -460,13 +478,14 @@ const NameRegistryEventFactory = Factory.define<flatbuffers.NameRegistryEventT, 
 
     return new flatbuffers.NameRegistryEventT(
       faker.datatype.number({ max: 100000 }),
-      Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 64 }))._unsafeUnwrap()),
-      Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 64 }))._unsafeUnwrap()),
+      Array.from(hexStringToBytes(BlockHashFactory.build())._unsafeUnwrap()),
+      Array.from(hexStringToBytes(TransactionHashFactory.build())._unsafeUnwrap()),
       faker.datatype.number({ max: 1000 }),
       Array.from(FnameFactory.build()),
       Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 40 }))._unsafeUnwrap()),
       Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 40 }))._unsafeUnwrap()),
-      flatbuffers.NameRegistryEventType.NameRegistryTransfer
+      NameRegistryEventTypeFactory.build(),
+      Array.from(numberToBytes(faker.datatype.number())._unsafeUnwrap())
     );
   }
 );
@@ -518,7 +537,9 @@ export const Factories = {
   UserDataBody: UserDataBodyFactory,
   UserDataAddData: UserDataAddDataFactory,
   Message: MessageFactory,
+  IdRegistryEventType: IdRegistryEventTypeFactory,
   IdRegistryEvent: IdRegistryEventFactory,
+  NameRegistryEventType: NameRegistryEventTypeFactory,
   NameRegistryEvent: NameRegistryEventFactory,
   Ed25519PrivateKey: Ed25519PrivateKeyFactory,
   Ed25519Signer: Ed25519SignerFactory,

--- a/packages/utils/src/factories.ts
+++ b/packages/utils/src/factories.ts
@@ -498,9 +498,17 @@ const Ed25519SignerFactory = Factory.define<Ed25519Signer>(() => {
   return new Ed25519Signer(Ed25519PrivateKeyFactory.build());
 });
 
+const Ed25519SignatureFactory = Factory.define<Uint8Array>(() => {
+  return BytesFactory.build(undefined, { transient: { length: 64 } });
+});
+
 const Eip712SignerFactory = Factory.define<Eip712Signer>(() => {
   const wallet = new ethers.Wallet(ethers.utils.randomBytes(32));
   return new Eip712Signer(wallet, wallet.address);
+});
+
+const Eip712SignatureFactory = Factory.define<Uint8Array>(() => {
+  return BytesFactory.build(undefined, { transient: { length: 65 } });
 });
 
 const ReactionTypeFactory = Factory.define<flatbuffers.ReactionType>(() => {
@@ -544,6 +552,8 @@ export const Factories = {
   NameRegistryEvent: NameRegistryEventFactory,
   Ed25519PrivateKey: Ed25519PrivateKeyFactory,
   Ed25519Signer: Ed25519SignerFactory,
+  Ed25519Signature: Ed25519SignatureFactory,
   Eip712Signer: Eip712SignerFactory,
+  Eip712Signature: Eip712SignatureFactory,
   ReactionType: ReactionTypeFactory,
 };

--- a/packages/utils/src/factories.ts
+++ b/packages/utils/src/factories.ts
@@ -513,6 +513,7 @@ export const Factories = {
   Fname: FnameFactory,
   TsHash: TsHashFactory,
   BlockHash: BlockHashFactory,
+  TransactionHash: TransactionHashFactory,
   UserId: UserIdFactory,
   CastId: CastIdFactory,
   ReactionBody: ReactionBodyFactory,


### PR DESCRIPTION
## Motivation

Tests were missing for `deserializeIdRegistryEvent` and `deserializeNameRegistryEvent`.

## Change Summary

- adds tests for `deserializeIdRegistryEvent` and `deserializeNameRegistryEvent`
- improve related factories
- organize functions in `utils.ts`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged