### PR TITLE
fix: validate inputs before serialization in @farcaster/js

### DIFF
--- a/apps/hub/src/storage/stores/signerStore.test.ts
+++ b/apps/hub/src/storage/stores/signerStore.test.ts
@@ -166,7 +166,7 @@ describe('mergeIdRegistryEvent', () => {
   test('fails if events have the same blockNumber but different blockHashes', async () => {
     const idRegistryEvent = await Factories.IdRegistryEvent.create({
       ...custody1Event.event.unpack(),
-      blockHash: Array.from(hexStringToBytes(Factories.BlockHash.build())._unsafeUnwrap()),
+      blockHash: Array.from(Factories.BlockHash.build()),
     });
 
     const blockHashConflictEvent = new IdRegistryEventModel(idRegistryEvent);

--- a/packages/js/jest.config.ts
+++ b/packages/js/jest.config.ts
@@ -2,12 +2,7 @@ import type { Config } from 'jest';
 
 const jestConfig: Config = {
   testEnvironment: 'node',
-  moduleNameMapper: {
-    '^~/(.*)$': '<rootDir>/src/$1',
-    '^(.+)_generated.js$': '$1_generated', // Support flatc generated files
-  },
-  coveragePathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
-  testPathIgnorePatterns: ['<rootDir>/build', '<rootDir>/node_modules'],
+  rootDir: 'src',
   extensionsToTreatAsEsm: ['.ts'],
   /**
    * For high performance with minimal configuration transform with TS with swc.

--- a/packages/js/src/builders.test.ts
+++ b/packages/js/src/builders.test.ts
@@ -166,7 +166,7 @@ describe('makeVerificationAddEthAddressData', () => {
   let ethSignature: Uint8Array;
   const signer = Factories.Eip712Signer.build();
   const address = signer.signerKeyHex;
-  const blockHash = Factories.BlockHash.build();
+  const blockHash = Factories.BlockHashHex.build();
   const claim = Factories.VerificationEthAddressClaim.build({ blockHash, fid }, { transient: { signer } });
 
   beforeAll(async () => {
@@ -200,7 +200,7 @@ describe('makeVerificationAddEthAddress', () => {
   let ethSignature: Uint8Array;
   const signer = Factories.Eip712Signer.build();
   const address = signer.signerKeyHex;
-  const blockHash = Factories.BlockHash.build();
+  const blockHash = Factories.BlockHashHex.build();
   const claim = Factories.VerificationEthAddressClaim.build({ blockHash, fid }, { transient: { signer } });
 
   beforeAll(async () => {

--- a/packages/js/src/utils.test.ts
+++ b/packages/js/src/utils.test.ts
@@ -41,7 +41,7 @@ describe('serializeFid', () => {
 });
 
 describe('deserializeBlockHash', () => {
-  const blockHash = Factories.BlockHash.build();
+  const blockHash = Factories.BlockHashHex.build();
   const blockHashBytes = hexStringToBytes(blockHash)._unsafeUnwrap();
 
   test(`succeeds`, () => {
@@ -50,16 +50,16 @@ describe('deserializeBlockHash', () => {
 });
 
 describe('serializeBlockHash', () => {
-  const blockHash = Factories.BlockHash.build();
-  const blockHashBytes = hexStringToBytes(blockHash)._unsafeUnwrap();
-
   test(`succeeds`, () => {
+    const blockHash = Factories.BlockHashHex.build();
+    const blockHashBytes = hexStringToBytes(blockHash)._unsafeUnwrap();
+
     expect(utils.serializeBlockHash(blockHash)).toEqual(ok(blockHashBytes));
   });
 });
 
 describe('deserializeTransactionHash', () => {
-  const transactionHash = Factories.TransactionHash.build();
+  const transactionHash = Factories.TransactionHashHex.build();
   const transactionHashBytes = hexStringToBytes(transactionHash)._unsafeUnwrap();
 
   test(`succeeds`, () => {
@@ -410,7 +410,7 @@ describe('deserializeVerificationAddEthAddressBody', () => {
   let serializedBody: VerificationAddEthAddressBody;
   let body: types.VerificationAddEthAddressBody;
   const signer = Factories.Eip712Signer.build();
-  const blockHash = Factories.BlockHash.build();
+  const blockHash = Factories.BlockHashHex.build();
   const blockHashBytes = utils.serializeBlockHash(blockHash)._unsafeUnwrap();
 
   beforeAll(async () => {
@@ -442,7 +442,7 @@ describe('serializeVerificationAddEthAddressBody', () => {
   let ethSignature: Uint8Array;
   let body: flatbuffers.VerificationAddEthAddressBodyT;
   const signer = Factories.Eip712Signer.build();
-  const blockHash = Factories.BlockHash.build();
+  const blockHash = Factories.BlockHashHex.build();
   const blockHashBytes = hexStringToBytes(blockHash)._unsafeUnwrap();
   const claim = Factories.VerificationEthAddressClaim.build(undefined, { transient: { signer } });
 

--- a/packages/js/src/utils.ts
+++ b/packages/js/src/utils.ts
@@ -505,7 +505,7 @@ export const deserializeBlockHash = (bytes: Uint8Array): HubResult<string> => {
  * Serializes a block hash from a hex string to byte array.
  */
 export const serializeBlockHash = (hash: string): HubResult<Uint8Array> => {
-  return hexStringToBytes(hash);
+  return validations.validateBlockHashHex(hash).andThen(hexStringToBytes);
 };
 
 /**
@@ -526,14 +526,14 @@ export const deserializeEip712Signature = (bytes: Uint8Array): HubResult<string>
  * Serializes an EIP-712 from a hex string to byte array.
  */
 export const serializeEip712Signature = (hash: string): HubResult<Uint8Array> => {
-  return hexStringToBytes(hash);
+  return validations.validateEip712SignatureHex(hash).andThen(hexStringToBytes);
 };
 
 /**
  * Deserialize an Ed25519 signature from a byte array to hex string.
  */
 export const deserializeEd25519Signature = (bytes: Uint8Array): HubResult<string> => {
-  return bytesToHexString(bytes, { size: 128 });
+  return bytesToHexString(bytes, { size: 128 }).andThen(validations.validateEd25519ignatureHex);
 };
 
 /**
@@ -564,7 +564,10 @@ export const deserializeEthAddress = (ethAddress: Uint8Array): HubResult<string>
 };
 
 export const serializeEthAddress = (ethAddress: string): HubResult<Uint8Array> => {
-  return hexStringToBytes(ethAddress).andThen((ethAddress) => validations.validateEthAddress(ethAddress));
+  return validations
+    .validateEthAddressHex(ethAddress)
+    .andThen(hexStringToBytes)
+    .andThen(validations.validateEthAddress);
 };
 
 export const deserializeEd25519PublicKey = (publicKey: Uint8Array): HubResult<string> => {
@@ -574,7 +577,10 @@ export const deserializeEd25519PublicKey = (publicKey: Uint8Array): HubResult<st
 };
 
 export const serializeEd25519PublicKey = (publicKey: string): HubResult<Uint8Array> => {
-  return hexStringToBytes(publicKey).andThen((publicKey) => validations.validateEd25519PublicKey(publicKey));
+  return validations
+    .validateEd25519PublicKeyHex(publicKey)
+    .andThen(hexStringToBytes)
+    .andThen(validations.validateEd25519PublicKey);
 };
 
 export const deserializeTsHash = (tsHash: Uint8Array): HubResult<string> => {
@@ -582,5 +588,5 @@ export const deserializeTsHash = (tsHash: Uint8Array): HubResult<string> => {
 };
 
 export const serializeTsHash = (tsHash: string): HubResult<Uint8Array> => {
-  return hexStringToBytes(tsHash).andThen((tsHash) => validations.validateTsHash(tsHash));
+  return validations.validateTsHashHex(tsHash).andThen(hexStringToBytes).andThen(validations.validateTsHash);
 };

--- a/packages/utils/src/crypto/eip712.test.ts
+++ b/packages/utils/src/crypto/eip712.test.ts
@@ -18,7 +18,7 @@ describe('signVerificationEthAddressClaim', () => {
     claim = {
       fid: BigNumber.from(fidNumber),
       address: wallet.address,
-      blockHash: Factories.BlockHash.build(),
+      blockHash: Factories.BlockHashHex.build(),
       network: FarcasterNetwork.Testnet,
     };
     signature = (await eip712.signVerificationEthAddressClaim(claim, wallet))._unsafeUnwrap();

--- a/packages/utils/src/factories.ts
+++ b/packages/utils/src/factories.ts
@@ -59,11 +59,19 @@ const TsHashFactory = Factory.define<Uint8Array, { timestamp?: number; hash?: Ui
   return toTsHash(timestamp, hash)._unsafeUnwrap();
 });
 
-const BlockHashFactory = Factory.define<string>(() => {
+const BlockHashFactory = Factory.define<Uint8Array>(() => {
+  return BytesFactory.build(undefined, { transient: { length: 32 } });
+});
+
+const BlockHashHexFactory = Factory.define<string>(() => {
   return faker.datatype.hexadecimal({ length: 64, case: 'lower' });
 });
 
-const TransactionHashFactory = Factory.define<string>(() => {
+const TransactionHashFactory = Factory.define<Uint8Array>(() => {
+  return BytesFactory.build(undefined, { transient: { length: 32 } });
+});
+
+const TransactionHashHexFactory = Factory.define<string>(() => {
   return faker.datatype.hexadecimal({ length: 64, case: 'lower' });
 });
 
@@ -240,7 +248,7 @@ const VerificationEthAddressClaimFactory = Factory.define<VerificationEthAddress
       fid: bytesToBigNumber(FIDFactory.build())._unsafeUnwrap(),
       network: flatbuffers.FarcasterNetwork.Testnet,
       address: signer.signerKeyHex,
-      blockHash: BlockHashFactory.build(),
+      blockHash: BlockHashHexFactory.build(),
     };
   }
 );
@@ -450,8 +458,8 @@ const IdRegistryEventFactory = Factory.define<flatbuffers.IdRegistryEventT, any,
 
     return new flatbuffers.IdRegistryEventT(
       faker.datatype.number({ max: 100000 }),
-      Array.from(hexStringToBytes(BlockHashFactory.build())._unsafeUnwrap()),
-      Array.from(hexStringToBytes(TransactionHashFactory.build())._unsafeUnwrap()),
+      Array.from(hexStringToBytes(BlockHashHexFactory.build())._unsafeUnwrap()),
+      Array.from(hexStringToBytes(TransactionHashHexFactory.build())._unsafeUnwrap()),
       faker.datatype.number({ max: 1000 }),
       Array.from(FIDFactory.build()),
       Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 40 }))._unsafeUnwrap()),
@@ -478,8 +486,8 @@ const NameRegistryEventFactory = Factory.define<flatbuffers.NameRegistryEventT, 
 
     return new flatbuffers.NameRegistryEventT(
       faker.datatype.number({ max: 100000 }),
-      Array.from(hexStringToBytes(BlockHashFactory.build())._unsafeUnwrap()),
-      Array.from(hexStringToBytes(TransactionHashFactory.build())._unsafeUnwrap()),
+      Array.from(hexStringToBytes(BlockHashHexFactory.build())._unsafeUnwrap()),
+      Array.from(hexStringToBytes(TransactionHashHexFactory.build())._unsafeUnwrap()),
       faker.datatype.number({ max: 1000 }),
       Array.from(FnameFactory.build()),
       Array.from(hexStringToBytes(faker.datatype.hexadecimal({ length: 40 }))._unsafeUnwrap()),
@@ -502,6 +510,10 @@ const Ed25519SignatureFactory = Factory.define<Uint8Array>(() => {
   return BytesFactory.build(undefined, { transient: { length: 64 } });
 });
 
+const Ed25519SignatureHexFactory = Factory.define<string>(() => {
+  return faker.datatype.hexadecimal({ length: 128, case: 'lower' });
+});
+
 const Eip712SignerFactory = Factory.define<Eip712Signer>(() => {
   const wallet = new ethers.Wallet(ethers.utils.randomBytes(32));
   return new Eip712Signer(wallet, wallet.address);
@@ -511,8 +523,28 @@ const Eip712SignatureFactory = Factory.define<Uint8Array>(() => {
   return BytesFactory.build(undefined, { transient: { length: 65 } });
 });
 
+const Eip712SignatureHexFactory = Factory.define<string>(() => {
+  return faker.datatype.hexadecimal({ length: 130, case: 'lower' });
+});
+
 const ReactionTypeFactory = Factory.define<flatbuffers.ReactionType>(() => {
   return faker.helpers.arrayElement([flatbuffers.ReactionType.Like, flatbuffers.ReactionType.Recast]);
+});
+
+const MessageHashHexFactory = Factory.define<string>(() => {
+  return faker.datatype.hexadecimal({ length: 32, case: 'lower' });
+});
+
+const EthAddressHexFactory = Factory.define<string>(() => {
+  return faker.datatype.hexadecimal({ length: 40, case: 'lower' });
+});
+
+const Ed25519PublicKeyHexFactory = Factory.define<string>(() => {
+  return faker.datatype.hexadecimal({ length: 64, case: 'lower' });
+});
+
+const TsHashHexFactory = Factory.define<string>(() => {
+  return faker.datatype.hexadecimal({ length: 40, case: 'lower' });
 });
 
 export const Factories = {
@@ -521,7 +553,9 @@ export const Factories = {
   Fname: FnameFactory,
   TsHash: TsHashFactory,
   BlockHash: BlockHashFactory,
+  BlockHashHex: BlockHashHexFactory,
   TransactionHash: TransactionHashFactory,
+  TransactionHashHex: TransactionHashHexFactory,
   UserId: UserIdFactory,
   CastId: CastIdFactory,
   ReactionBody: ReactionBodyFactory,
@@ -553,7 +587,13 @@ export const Factories = {
   Ed25519PrivateKey: Ed25519PrivateKeyFactory,
   Ed25519Signer: Ed25519SignerFactory,
   Ed25519Signature: Ed25519SignatureFactory,
+  Ed25519SignatureHex: Ed25519SignatureHexFactory,
   Eip712Signer: Eip712SignerFactory,
   Eip712Signature: Eip712SignatureFactory,
+  Eip712SignatureHex: Eip712SignatureHexFactory,
   ReactionType: ReactionTypeFactory,
+  MessageHashHex: MessageHashHexFactory,
+  EthAddressHex: EthAddressHexFactory,
+  Ed25519PublicKeyHex: Ed25519PublicKeyHexFactory,
+  TsHashHex: TsHashHexFactory,
 };

--- a/packages/utils/src/signers/eip712Signer.test.ts
+++ b/packages/utils/src/signers/eip712Signer.test.ts
@@ -46,7 +46,7 @@ describe('Eip712Signer', () => {
         claim = {
           fid: BigNumber.from(Factories.FID.build()),
           address: signer.signerKeyHex,
-          blockHash: Factories.BlockHash.build('', { transient: { case: 'mixed' } }),
+          blockHash: Factories.BlockHashHex.build(undefined, { transient: { case: 'mixed' } }),
           network: FarcasterNetwork.Testnet,
         };
         signature = (await signer.signVerificationEthAddressClaim(claim))._unsafeUnwrap();

--- a/packages/utils/src/validations.test.ts
+++ b/packages/utils/src/validations.test.ts
@@ -663,7 +663,12 @@ describe('validateMessageData', () => {
   });
 });
 
-const testHexValidation = (validateHexFn: (hex: string) => HubResult<string>, validHex: string, length?: number) => {
+const testHexValidation = (
+  validateHexFn: (hex: string) => HubResult<string>,
+  validHex: string,
+  length?: number,
+  label?: string
+) => {
   test('succeeds with valid string', async () => {
     const result = validateHexFn(validHex);
     expect(result).toEqual(ok(validHex));
@@ -673,7 +678,7 @@ const testHexValidation = (validateHexFn: (hex: string) => HubResult<string>, va
     const invalidHex = validHex.substring(0, validHex.length - 1) + 'G';
     const result = validateHexFn(invalidHex);
     expect(result).toEqual(
-      err(new HubError('bad_request.validation_failure', `string "${invalidHex}" is not valid hex`))
+      err(new HubError('bad_request.validation_failure', `${label} "${invalidHex}" is not valid hex`))
     );
   });
 
@@ -681,39 +686,59 @@ const testHexValidation = (validateHexFn: (hex: string) => HubResult<string>, va
     const invalidHex = validHex.substring(0, validHex.length - 1);
     const result = validateHexFn(invalidHex);
     expect(result).toEqual(
-      err(new HubError('bad_request.validation_failure', `hex string "${invalidHex} is not ${length} characters`))
+      err(new HubError('bad_request.validation_failure', `${label} "${invalidHex} is not ${length} characters`))
     );
   });
 };
 
 describe('validateBlockHashHex', () => {
-  testHexValidation(validations.validateBlockHashHex, Factories.BlockHashHex.build(), 64);
+  testHexValidation(validations.validateBlockHashHex, Factories.BlockHashHex.build(), 64, 'block hash');
 });
 
 describe('validateTransactionHashHex', () => {
-  testHexValidation(validations.validateTransactionHashHex, Factories.TransactionHashHex.build(), 64);
+  testHexValidation(
+    validations.validateTransactionHashHex,
+    Factories.TransactionHashHex.build(),
+    64,
+    'transaction hash'
+  );
 });
 
 describe('validateEip712SignatureHex', () => {
-  testHexValidation(validations.validateEip712SignatureHex, Factories.Eip712SignatureHex.build(), 130);
+  testHexValidation(
+    validations.validateEip712SignatureHex,
+    Factories.Eip712SignatureHex.build(),
+    130,
+    'EIP-712 signature'
+  );
 });
 
 describe('validateEd25519SignatureHex', () => {
-  testHexValidation(validations.validateEd25519ignatureHex, Factories.Ed25519SignatureHex.build(), 128);
+  testHexValidation(
+    validations.validateEd25519ignatureHex,
+    Factories.Ed25519SignatureHex.build(),
+    128,
+    'Ed25519 signature'
+  );
 });
 
 describe('validateMessageHashHex', () => {
-  testHexValidation(validations.validateMessageHashHex, Factories.MessageHashHex.build(), 32);
+  testHexValidation(validations.validateMessageHashHex, Factories.MessageHashHex.build(), 32, 'message hash');
 });
 
 describe('validateEthAddressHex', () => {
-  testHexValidation(validations.validateEthAddressHex, Factories.EthAddressHex.build(), 40);
+  testHexValidation(validations.validateEthAddressHex, Factories.EthAddressHex.build(), 40, 'eth address');
 });
 
 describe('validateEd25519PublicKeyHex', () => {
-  testHexValidation(validations.validateEd25519PublicKeyHex, Factories.Ed25519PublicKeyHex.build(), 64);
+  testHexValidation(
+    validations.validateEd25519PublicKeyHex,
+    Factories.Ed25519PublicKeyHex.build(),
+    64,
+    'Ed25519 public key'
+  );
 });
 
 describe('validateTsHashHex', () => {
-  testHexValidation(validations.validateTsHashHex, Factories.TsHashHex.build(), 40);
+  testHexValidation(validations.validateTsHashHex, Factories.TsHashHex.build(), 40, 'ts-hash');
 });

--- a/packages/utils/src/validations.ts
+++ b/packages/utils/src/validations.ts
@@ -480,42 +480,42 @@ export const validateFname = <T extends string | Uint8Array>(fnameP?: T | null):
   return ok(fnameP);
 };
 
-const buildValidateHex = (length?: number) => (hex: string) =>
-  validateHexString(hex).andThen(() => {
+const buildValidateHex = (length?: number, label?: string) => (hex: string) =>
+  validateHexString(hex, label).andThen(() => {
     if (length) {
-      return validateHexLength(hex, length);
+      return validateHexLength(hex, length, label);
     } else {
       return ok(hex);
     }
   });
 
-const validateHexString = (hex: string): HubResult<string> => {
+const validateHexString = (hex: string, label = 'hex string'): HubResult<string> => {
   const hasValidChars = HEX_REGEX.test(hex);
   if (hasValidChars === false) {
-    return err(new HubError('bad_request.validation_failure', `string "${hex}" is not valid hex`));
+    return err(new HubError('bad_request.validation_failure', `${label} "${hex}" is not valid hex`));
   }
 
   return ok(hex);
 };
 
-const validateHexLength = (hex: string, length: number): HubResult<string> => {
+const validateHexLength = (hex: string, length: number, label = 'hex string'): HubResult<string> => {
   let value = hex;
   if (value.substring(0, 2) === '0x') {
     value = value.substring(2);
   }
 
   if (value.length !== length) {
-    return err(new HubError('bad_request.validation_failure', `hex string "${hex} is not ${length} characters`));
+    return err(new HubError('bad_request.validation_failure', `${label} "${hex} is not ${length} characters`));
   }
 
   return ok(hex);
 };
 
-export const validateBlockHashHex = buildValidateHex(64);
-export const validateTransactionHashHex = buildValidateHex(64);
-export const validateEip712SignatureHex = buildValidateHex(130);
-export const validateEd25519ignatureHex = buildValidateHex(128);
-export const validateMessageHashHex = buildValidateHex(32);
-export const validateEthAddressHex = buildValidateHex(40);
-export const validateEd25519PublicKeyHex = buildValidateHex(64);
-export const validateTsHashHex = buildValidateHex(40);
+export const validateBlockHashHex = buildValidateHex(64, 'block hash');
+export const validateTransactionHashHex = buildValidateHex(64, 'transaction hash');
+export const validateEip712SignatureHex = buildValidateHex(130, 'EIP-712 signature');
+export const validateEd25519ignatureHex = buildValidateHex(128, 'Ed25519 signature');
+export const validateMessageHashHex = buildValidateHex(32, 'message hash');
+export const validateEthAddressHex = buildValidateHex(40, 'eth address');
+export const validateEd25519PublicKeyHex = buildValidateHex(64, 'Ed25519 public key');
+export const validateTsHashHex = buildValidateHex(40, 'ts-hash');


### PR DESCRIPTION
## Motivation

closes #404 

## Change Summary

- add validations on all serialization functions that take a hex value as input

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)