### PR TITLE
feat: update stores to return error statuses for duplicates and conflicts

### DIFF
--- a/apps/hub/src/flatbuffers/models/types.ts
+++ b/apps/hub/src/flatbuffers/models/types.ts
@@ -85,18 +85,22 @@ export type UserMessagePostfix =
 
 export interface CastRemoveModel extends MessageModel {
   body(): flatbuffers.CastRemoveBody;
+  type(): flatbuffers.MessageType.CastRemove;
 }
 
 export interface CastAddModel extends MessageModel {
   body(): flatbuffers.CastAddBody;
+  type(): flatbuffers.MessageType.CastAdd;
 }
 
 export interface AmpAddModel extends MessageModel {
   body(): flatbuffers.AmpBody;
+  type(): flatbuffers.MessageType.AmpAdd;
 }
 
 export interface AmpRemoveModel extends MessageModel {
   body(): flatbuffers.AmpBody;
+  type(): flatbuffers.MessageType.AmpRemove;
 }
 
 export interface ReactionAddModel extends MessageModel {
@@ -124,22 +128,27 @@ export interface ReactionRemoveModel extends MessageModel {
  */
 export interface VerificationAddEthAddressModel extends MessageModel {
   body(): flatbuffers.VerificationAddEthAddressBody;
+  type(): flatbuffers.MessageType.VerificationAddEthAddress;
 }
 
 export interface VerificationRemoveModel extends MessageModel {
   body(): flatbuffers.VerificationRemoveBody;
+  type(): flatbuffers.MessageType.VerificationRemove;
 }
 
 export interface SignerAddModel extends MessageModel {
   body(): flatbuffers.SignerBody;
+  type(): flatbuffers.MessageType.SignerAdd;
 }
 
 export interface SignerRemoveModel extends MessageModel {
   body(): flatbuffers.SignerBody;
+  type(): flatbuffers.MessageType.SignerRemove;
 }
 
 export interface UserDataAddModel extends MessageModel {
   body(): flatbuffers.UserDataBody;
+  type(): flatbuffers.MessageType.UserDataAdd;
 }
 
 export type StorePruneOptions = {

--- a/apps/hub/src/flatbuffers/models/types.ts
+++ b/apps/hub/src/flatbuffers/models/types.ts
@@ -1,4 +1,4 @@
-import * as message_generated from '@farcaster/flatbuffers';
+import * as flatbuffers from '@farcaster/flatbuffers';
 import { HubAsyncResult } from '@farcaster/utils';
 import HubStateModel from '~/flatbuffers/models/hubStateModel';
 import IdRegistryEventModel from '~/flatbuffers/models/idRegistryEventModel';
@@ -84,27 +84,29 @@ export type UserMessagePostfix =
   | UserPostfix.UserDataMessage;
 
 export interface CastRemoveModel extends MessageModel {
-  body(): message_generated.CastRemoveBody;
+  body(): flatbuffers.CastRemoveBody;
 }
 
 export interface CastAddModel extends MessageModel {
-  body(): message_generated.CastAddBody;
+  body(): flatbuffers.CastAddBody;
 }
 
 export interface AmpAddModel extends MessageModel {
-  body(): message_generated.AmpBody;
+  body(): flatbuffers.AmpBody;
 }
 
 export interface AmpRemoveModel extends MessageModel {
-  body(): message_generated.AmpBody;
+  body(): flatbuffers.AmpBody;
 }
 
 export interface ReactionAddModel extends MessageModel {
-  body(): message_generated.ReactionBody;
+  body(): flatbuffers.ReactionBody;
+  type(): flatbuffers.MessageType.ReactionAdd;
 }
 
 export interface ReactionRemoveModel extends MessageModel {
-  body(): message_generated.ReactionBody;
+  body(): flatbuffers.ReactionBody;
+  type(): flatbuffers.MessageType.ReactionRemove;
 }
 
 /**
@@ -121,23 +123,23 @@ export interface ReactionRemoveModel extends MessageModel {
  * body.blockHash - user-reported latest ethereum block hash at time of signing
  */
 export interface VerificationAddEthAddressModel extends MessageModel {
-  body(): message_generated.VerificationAddEthAddressBody;
+  body(): flatbuffers.VerificationAddEthAddressBody;
 }
 
 export interface VerificationRemoveModel extends MessageModel {
-  body(): message_generated.VerificationRemoveBody;
+  body(): flatbuffers.VerificationRemoveBody;
 }
 
 export interface SignerAddModel extends MessageModel {
-  body(): message_generated.SignerBody;
+  body(): flatbuffers.SignerBody;
 }
 
 export interface SignerRemoveModel extends MessageModel {
-  body(): message_generated.SignerBody;
+  body(): flatbuffers.SignerBody;
 }
 
 export interface UserDataAddModel extends MessageModel {
-  body(): message_generated.UserDataBody;
+  body(): flatbuffers.UserDataBody;
 }
 
 export type StorePruneOptions = {

--- a/apps/hub/src/network/sync/syncEngine.ts
+++ b/apps/hub/src/network/sync/syncEngine.ts
@@ -27,8 +27,12 @@ class SyncEngine {
     this._trie = new MerkleTrie();
     this.engine = engine;
 
-    this.engine.eventHandler.on('mergeMessage', async (message) => {
+    this.engine.eventHandler.on('mergeMessage', async (message: MessageModel, deletedMessages?: MessageModel[]) => {
       this.addMessage(message);
+
+      for (const deletedMessage of deletedMessages ?? []) {
+        this.removeMessage(deletedMessage);
+      }
     });
 
     // Note: There's no guarantee that the message is actually deleted, because the transaction could fail.

--- a/apps/hub/src/rpc/server/index.ts
+++ b/apps/hub/src/rpc/server/index.ts
@@ -23,7 +23,10 @@ export const toServiceError = (err: HubError): grpc.ServiceError => {
   } else if (
     err.errCode === 'bad_request' ||
     err.errCode === 'bad_request.parse_failure' ||
-    err.errCode === 'bad_request.validation_failure'
+    err.errCode === 'bad_request.validation_failure' ||
+    err.errCode === 'bad_request.invalid_param' ||
+    err.errCode === 'bad_request.conflict' ||
+    err.errCode === 'bad_request.duplicate'
   ) {
     grpcCode = grpc.status.INVALID_ARGUMENT;
   } else if (err.errCode === 'not_found') {

--- a/apps/hub/src/storage/db/rocksdb.ts
+++ b/apps/hub/src/storage/db/rocksdb.ts
@@ -156,7 +156,7 @@ class RocksDB {
    */
   iteratorByPrefix(prefix: Buffer, options: AbstractRocksDB.IteratorOptions = {}): AbstractRocksDB.Iterator {
     options.gte = prefix;
-    const nextPrefix = bytesIncrement(new Uint8Array(prefix));
+    const nextPrefix = bytesIncrement(new Uint8Array(prefix), { endianness: 'big' });
     if (nextPrefix.length === prefix.length) {
       options.lt = Buffer.from(nextPrefix);
     }

--- a/apps/hub/src/storage/jobs/revokeSignerJob.ts
+++ b/apps/hub/src/storage/jobs/revokeSignerJob.ts
@@ -167,7 +167,7 @@ export class RevokeSignerJobQueue {
       }
       lt = maxJobKey.value;
     } else {
-      lt = Buffer.from(bytesIncrement(new Uint8Array(gte)));
+      lt = Buffer.from(bytesIncrement(new Uint8Array(gte), { endianness: 'big' }));
     }
 
     return ok(this._db.iterator({ gte, lt }));

--- a/apps/hub/src/storage/stores/castStore.ts
+++ b/apps/hub/src/storage/stores/castStore.ts
@@ -328,9 +328,9 @@ class CastStore extends SequentialMergeStore {
       () => undefined
     );
 
-    // If remove tsHash exists, no-op because this cast has already been removed
+    // If remove tsHash exists, fail because this cast has already been removed
     if (castRemoveTsHash.isOk()) {
-      return undefined;
+      throw new HubError('bad_request.conflict', 'message conflicts with a CastRemove');
     }
 
     // Look up the add tsHash for this cast
@@ -341,7 +341,7 @@ class CastStore extends SequentialMergeStore {
 
     // If add tsHash exists, no-op because this cast has already been added
     if (castAddTsHash.isOk()) {
-      return undefined;
+      throw new HubError('bad_request.duplicate', 'message has already been merged');
     }
 
     // Add putCastAdd operations to the RocksDB transaction
@@ -352,6 +352,8 @@ class CastStore extends SequentialMergeStore {
 
     // Emit store event
     this._eventHandler.emit('mergeMessage', message);
+
+    return undefined;
   }
 
   private async mergeRemove(message: CastRemoveModel): Promise<void> {

--- a/apps/hub/src/storage/stores/reactionStore.test.ts
+++ b/apps/hub/src/storage/stores/reactionStore.test.ts
@@ -315,7 +315,7 @@ describe('merge', () => {
 
         const addMessage = await Factories.Message.create({
           data: Array.from(addData.bb?.bytes() ?? []),
-          hash: Array.from(bytesIncrement(reactionAdd.hash().slice())),
+          hash: Array.from(bytesIncrement(reactionAdd.hash())),
         });
 
         reactionAddLater = new MessageModel(addMessage) as ReactionAddModel;
@@ -380,7 +380,7 @@ describe('merge', () => {
 
         const reactionRemoveMessage = await Factories.Message.create({
           data: Array.from(reactionRemoveData.bb?.bytes() ?? []),
-          hash: Array.from(bytesIncrement(reactionAdd.hash().slice())),
+          hash: Array.from(bytesIncrement(reactionAdd.hash())),
         });
 
         const reactionRemoveLater = new MessageModel(reactionRemoveMessage) as ReactionRemoveModel;
@@ -402,7 +402,7 @@ describe('merge', () => {
 
         const reactionRemoveMessage = await Factories.Message.create({
           data: Array.from(reactionRemoveData.bb?.bytes() ?? []),
-          hash: Array.from(bytesDecrement(reactionAdd.hash().slice())),
+          hash: Array.from(bytesDecrement(reactionAdd.hash())),
         });
 
         const reactionRemoveEarlier = new MessageModel(reactionRemoveMessage) as ReactionRemoveModel;
@@ -477,7 +477,7 @@ describe('merge', () => {
 
         const addMessage = await Factories.Message.create({
           data: Array.from(reactionRemoveData.bb?.bytes() ?? []),
-          hash: Array.from(bytesIncrement(reactionRemove.hash().slice())),
+          hash: Array.from(bytesIncrement(reactionRemove.hash())),
         });
 
         reactionRemoveLater = new MessageModel(addMessage) as ReactionRemoveModel;
@@ -538,7 +538,7 @@ describe('merge', () => {
 
         const addMessage = await Factories.Message.create({
           data: Array.from(addData.bb?.bytes() ?? []),
-          hash: Array.from(bytesIncrement(reactionRemove.hash().slice())),
+          hash: Array.from(bytesIncrement(reactionRemove.hash())),
         });
         const reactionAddLater = new MessageModel(addMessage) as ReactionAddModel;
 
@@ -556,7 +556,7 @@ describe('merge', () => {
 
         const removeMessage = await Factories.Message.create({
           data: Array.from(removeData.bb?.bytes() ?? []),
-          hash: Array.from(bytesDecrement(reactionRemove.hash().slice())),
+          hash: Array.from(bytesDecrement(reactionRemove.hash())),
         });
 
         const reactionRemoveEarlier = new MessageModel(removeMessage) as ReactionRemoveModel;

--- a/apps/hub/src/storage/stores/sequentialMergeStore.ts
+++ b/apps/hub/src/storage/stores/sequentialMergeStore.ts
@@ -48,10 +48,10 @@ abstract class SequentialMergeStore extends TypedEmitter<MergeProcessingEvents> 
 
     // Return promise that resolves once the merge is processed
     return new Promise((resolve) => {
-      const listenForMerge = (mergedId: string) => {
+      const listenForMerge = (mergedId: string, mergeResult?: HubResult<void>) => {
         if (mergedId === mergeId) {
           clearTimeout(timeoutId);
-          resolve(ok(undefined));
+          resolve(mergeResult ?? ok(undefined));
         }
       };
       this.on('processed', listenForMerge);
@@ -60,6 +60,7 @@ abstract class SequentialMergeStore extends TypedEmitter<MergeProcessingEvents> 
         // Remove listener and remove message from store, which will prevent it from being processed
         this.off('processed', listenForMerge);
         this._mergeIdsStore.delete(mergeId);
+        resolve(err(new HubError('unavailable.storage_failure', 'mergeSequential timed out')));
       }, MERGE_TIMEOUT);
     });
   }

--- a/apps/hub/src/storage/stores/sequentialMergeStore.ts
+++ b/apps/hub/src/storage/stores/sequentialMergeStore.ts
@@ -27,6 +27,7 @@ abstract class SequentialMergeStore extends TypedEmitter<MergeProcessingEvents> 
     this._mergeIdsQueue = [];
     this._mergeIdsStore = new Map();
     this._mergeIsProcessing = false;
+    this.setMaxListeners(1_000);
   }
 
   /**
@@ -51,6 +52,7 @@ abstract class SequentialMergeStore extends TypedEmitter<MergeProcessingEvents> 
       const listenForMerge = (mergedId: string, mergeResult?: HubResult<void>) => {
         if (mergedId === mergeId) {
           clearTimeout(timeoutId);
+          this.off('processed', listenForMerge);
           resolve(mergeResult ?? ok(undefined));
         }
       };

--- a/apps/hub/src/storage/stores/storeEventHandler.ts
+++ b/apps/hub/src/storage/stores/storeEventHandler.ts
@@ -4,10 +4,36 @@ import MessageModel from '~/flatbuffers/models/messageModel';
 import NameRegistryEventModel from '~/flatbuffers/models/nameRegistryEventModel';
 
 export type StoreEvents = {
-  mergeMessage: (message: MessageModel) => void;
+  /**
+   * mergeMessage is emitted when a message is merged into one of the stores. If
+   * messages are deleted as part of the merge transaction (i.e. due to conflicts between
+   * messages), they are emitted as part of the deletedMessages argument.
+   */
+  mergeMessage: (message: MessageModel, deletedMessages?: MessageModel[]) => void;
+
+  /**
+   * pruneMessage is emitted when a message is pruned from a store due to size
+   * or time-based limits.
+   */
   pruneMessage: (message: MessageModel) => void;
+
+  /**
+   * revokeMessage is emitted when a message is deleted because its signer has been
+   * removed. Signers are removed when SignerRemove messages are merged or an fid changes
+   * custody address.
+   */
   revokeMessage: (message: MessageModel) => void;
+
+  /**
+   * mergeIdRegistryEvent is emitted when an event from the ID Registry contract is
+   * merged into the SignerStore.
+   */
   mergeIdRegistryEvent: (event: IdRegistryEventModel) => void;
+
+  /**
+   * mergeNameRegistryEvent is emitted when an event from the Name Registry contract
+   * is merged into the UserDataStore.
+   */
   mergeNameRegistryEvent: (event: NameRegistryEventModel) => void;
 };
 

--- a/packages/utils/src/bytes.test.ts
+++ b/packages/utils/src/bytes.test.ts
@@ -31,22 +31,43 @@ describe('bytesCompare', () => {
 });
 
 describe('bytesIncrement', () => {
-  const cases: [Uint8Array, Uint8Array][] = [
-    [new Uint8Array([1]), new Uint8Array([2])],
-    [new Uint8Array([1, 1]), new Uint8Array([1, 2])],
-    [new Uint8Array([0]), new Uint8Array([1])],
-    [new Uint8Array([255]), new Uint8Array([1, 0])],
-    [new Uint8Array([254]), new Uint8Array([255])],
-    [new Uint8Array([1, 0, 0, 255]), new Uint8Array([1, 0, 1, 0])],
-    [new Uint8Array([255, 255, 255]), new Uint8Array([1, 0, 0, 0])],
-    [new Uint8Array([0, 0, 1]), new Uint8Array([0, 0, 2])],
-  ];
+  describe('big endian', () => {
+    const cases: [Uint8Array, Uint8Array][] = [
+      [new Uint8Array([1]), new Uint8Array([2])],
+      [new Uint8Array([1, 1]), new Uint8Array([1, 2])],
+      [new Uint8Array([0]), new Uint8Array([1])],
+      [new Uint8Array([255]), new Uint8Array([1, 0])],
+      [new Uint8Array([254]), new Uint8Array([255])],
+      [new Uint8Array([1, 0, 0, 255]), new Uint8Array([1, 0, 1, 0])],
+      [new Uint8Array([255, 255, 255]), new Uint8Array([1, 0, 0, 0])],
+      [new Uint8Array([0, 0, 1]), new Uint8Array([0, 0, 2])],
+    ];
 
-  for (const [input, output] of cases) {
-    test(`increments byte array: ${input}`, () => {
-      expect(bytesIncrement(input)).toEqual(output);
-    });
-  }
+    for (const [input, output] of cases) {
+      test(`increments big endian byte array: ${input}`, () => {
+        expect(bytesIncrement(input, { endianness: 'big' })).toEqual(output);
+      });
+    }
+  });
+
+  describe('little endian', () => {
+    const cases: [Uint8Array, Uint8Array][] = [
+      [new Uint8Array([1]), new Uint8Array([2])],
+      [new Uint8Array([1, 1]), new Uint8Array([2, 1])],
+      [new Uint8Array([0]), new Uint8Array([1])],
+      [new Uint8Array([255]), new Uint8Array([0, 1])],
+      [new Uint8Array([254]), new Uint8Array([255])],
+      [new Uint8Array([255, 0, 0, 1]), new Uint8Array([0, 1, 0, 1])],
+      [new Uint8Array([255, 255, 255]), new Uint8Array([0, 0, 0, 1])],
+      [new Uint8Array([1, 0, 0]), new Uint8Array([2, 0, 0])],
+    ];
+
+    for (const [input, output] of cases) {
+      test(`increments little endian byte array: ${input}`, () => {
+        expect(bytesIncrement(input)).toEqual(output);
+      });
+    }
+  });
 
   test('input byte array is not mutated', () => {
     const input = new Uint8Array([112, 102, 104]);
@@ -58,28 +79,55 @@ describe('bytesIncrement', () => {
 });
 
 describe('bytesDecrement', () => {
-  const passingCases: [Uint8Array, Uint8Array][] = [
-    [new Uint8Array([1]), new Uint8Array([0])],
-    [new Uint8Array([1, 2]), new Uint8Array([1, 1])],
-    [new Uint8Array([1, 0]), new Uint8Array([0, 255])],
-    [new Uint8Array([1, 0, 1, 0]), new Uint8Array([1, 0, 0, 255])],
-    [new Uint8Array([0, 0, 2]), new Uint8Array([0, 0, 1])],
-    [new Uint8Array([1, 0, 0, 0]), new Uint8Array([0, 255, 255, 255])],
-  ];
+  describe('big endian', () => {
+    const passingCases: [Uint8Array, Uint8Array][] = [
+      [new Uint8Array([1]), new Uint8Array([0])],
+      [new Uint8Array([1, 2]), new Uint8Array([1, 1])],
+      [new Uint8Array([1, 0]), new Uint8Array([0, 255])],
+      [new Uint8Array([1, 0, 1, 0]), new Uint8Array([1, 0, 0, 255])],
+      [new Uint8Array([0, 0, 2]), new Uint8Array([0, 0, 1])],
+      [new Uint8Array([1, 0, 0, 0]), new Uint8Array([0, 255, 255, 255])],
+    ];
 
-  const failingCases: Uint8Array[] = [new Uint8Array([0]), new Uint8Array([0, 0])];
+    for (const [input, output] of passingCases) {
+      test(`decrements byte array: ${input}`, () => {
+        expect(bytesDecrement(input, { endianness: 'big' })).toEqual(output);
+      });
+    }
 
-  for (const [input, output] of passingCases) {
-    test(`decrements byte array: ${input}`, () => {
-      expect(bytesDecrement(input)).toEqual(output);
-    });
-  }
+    const failingCases: Uint8Array[] = [new Uint8Array([0]), new Uint8Array([0, 0])];
 
-  for (const input of failingCases) {
-    test(`fails when decrementing byte array: ${input}`, () => {
-      expect(() => bytesDecrement(input)).toThrow(HubError);
-    });
-  }
+    for (const input of failingCases) {
+      test(`fails when decrementing byte array: ${input}`, () => {
+        expect(() => bytesDecrement(input, { endianness: 'big' })).toThrow(HubError);
+      });
+    }
+  });
+
+  describe('little endian', () => {
+    const passingCases: [Uint8Array, Uint8Array][] = [
+      [new Uint8Array([1]), new Uint8Array([0])],
+      [new Uint8Array([2, 1]), new Uint8Array([1, 1])],
+      [new Uint8Array([0, 1]), new Uint8Array([255, 0])],
+      [new Uint8Array([0, 1, 0, 1]), new Uint8Array([255, 0, 0, 1])],
+      [new Uint8Array([2, 0, 0]), new Uint8Array([1, 0, 0])],
+      [new Uint8Array([0, 0, 0, 1]), new Uint8Array([255, 255, 255, 0])],
+    ];
+
+    for (const [input, output] of passingCases) {
+      test(`decrements byte array: ${input}`, () => {
+        expect(bytesDecrement(input)).toEqual(output);
+      });
+    }
+
+    const failingCases: Uint8Array[] = [new Uint8Array([0]), new Uint8Array([0, 0])];
+
+    for (const input of failingCases) {
+      test(`fails when decrementing byte array: ${input}`, () => {
+        expect(() => bytesDecrement(input)).toThrow(HubError);
+      });
+    }
+  });
 
   test('input byte array is not mutated', () => {
     const input = new Uint8Array([112, 102, 104]);

--- a/packages/utils/src/bytes.test.ts
+++ b/packages/utils/src/bytes.test.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from 'ethers';
+import { ok } from 'neverthrow';
 import {
   bigNumberToBytes,
   bytesCompare,
@@ -9,6 +10,7 @@ import {
   bytesToUtf8String,
   hexStringToBytes,
   numberToBytes,
+  utf8StringToBytes,
 } from './bytes';
 import { HubError } from './errors';
 
@@ -268,6 +270,24 @@ describe('bytesToUtf8String', () => {
 
     bytesToUtf8String(input);
     expect(bytesCompare(input, inputClone)).toBe(0);
+  });
+});
+
+describe('utf8StringToBytes', () => {
+  describe('little endian', () => {
+    const passingCases: [string, Uint8Array][] = [
+      ['pfh', new Uint8Array([104, 102, 112])],
+      ['farcaster', new Uint8Array([114, 101, 116, 115, 97, 99, 114, 97, 102])],
+      ['', new Uint8Array([])],
+      [' ', new Uint8Array([32])],
+      [' a', new Uint8Array([97, 32])],
+    ];
+
+    for (const [input, output] of passingCases) {
+      test(`converts utf8 string to little endian byte array: ${input}`, () => {
+        expect(utf8StringToBytes(input)).toEqual(ok(output));
+      });
+    }
   });
 });
 

--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -35,43 +35,56 @@ export const bytesCompare = (a: Uint8Array, b: Uint8Array): number => {
   }
 };
 
-// TOOD: support both big and little endian
 /* eslint-disable security/detect-object-injection */
-export const bytesIncrement = (inputBytes: Uint8Array): Uint8Array => {
+export const bytesIncrement = (inputBytes: Uint8Array, options: BytesOptions = {}): Uint8Array => {
   const bytes = new Uint8Array(inputBytes); // avoid mutating input
 
+  const endianness: Endianness = options.endianness ?? 'little';
+
+  // Start from least significant byte
   let i = bytes.length - 1;
   while (i >= 0) {
-    if ((bytes[i] as number) < 255) {
-      bytes[i] = (bytes[i] as number) + 1;
+    const pos = endianness === 'little' ? bytes.length - 1 - i : i;
+    if ((bytes[pos] as number) < 255) {
+      bytes[pos] = (bytes[pos] as number) + 1;
       return bytes;
     } else {
-      bytes[i] = 0;
+      bytes[pos] = 0;
     }
     i = i - 1;
   }
-  return new Uint8Array([1, ...bytes]);
+
+  if (endianness === 'little') {
+    return new Uint8Array([...bytes, 1]);
+  } else {
+    return new Uint8Array([1, ...bytes]);
+  }
 };
 
 // TODO: support both big and little endian
-export const bytesDecrement = (inputBytes: Uint8Array): Uint8Array => {
+export const bytesDecrement = (inputBytes: Uint8Array, options: BytesOptions = {}): Uint8Array => {
   const bytes = new Uint8Array(inputBytes); // avoid mutating input
+
+  const endianness: Endianness = options.endianness ?? 'little';
+
+  // start from least significant byte
   let i = bytes.length - 1;
   while (i >= 0) {
-    if ((bytes[i] as number) > 0) {
-      bytes[i] = (bytes[i] as number) - 1;
+    const pos = endianness === 'little' ? bytes.length - 1 - i : i;
+    if ((bytes[pos] as number) > 0) {
+      bytes[pos] = (bytes[pos] as number) - 1;
       return bytes;
     } else {
       if (i === 0) {
         throw new HubError('bad_request.invalid_param', 'Cannot decrement zero');
       }
 
-      bytes[i] = 255;
+      bytes[pos] = 255;
     }
     i = i - 1;
   }
 
-  return new Uint8Array([...bytes]);
+  return bytes;
 };
 
 export const toByteBuffer = (buffer: Buffer): ByteBuffer => {

--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -60,6 +60,8 @@ export type HubErrorCode =
   | 'bad_request.parse_failure'
   | 'bad_request.invalid_param'
   | 'bad_request.validation_failure'
+  | 'bad_request.duplicate'
+  | 'bad_request.conflict'
   /* The requested resource could not be found */
   | 'not_found'
   /* The request could not be completed because the operation is not executable */

--- a/packages/utils/src/tsHash.test.ts
+++ b/packages/utils/src/tsHash.test.ts
@@ -4,11 +4,12 @@ import { Factories } from './factories';
 import { toFarcasterTime } from './time';
 import { toTsHash } from './tsHash';
 
+const farcasterTimeNow = toFarcasterTime(Date.now());
+
 test('stores timestamp in big-endian order', () => {
-  const time = toFarcasterTime(Date.now());
   const hash = Factories.Bytes.build({}, { transient: { length: 16 } });
-  const a = toTsHash(time, hash)._unsafeUnwrap();
-  const b = toTsHash(time + 1, hash)._unsafeUnwrap();
+  const a = toTsHash(farcasterTimeNow, hash)._unsafeUnwrap();
+  const b = toTsHash(farcasterTimeNow + 1, hash)._unsafeUnwrap();
   expect(bytesCompare(a, b)).toEqual(-1);
 });
 

--- a/packages/utils/src/tsHash.ts
+++ b/packages/utils/src/tsHash.ts
@@ -8,8 +8,15 @@ export const toTsHash = (timestamp: number, hash: Uint8Array): HubResult<Uint8Ar
   }
   const buffer = new ArrayBuffer(4 + hash.length);
   const view = new DataView(buffer);
-  view.setUint32(0, timestamp, false); // Stores timestamp as big-endian in first 4 bytes
-  const bytes = new Uint8Array(buffer);
-  bytes.set(hash, 4);
-  return ok(bytes);
+
+  // Store timestamp as big-endian in first 4 bytes
+  view.setUint32(0, timestamp, false);
+
+  // Iterate through little-endian hash, storing as big-endian in tsHash
+  for (let i = 0; i < hash.length; i++) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    view.setUint8(4 + i, hash[hash.length - 1 - i]!);
+  }
+
+  return ok(new Uint8Array(buffer));
 };


### PR DESCRIPTION
## Motivation

`mergeMessage` should only return ok if the message is successfully merged. If the message is a duplicate or conflicts with a later message, the store should return an error. Closes #423 

## Change Summary

* Update all stores to throw hub error with error code `bad_request.duplicate` when duplicate message is submitted
* Update all stores to throw hub error with code `bad_request.conflict` when message is submitted that conflicts with a more recent existing message
* Update `mergeMessage` event to include array of deleted messages as well as the merged message and update the sync engine to remove messages when they are marked as deleted there
* Support passing `endianness` as option to `bytesIncrement` and `bytesDecrement`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
