### PR TITLE
chore: refactor functions in `packages/*` to return HubResult

### DIFF
--- a/.changeset/thirty-tools-drum.md
+++ b/.changeset/thirty-tools-drum.md
@@ -1,0 +1,7 @@
+---
+'@farcaster/utils': patch
+'@farcaster/js': patch
+'@farcaster/hub': patch
+---
+
+chore: refactor functions in packages/\* to return HubResult

--- a/apps/hub/src/network/sync/syncEngine.test.ts
+++ b/apps/hub/src/network/sync/syncEngine.test.ts
@@ -192,8 +192,8 @@ describe('SyncEngine', () => {
   });
 
   test('snapshotTimestampPrefix trims the seconds', async () => {
-    const nowInSeconds = getFarcasterTime();
-    const snapshotTimestamp = syncEngine.snapshotTimestamp;
+    const nowInSeconds = getFarcasterTime()._unsafeUnwrap();
+    const snapshotTimestamp = syncEngine.snapshotTimestamp._unsafeUnwrap();
     expect(snapshotTimestamp).toBeLessThanOrEqual(nowInSeconds);
     expect(snapshotTimestamp).toEqual(Math.floor(nowInSeconds / 10) * 10);
   });
@@ -203,7 +203,7 @@ describe('SyncEngine', () => {
     const rpcClient = instance(mockRPCClient);
     let called = false;
     when(mockRPCClient.getSyncMetadataByPrefix(anyString())).thenCall(() => {
-      expect(syncEngine.shouldSync([])).toBeFalsy();
+      expect(syncEngine.shouldSync([])._unsafeUnwrap()).toBeFalsy();
       called = true;
       // Return an empty child map so sync will finish with a noop
       return Promise.resolve(ok({ prefix: '', numMessages: 1000, hash: '', children: new Map() }));
@@ -217,7 +217,7 @@ describe('SyncEngine', () => {
     await engine.mergeMessage(signerAdd);
 
     await addMessagesWithTimestamps([30662167, 30662169, 30662172]);
-    expect(syncEngine.shouldSync(syncEngine.snapshot.excludedHashes)).toBeFalsy();
+    expect(syncEngine.shouldSync(syncEngine.snapshot._unsafeUnwrap().excludedHashes)._unsafeUnwrap()).toBeFalsy();
   });
 
   test('shouldSync returns true when hashes dont match', async () => {
@@ -225,10 +225,10 @@ describe('SyncEngine', () => {
     await engine.mergeMessage(signerAdd);
 
     await addMessagesWithTimestamps([30662167, 30662169, 30662172]);
-    const oldSnapshot = syncEngine.snapshot;
+    const oldSnapshot = syncEngine.snapshot._unsafeUnwrap();
     await addMessagesWithTimestamps([30662372]);
-    expect(oldSnapshot.excludedHashes).not.toEqual(syncEngine.snapshot.excludedHashes);
-    expect(syncEngine.shouldSync(oldSnapshot.excludedHashes)).toBeTruthy();
+    expect(oldSnapshot.excludedHashes).not.toEqual(syncEngine.snapshot._unsafeUnwrap().excludedHashes);
+    expect(syncEngine.shouldSync(oldSnapshot.excludedHashes)._unsafeUnwrap()).toBeTruthy();
   });
 
   // xtest('should not sync if messages were added within the sync threshold', async () => {

--- a/apps/hub/src/rpc/server/serviceImplementations/syncImplementation.ts
+++ b/apps/hub/src/rpc/server/serviceImplementations/syncImplementation.ts
@@ -83,7 +83,7 @@ export const syncImplementation = (engine: Engine, syncEngine: SyncEngine) => {
       callback: grpc.sendUnaryData<flatbuffers.TrieNodeSnapshotResponse>
     ) => {
       const prefix = bytesToUtf8String(call.request.prefixArray() ?? new Uint8Array())._unsafeUnwrap();
-      const result = syncEngine.getSnapshotByPrefix(prefix);
+      const result = syncEngine.getSnapshotByPrefix(prefix)._unsafeUnwrap();
       const rootHash = syncEngine.trie.rootHash;
       if (result) {
         callback(null, toTrieNodeSnapshotResponse(result, rootHash));

--- a/apps/hub/src/storage/stores/ampStore.test.ts
+++ b/apps/hub/src/storage/stores/ampStore.test.ts
@@ -346,7 +346,7 @@ describe('merge', () => {
 
         const removeMessage = await Factories.Message.create({
           data: Array.from(removeData.bb?.bytes() ?? []),
-          hash: Array.from(bytesDecrement(ampAdd.hash())),
+          hash: Array.from(bytesDecrement(ampAdd.hash())._unsafeUnwrap()),
         });
 
         const ampRemoveEarlier = new MessageModel(removeMessage) as AmpRemoveModel;
@@ -520,7 +520,7 @@ describe('merge', () => {
 
         const removeMessage = await Factories.Message.create({
           data: Array.from(removeData.bb?.bytes() ?? []),
-          hash: Array.from(bytesDecrement(ampRemove.hash())),
+          hash: Array.from(bytesDecrement(ampRemove.hash())._unsafeUnwrap()),
         });
 
         const ampRemoveEarlier = new MessageModel(removeMessage) as AmpRemoveModel;
@@ -591,7 +591,7 @@ describe('pruneMessages', () => {
   };
 
   beforeAll(async () => {
-    const time = getFarcasterTime() - 10;
+    const time = getFarcasterTime()._unsafeUnwrap() - 10;
     add1 = await generateAddWithTimestamp(fid, time + 1);
     add2 = await generateAddWithTimestamp(fid, time + 2);
     add3 = await generateAddWithTimestamp(fid, time + 3);

--- a/apps/hub/src/storage/stores/ampStore.ts
+++ b/apps/hub/src/storage/stores/ampStore.ts
@@ -197,8 +197,13 @@ class AmpStore extends SequentialMergeStore {
     // Calculate the number of messages that need to be pruned, based on the store's size limit
     let sizeToPrune = count - this._pruneSizeLimit;
 
+    const farcasterTime = getFarcasterTime();
+    if (farcasterTime.isErr()) {
+      return err(farcasterTime.error);
+    }
+
     // Calculate the timestamp cut-off to prune
-    const timestampToPrune = getFarcasterTime() - this._pruneTimeLimit;
+    const timestampToPrune = farcasterTime.value - this._pruneTimeLimit;
 
     // Keep track of the messages that get pruned so that we can emit pruneMessage events after the transaction settles
     const messageToPrune: (AmpAddModel | AmpRemoveModel)[] = [];

--- a/apps/hub/src/storage/stores/castStore.test.ts
+++ b/apps/hub/src/storage/stores/castStore.test.ts
@@ -290,7 +290,7 @@ describe('merge', () => {
 
         const removeMessage = await Factories.Message.create({
           data: Array.from(removeData.bb?.bytes() ?? []),
-          hash: Array.from(bytesDecrement(castAdd.hash().slice())),
+          hash: Array.from(bytesDecrement(castAdd.hash().slice())._unsafeUnwrap()),
         });
 
         const castRemoveEarlier = new MessageModel(removeMessage) as CastRemoveModel;
@@ -476,7 +476,7 @@ describe('merge', () => {
         });
         const removeMessage = await Factories.Message.create({
           data: Array.from(removeData.bb?.bytes() ?? []),
-          hash: Array.from(bytesDecrement(castAdd.hash().slice())),
+          hash: Array.from(bytesDecrement(castAdd.hash().slice())._unsafeUnwrap()),
         });
         const castRemoveEarlier = new MessageModel(removeMessage) as CastRemoveModel;
 
@@ -572,7 +572,7 @@ describe('pruneMessages', () => {
   };
 
   beforeAll(async () => {
-    const time = getFarcasterTime() - 10;
+    const time = getFarcasterTime()._unsafeUnwrap() - 10;
     add1 = await generateAddWithTimestamp(fid, time + 1);
     add2 = await generateAddWithTimestamp(fid, time + 2);
     add3 = await generateAddWithTimestamp(fid, time + 3);

--- a/apps/hub/src/storage/stores/castStore.ts
+++ b/apps/hub/src/storage/stores/castStore.ts
@@ -1,6 +1,6 @@
 import { CastId, MessageType } from '@farcaster/flatbuffers';
 import { bytesCompare, getFarcasterTime, HubAsyncResult, HubError } from '@farcaster/utils';
-import { ok, ResultAsync } from 'neverthrow';
+import { err, ok, ResultAsync } from 'neverthrow';
 import MessageModel, { FID_BYTES, TRUE_VALUE } from '~/flatbuffers/models/messageModel';
 import { isCastAdd, isCastRemove } from '~/flatbuffers/models/typeguards';
 import { CastAddModel, CastRemoveModel, RootPrefix, StorePruneOptions, UserPostfix } from '~/flatbuffers/models/types';
@@ -255,8 +255,13 @@ class CastStore extends SequentialMergeStore {
     // Calculate the number of messages that need to be pruned, based on the store's size limit
     let sizeToPrune = count - this._pruneSizeLimit;
 
+    const farcasterTime = getFarcasterTime();
+    if (farcasterTime.isErr()) {
+      return err(farcasterTime.error);
+    }
+
     // Calculate the timestamp cut-off to prune
-    const timestampToPrune = getFarcasterTime() - this._pruneTimeLimit;
+    const timestampToPrune = farcasterTime.value - this._pruneTimeLimit;
 
     // Keep track of the messages that get pruned so that we can emit pruneMessage events after the transaction settles
     const messageToPrune: (CastAddModel | CastRemoveModel)[] = [];

--- a/apps/hub/src/storage/stores/reactionStore.test.ts
+++ b/apps/hub/src/storage/stores/reactionStore.test.ts
@@ -438,7 +438,7 @@ describe('merge', () => {
 
         const reactionRemoveMessage = await Factories.Message.create({
           data: Array.from(reactionRemoveData.bb?.bytes() ?? []),
-          hash: Array.from(bytesDecrement(reactionAdd.hash())),
+          hash: Array.from(bytesDecrement(reactionAdd.hash())._unsafeUnwrap()),
         });
 
         const reactionRemoveEarlier = new MessageModel(reactionRemoveMessage) as ReactionRemoveModel;
@@ -614,7 +614,7 @@ describe('merge', () => {
 
         const removeMessage = await Factories.Message.create({
           data: Array.from(removeData.bb?.bytes() ?? []),
-          hash: Array.from(bytesDecrement(reactionRemove.hash())),
+          hash: Array.from(bytesDecrement(reactionRemove.hash())._unsafeUnwrap()),
         });
 
         const reactionRemoveEarlier = new MessageModel(removeMessage) as ReactionRemoveModel;
@@ -685,7 +685,7 @@ describe('pruneMessages', () => {
   };
 
   beforeAll(async () => {
-    const time = getFarcasterTime() - 10;
+    const time = getFarcasterTime()._unsafeUnwrap() - 10;
     add1 = await generateAddWithTimestamp(fid, time + 1);
     add2 = await generateAddWithTimestamp(fid, time + 2);
     add3 = await generateAddWithTimestamp(fid, time + 3);

--- a/apps/hub/src/storage/stores/reactionStore.ts
+++ b/apps/hub/src/storage/stores/reactionStore.ts
@@ -293,8 +293,13 @@ class ReactionStore extends SequentialMergeStore {
     // Calculate the number of messages that need to be pruned, based on the store's size limit
     let sizeToPrune = count - this._pruneSizeLimit;
 
+    const farcasterTime = getFarcasterTime();
+    if (farcasterTime.isErr()) {
+      return err(farcasterTime.error);
+    }
+
     // Calculate the timestamp cut-off to prune
-    const timestampToPrune = getFarcasterTime() - this._pruneTimeLimit;
+    const timestampToPrune = farcasterTime.value - this._pruneTimeLimit;
 
     // Keep track of the messages that get pruned so that we can emit pruneMessage events after the transaction settles
     const messageToPrune: (types.ReactionAddModel | types.ReactionRemoveModel)[] = [];

--- a/apps/hub/src/storage/stores/signerStore.test.ts
+++ b/apps/hub/src/storage/stores/signerStore.test.ts
@@ -489,7 +489,7 @@ describe('merge', () => {
         const removeMessage = await Factories.Message.create(
           {
             data: Array.from(removeData.bb?.bytes() ?? []),
-            hash: Array.from(bytesDecrement(signerAdd.hash())),
+            hash: Array.from(bytesDecrement(signerAdd.hash().slice())._unsafeUnwrap()),
           },
           { transient: { ethSigner: custody1 } }
         );
@@ -686,7 +686,7 @@ describe('merge', () => {
         const addMessage = await Factories.Message.create(
           {
             data: Array.from(addData.bb?.bytes() ?? []),
-            hash: Array.from(bytesDecrement(signerRemove.hash())),
+            hash: Array.from(bytesDecrement(signerRemove.hash())._unsafeUnwrap()),
           },
           { transient: { ethSigner: custody1 } }
         );
@@ -866,7 +866,7 @@ describe('pruneMessages', () => {
   };
 
   beforeAll(async () => {
-    const time = getFarcasterTime() - 10;
+    const time = getFarcasterTime()._unsafeUnwrap() - 10;
     add1 = await generateAddWithTimestamp(fid, time + 1);
     add2 = await generateAddWithTimestamp(fid, time + 2);
     add3 = await generateAddWithTimestamp(fid, time + 3);

--- a/apps/hub/src/storage/stores/userDataStore.test.ts
+++ b/apps/hub/src/storage/stores/userDataStore.test.ts
@@ -252,7 +252,7 @@ describe('pruneMessages', () => {
   };
 
   beforeAll(async () => {
-    const time = getFarcasterTime() - 10;
+    const time = getFarcasterTime()._unsafeUnwrap() - 10;
     add1 = await generateAddWithTimestamp(fid, time + 1, UserDataType.Pfp);
     add2 = await generateAddWithTimestamp(fid, time + 2, UserDataType.Display);
     add3 = await generateAddWithTimestamp(fid, time + 3, UserDataType.Bio);

--- a/apps/hub/src/storage/stores/verificationStore.test.ts
+++ b/apps/hub/src/storage/stores/verificationStore.test.ts
@@ -285,7 +285,7 @@ describe('merge', () => {
 
         const removeMessage = await Factories.Message.create({
           data: Array.from(removeData.bb?.bytes() ?? []),
-          hash: Array.from(bytesDecrement(verificationAdd.hash().slice())),
+          hash: Array.from(bytesDecrement(verificationAdd.hash().slice())._unsafeUnwrap()),
         });
 
         const verificationRemoveEarlier = new MessageModel(removeMessage) as VerificationRemoveModel;
@@ -452,7 +452,7 @@ describe('merge', () => {
 
         const addMessage = await Factories.Message.create({
           data: Array.from(addData.bb?.bytes() ?? []),
-          hash: Array.from(bytesDecrement(verificationRemove.hash().slice())),
+          hash: Array.from(bytesDecrement(verificationRemove.hash().slice())._unsafeUnwrap()),
         });
 
         const verificationAddHigherHash = new MessageModel(addMessage) as VerificationRemoveModel;
@@ -524,7 +524,7 @@ describe('pruneMessages', () => {
   };
 
   beforeAll(async () => {
-    const time = getFarcasterTime() - 10;
+    const time = getFarcasterTime()._unsafeUnwrap() - 10;
     add1 = await generateAddWithTimestamp(fid, time + 1);
     add2 = await generateAddWithTimestamp(fid, time + 2);
     add3 = await generateAddWithTimestamp(fid, time + 3);

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -14,12 +14,12 @@ const client = new Client('<insert hub address and port>');
 // Define default fid and network for created messages
 const dataOptions = { fid: 15, network: types.FarcasterNetwork.Testnet };
 
-// Create EIP-712 signer from ethers wallet (can be ethers.Wallet or ethers.JsonRpcSigner)
+// Create EIP-712 signer from ethers wallet (can be ethers.Wallet or ethers.JsonRpcSigner) (avoid _unsafeWrap in production)
 const custodyWallet = ethers.Wallet.fromMnemonic('<custody address mnemonic>');
-const eip712Signer = new Eip712Signer(custodyWallet, custodyWallet.address);
+const eip712Signer = Eip712Signer.fromSigner(custodyWallet, custodyWallet.address)._unsafeUnwrap();
 
-// Create Ed25519 signer (i.e. a delegate signer)
-const ed25519Signer = new Ed25519Signer('<ed25519 private key>');
+// Create Ed25519 signer (i.e. a delegate signer) (avoid _unsafeWrap in production)
+const ed25519Signer = Ed25519Signer.fromPrivateKey('<ed25519 private key>')._unsafeUnwrap();
 
 // Make SignerAdd message, signed by the EIP-712 signer
 const signerAdd = await makeSignerAdd({ signer: ed25519Signer.signerKeyHex }, dataOptions, eip712Signer);

--- a/packages/js/src/builders.test.ts
+++ b/packages/js/src/builders.test.ts
@@ -12,9 +12,9 @@ const timestamp = Date.now();
 const network = flatbuffers.FarcasterNetwork.Testnet;
 const tsHash = bytesToHexString(Factories.TsHash.build())._unsafeUnwrap();
 
-const ed25519Signer = new Ed25519Signer(Factories.Ed25519PrivateKey.build());
+const ed25519Signer = Ed25519Signer.fromPrivateKey(Factories.Ed25519PrivateKey.build())._unsafeUnwrap();
 const wallet = new ethers.Wallet(ethers.utils.randomBytes(32));
-const eip712Signer = new Eip712Signer(wallet, wallet.address);
+const eip712Signer = Eip712Signer.fromSigner(wallet, wallet.address)._unsafeUnwrap();
 
 describe('makeCastAddData', () => {
   test('succeeds', async () => {

--- a/packages/js/src/builders.ts
+++ b/packages/js/src/builders.ts
@@ -108,12 +108,15 @@ const makeMessageData = (
   }
 
   const timestamp = toFarcasterTime(dataOptions.timestamp || Date.now());
+  if (timestamp.isErr()) {
+    return err(timestamp.error);
+  }
 
   const dataT = new flatbuffers.MessageDataT(
     bodyType,
     bodyT,
     messageType,
-    timestamp,
+    timestamp.value,
     Array.from(serializedFid.value),
     dataOptions.network
   );

--- a/packages/utils/src/bytes.test.ts
+++ b/packages/utils/src/bytes.test.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'ethers';
-import { ok } from 'neverthrow';
+import { err, ok } from 'neverthrow';
 import {
   bigNumberToBytes,
   bytesCompare,
@@ -93,7 +93,7 @@ describe('bytesDecrement', () => {
 
     for (const [input, output] of passingCases) {
       test(`decrements byte array: ${input}`, () => {
-        expect(bytesDecrement(input, { endianness: 'big' })).toEqual(output);
+        expect(bytesDecrement(input, { endianness: 'big' })).toEqual(ok(output));
       });
     }
 
@@ -101,7 +101,9 @@ describe('bytesDecrement', () => {
 
     for (const input of failingCases) {
       test(`fails when decrementing byte array: ${input}`, () => {
-        expect(() => bytesDecrement(input, { endianness: 'big' })).toThrow(HubError);
+        expect(bytesDecrement(input, { endianness: 'big' })).toEqual(
+          err(new HubError('bad_request.invalid_param', 'Cannot decrement zero'))
+        );
       });
     }
   });
@@ -118,7 +120,7 @@ describe('bytesDecrement', () => {
 
     for (const [input, output] of passingCases) {
       test(`decrements byte array: ${input}`, () => {
-        expect(bytesDecrement(input)).toEqual(output);
+        expect(bytesDecrement(input)).toEqual(ok(output));
       });
     }
 
@@ -126,7 +128,7 @@ describe('bytesDecrement', () => {
 
     for (const input of failingCases) {
       test(`fails when decrementing byte array: ${input}`, () => {
-        expect(() => bytesDecrement(input)).toThrow(HubError);
+        expect(bytesDecrement(input)).toEqual(err(new HubError('bad_request.invalid_param', 'Cannot decrement zero')));
       });
     }
   });

--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -61,8 +61,7 @@ export const bytesIncrement = (inputBytes: Uint8Array, options: BytesOptions = {
   }
 };
 
-// TODO: support both big and little endian
-export const bytesDecrement = (inputBytes: Uint8Array, options: BytesOptions = {}): Uint8Array => {
+export const bytesDecrement = (inputBytes: Uint8Array, options: BytesOptions = {}): HubResult<Uint8Array> => {
   const bytes = new Uint8Array(inputBytes); // avoid mutating input
 
   const endianness: Endianness = options.endianness ?? 'little';
@@ -73,10 +72,10 @@ export const bytesDecrement = (inputBytes: Uint8Array, options: BytesOptions = {
     const pos = endianness === 'little' ? bytes.length - 1 - i : i;
     if ((bytes[pos] as number) > 0) {
       bytes[pos] = (bytes[pos] as number) - 1;
-      return bytes;
+      return ok(bytes);
     } else {
       if (i === 0) {
-        throw new HubError('bad_request.invalid_param', 'Cannot decrement zero');
+        return err(new HubError('bad_request.invalid_param', 'Cannot decrement zero'));
       }
 
       bytes[pos] = 255;
@@ -84,7 +83,7 @@ export const bytesDecrement = (inputBytes: Uint8Array, options: BytesOptions = {
     i = i - 1;
   }
 
-  return bytes;
+  return ok(bytes);
 };
 
 export const toByteBuffer = (buffer: Buffer): ByteBuffer => {

--- a/packages/utils/src/factories.test.ts
+++ b/packages/utils/src/factories.test.ts
@@ -33,7 +33,10 @@ describe('TsHashFactory', () => {
   });
 
   test('accepts timestamp', () => {
-    const tsHash = Factories.TsHash.build({}, { transient: { timestamp: toFarcasterTime(Date.now()) } });
+    const tsHash = Factories.TsHash.build(
+      {},
+      { transient: { timestamp: toFarcasterTime(Date.now())._unsafeUnwrap() } }
+    );
     expect(tsHash.byteLength).toEqual(20);
   });
 });

--- a/packages/utils/src/factories.ts
+++ b/packages/utils/src/factories.ts
@@ -54,7 +54,7 @@ const FnameFactory = Factory.define<Uint8Array>(() => {
 });
 
 const TsHashFactory = Factory.define<Uint8Array, { timestamp?: number; hash?: Uint8Array }>(({ transientParams }) => {
-  const timestamp = transientParams.timestamp ?? toFarcasterTime(faker.date.recent().getTime());
+  const timestamp = transientParams.timestamp ?? toFarcasterTime(faker.date.recent().getTime())._unsafeUnwrap();
   const hash = transientParams.hash ?? blake3(faker.random.alphaNumeric(256), { dkLen: 16 });
   return toTsHash(timestamp, hash)._unsafeUnwrap();
 });
@@ -98,7 +98,7 @@ const MessageDataFactory = Factory.define<flatbuffers.MessageDataT, any, flatbuf
     flatbuffers.MessageBody.CastAddBody,
     CastAddBodyFactory.build(),
     flatbuffers.MessageType.CastAdd,
-    toFarcasterTime(faker.date.recent().getTime()),
+    toFarcasterTime(faker.date.recent().getTime())._unsafeUnwrap(),
     Array.from(FIDFactory.build()),
     flatbuffers.FarcasterNetwork.Testnet
   );
@@ -495,7 +495,7 @@ const Ed25519PrivateKeyFactory = Factory.define<Uint8Array>(() => {
 });
 
 const Ed25519SignerFactory = Factory.define<Ed25519Signer>(() => {
-  return new Ed25519Signer(Ed25519PrivateKeyFactory.build());
+  return Ed25519Signer.fromPrivateKey(Ed25519PrivateKeyFactory.build())._unsafeUnwrap();
 });
 
 const Ed25519SignatureFactory = Factory.define<Uint8Array>(() => {
@@ -504,7 +504,7 @@ const Ed25519SignatureFactory = Factory.define<Uint8Array>(() => {
 
 const Eip712SignerFactory = Factory.define<Eip712Signer>(() => {
   const wallet = new ethers.Wallet(ethers.utils.randomBytes(32));
-  return new Eip712Signer(wallet, wallet.address);
+  return Eip712Signer.fromSigner(wallet, wallet.address)._unsafeUnwrap();
 });
 
 const Eip712SignatureFactory = Factory.define<Uint8Array>(() => {

--- a/packages/utils/src/signers/ed25519Signer.test.ts
+++ b/packages/utils/src/signers/ed25519Signer.test.ts
@@ -9,7 +9,7 @@ describe('Ed25519Signer', () => {
   const privateKey = Factories.Ed25519PrivateKey.build();
 
   beforeAll(async () => {
-    signer = new Ed25519Signer(privateKey);
+    signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
   });
 
   describe('static methods', () => {

--- a/packages/utils/src/signers/eip712Signer.test.ts
+++ b/packages/utils/src/signers/eip712Signer.test.ts
@@ -16,7 +16,7 @@ describe('Eip712Signer', () => {
   beforeAll(async () => {
     typedDataSigner = new ethers.Wallet(ethers.utils.randomBytes(32));
     ethAddress = await typedDataSigner.getAddress();
-    signer = new Eip712Signer(typedDataSigner, ethAddress);
+    signer = Eip712Signer.fromSigner(typedDataSigner, ethAddress)._unsafeUnwrap();
   });
 
   describe('static methods', () => {

--- a/packages/utils/src/signers/eip712Signer.ts
+++ b/packages/utils/src/signers/eip712Signer.ts
@@ -20,15 +20,15 @@ export class Eip712Signer implements Signer {
 
   private readonly _typedDataSigner: TypedDataSigner;
 
-  constructor(typedDataSigner: TypedDataSigner, address: string) {
+  public static fromSigner(typedDataSigner: TypedDataSigner, address: string) {
+    const signerKeyHex = address.toLowerCase();
+    return hexStringToBytes(signerKeyHex).map((signerKey) => new this(typedDataSigner, address, signerKey));
+  }
+
+  constructor(typedDataSigner: TypedDataSigner, address: string, signerKey: Uint8Array) {
     this._typedDataSigner = typedDataSigner;
     this.signerKeyHex = address.toLowerCase();
-
-    const signerKey = hexStringToBytes(this.signerKeyHex);
-    if (signerKey.isErr()) {
-      throw signerKey.error;
-    }
-    this.signerKey = signerKey.value;
+    this.signerKey = signerKey;
   }
 
   /** generates 256-bit signature from an Ethereum address */

--- a/packages/utils/src/time.test.ts
+++ b/packages/utils/src/time.test.ts
@@ -1,20 +1,23 @@
+import { err } from 'neverthrow';
 import { HubError } from './errors';
 import { FARCASTER_EPOCH, fromFarcasterTime, toFarcasterTime } from './time';
 
 describe('fromFarcasterTime', () => {
   test('returns seconds since 01/01/2022', () => {
     const time = Date.now();
-    const farcasterTime = toFarcasterTime(time);
+    const farcasterTime = toFarcasterTime(time)._unsafeUnwrap();
     expect(farcasterTime).toBeLessThan(2 ** 32 - 1); // uint32 max value
     expect(fromFarcasterTime(farcasterTime)).toEqual(Math.round(time / 1000) * 1000);
   });
 
   test('fails for time before 01/01/2022', () => {
-    expect(() => toFarcasterTime(FARCASTER_EPOCH - 1)).toThrow(HubError);
+    expect(toFarcasterTime(FARCASTER_EPOCH - 1)).toEqual(
+      err(new HubError('bad_request.invalid_param', 'time must be after Farcaster epoch (01/01/2022)'))
+    );
   });
 
   test('fails when farcaster time does not fit in uint32', () => {
     const time = (FARCASTER_EPOCH / 1000 + 2 ** 32) * 1000;
-    expect(() => toFarcasterTime(time)).toThrow(HubError);
+    expect(toFarcasterTime(time)).toEqual(err(new HubError('bad_request.invalid_param', 'time too far in future')));
   });
 });

--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -1,19 +1,20 @@
-import { HubError } from './errors';
+import { err, ok } from 'neverthrow';
+import { HubError, HubResult } from './errors';
 
 export const FARCASTER_EPOCH = 1640995200000; // January 1, 2022 UTC
-export const getFarcasterTime = (): number => {
+export const getFarcasterTime = (): HubResult<number> => {
   return toFarcasterTime(Date.now());
 };
 
-export const toFarcasterTime = (time: number): number => {
+export const toFarcasterTime = (time: number): HubResult<number> => {
   if (time < FARCASTER_EPOCH) {
-    throw new HubError('bad_request.invalid_param', 'time must be after Farcaster epoch (01/01/2022)');
+    return err(new HubError('bad_request.invalid_param', 'time must be after Farcaster epoch (01/01/2022)'));
   }
   const secondsSinceEpoch = Math.round((time - FARCASTER_EPOCH) / 1000);
   if (secondsSinceEpoch > 2 ** 32 - 1) {
-    throw new HubError('bad_request.invalid_param', 'time too far in future');
+    return err(new HubError('bad_request.invalid_param', 'time too far in future'));
   }
-  return secondsSinceEpoch;
+  return ok(secondsSinceEpoch);
 };
 
 export const fromFarcasterTime = (time: number): number => {

--- a/packages/utils/src/tsHash.test.ts
+++ b/packages/utils/src/tsHash.test.ts
@@ -4,7 +4,7 @@ import { Factories } from './factories';
 import { toFarcasterTime } from './time';
 import { toTsHash } from './tsHash';
 
-const farcasterTimeNow = toFarcasterTime(Date.now());
+const farcasterTimeNow = toFarcasterTime(Date.now())._unsafeUnwrap();
 
 test('stores timestamp in big-endian order', () => {
   const hash = Factories.Bytes.build({}, { transient: { length: 16 } });

--- a/packages/utils/src/validations.test.ts
+++ b/packages/utils/src/validations.test.ts
@@ -654,7 +654,7 @@ describe('validateMessage', () => {
 describe('validateMessageData', () => {
   test('fails with timestamp more than 10 mins in the future', async () => {
     const data = await Factories.MessageData.create({
-      timestamp: getFarcasterTime() + validations.ALLOWED_CLOCK_SKEW_SECONDS + 1,
+      timestamp: getFarcasterTime()._unsafeUnwrap() + validations.ALLOWED_CLOCK_SKEW_SECONDS + 1,
     });
     const result = await validations.validateMessageData(data);
     expect(result._unsafeUnwrapErr()).toEqual(

--- a/packages/utils/src/validations.ts
+++ b/packages/utils/src/validations.ts
@@ -186,8 +186,13 @@ export const validateMessageData = (data: flatbuffers.MessageData): HubResult<fl
     return err(validFid.error);
   }
 
+  const farcasterTime = getFarcasterTime();
+  if (farcasterTime.isErr()) {
+    return err(farcasterTime.error);
+  }
+
   // 2. Validate timestamp
-  if (data.timestamp() - getFarcasterTime() > ALLOWED_CLOCK_SKEW_SECONDS) {
+  if (data.timestamp() - farcasterTime.value > ALLOWED_CLOCK_SKEW_SECONDS) {
     return err(new HubError('bad_request.validation_failure', 'timestamp more than 10 mins in the future'));
   }
 


### PR DESCRIPTION
## Motivation

moves #213 forward by refactoring @farcaster/utils to use HubResult

## Change Summary

- removes all usages of `throw` from `packages/*`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
