### PR TITLE
fix: Add required `--eth-rpc-url` flag to Docker image default command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,4 +77,4 @@ COPY --chown=node:node ./apps/hub ./apps/hub
 # TODO: load identity from some secure store instead of generating a new one
 RUN yarn --cwd=apps/hub identity create
 
-CMD ["yarn", "--cwd=apps/hub", "start", "--rpc-port", "8080", "--gossip-port", "9090" ]
+CMD ["yarn", "--cwd=apps/hub", "start", "--rpc-port", "8080", "--gossip-port", "9090", "--eth-rpc-url", "https://eth-goerli.g.alchemy.com/v2/IvjMoCKt1hT66f9OJoL_dMXypnvQYUdd"]


### PR DESCRIPTION
## Motivation

For ease of getting started developing with zero configuration add a required flag.

## Change Summary

Add the (now required) `--eth-rpc-url` flag to the default command.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged
