### PR TITLE
feat: Add debugging console REPL

### DIFF
--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -23,6 +23,7 @@
     "lint:fix": "yarn run lint -- --fix",
     "start": "tsx src/cli.ts start",
     "identity": "tsx src/cli.ts identity",
+    "console": "tsx src/cli.ts console",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage"
   },

--- a/apps/hub/src/cli.ts
+++ b/apps/hub/src/cli.ts
@@ -11,6 +11,7 @@ import { exit } from 'process';
 import { APP_VERSION, Hub, HubOptions } from '~/hub';
 import { logger } from '~/utils/logger';
 import { addressInfoFromParts, ipMultiAddrStrFromAddressInfo } from '~/utils/p2p';
+import { startConsole } from './console/console';
 
 /** A CLI to accept options from the user and start the Hub */
 
@@ -184,6 +185,13 @@ app
   .description('Create or verify a peerID')
   .addCommand(createIdCommand)
   .addCommand(verifyIdCommand);
+
+app
+  .command('console')
+  .description('Start a REPL console')
+  .action(async () => {
+    startConsole();
+  });
 
 const readPeerId = async (filePath: string) => {
   const proto = await readFile(filePath);

--- a/apps/hub/src/console/castsCommand.ts
+++ b/apps/hub/src/console/castsCommand.ts
@@ -1,0 +1,90 @@
+import { CastIdT, UserIdT } from '~/../../../packages/flatbuffers/dist';
+import { hexStringToBytes, HubError } from '~/../../../packages/utils/dist';
+import MessageModel from '~/flatbuffers/models/messageModel';
+import HubRpcClient from '~/rpc/client';
+
+export class CastsCommand {
+  constructor(private readonly rpcClient: HubRpcClient) {}
+
+  castByFidAndHash = async (fid: string, tsHash: string): Promise<string | MessageModel> => {
+    const fidBytes = hexStringToBytes(fid);
+    if (fidBytes.isErr()) {
+      return JSON.stringify(fidBytes.error);
+    }
+
+    const tsHashBytes = hexStringToBytes(tsHash);
+    if (tsHashBytes.isErr()) {
+      return JSON.stringify(tsHashBytes.error);
+    }
+
+    const result = await this.rpcClient.getCast(fidBytes._unsafeUnwrap(), tsHashBytes._unsafeUnwrap());
+    return result.match<string | MessageModel>(
+      (cast) => {
+        const mm = new MessageModel(cast);
+        return mm;
+      },
+      (err: HubError) => {
+        return `${err}`;
+      }
+    );
+  };
+
+  castsByFid = async (fid: string): Promise<string | MessageModel[]> => {
+    const fidBytes = hexStringToBytes(fid);
+    if (fidBytes.isErr()) {
+      return JSON.stringify(fidBytes.error);
+    }
+
+    const result = await this.rpcClient.getCastsByFid(fidBytes._unsafeUnwrap());
+    return result.match<string | MessageModel[]>(
+      (casts) => {
+        return casts.map((cast) => new MessageModel(cast));
+      },
+      (err: HubError) => {
+        return `${err}`;
+      }
+    );
+  };
+
+  castsByParent = async (fid: string, tsHash: string): Promise<string | MessageModel[]> => {
+    const fidBytes = hexStringToBytes(fid);
+    if (fidBytes.isErr()) {
+      return JSON.stringify(fidBytes.error);
+    }
+
+    const tsHashBytes = hexStringToBytes(tsHash);
+    if (tsHashBytes.isErr()) {
+      return JSON.stringify(tsHashBytes.error);
+    }
+
+    const castIdT = new CastIdT(Array.from(tsHashBytes._unsafeUnwrap()), Array.from(tsHashBytes._unsafeUnwrap()));
+    const result = await this.rpcClient.getCastsByParent(castIdT);
+    return result.match<string | MessageModel[]>(
+      (casts) => {
+        return casts.map((cast) => new MessageModel(cast));
+      },
+      (err: HubError) => {
+        return `${err}`;
+      }
+    );
+  };
+
+  castsByMention = async (userId: string): Promise<string | MessageModel[]> => {
+    const userFidBytes = hexStringToBytes(userId);
+    if (userFidBytes.isErr()) {
+      return JSON.stringify(userFidBytes.error);
+    }
+
+    const userIdT = new UserIdT(Array.from(userFidBytes._unsafeUnwrap()));
+
+    const result = await this.rpcClient.getCastsByMention(userIdT);
+    return result.match<string | MessageModel[]>(
+      (casts) => {
+        return casts.map((cast) => new MessageModel(cast));
+      },
+      (err: HubError) => {
+        return `${err}`;
+      }
+    );
+  };
+}

--- a/apps/hub/src/console/console.ts
+++ b/apps/hub/src/console/console.ts
@@ -1,0 +1,53 @@
+import path from 'path';
+import * as repl from 'repl';
+import HubRpcClient from '~/rpc/client';
+import { logger } from '~/utils/logger';
+import { addressInfoFromParts } from '~/utils/p2p';
+import { CastsCommand } from './castsCommand';
+import { InfoCommand } from './infoCommand';
+import { SyncTrieCommand } from './syncTrieCommand';
+
+const addressInfo = addressInfoFromParts('127.0.0.1', 13112)._unsafeUnwrap();
+
+export const startConsole = async () => {
+  const replServer = repl
+    .start({
+      prompt: 'hub> ',
+      useColors: true,
+      useGlobal: true,
+      breakEvalOnSigint: true,
+    })
+    .on('exit', () => {
+      process.exit(0);
+    });
+
+  replServer.output.write("\nWelcome to the Hub console. Type '.help' for a list of commands.\n");
+  replServer.output.write('Connected to hub at ' + JSON.stringify(addressInfo) + '\n');
+
+  replServer.setupHistory(path.join(process.cwd(), '.hub_history'), (err) => {
+    if (err) {
+      logger.error(err);
+    }
+  });
+
+  replServer.defineCommand('help', {
+    help: 'Show this help',
+    action() {
+      this.clearBufferedCommand();
+      this.output.write(`Available commands:
+            syncTrie: Query the sync trie
+            info: Get the hub version info
+            casts: Get the list of casts by fid/tsHash or other parameters
+    `);
+      this.displayPrompt();
+    },
+  });
+
+  const rpcClient = new HubRpcClient(addressInfo);
+
+  replServer.context['syncTrie'] = new SyncTrieCommand(rpcClient);
+  replServer.context['info'] = new InfoCommand(rpcClient);
+  replServer.context['casts'] = new CastsCommand(rpcClient);
+
+  replServer.displayPrompt();
+};

--- a/apps/hub/src/console/infoCommand.ts
+++ b/apps/hub/src/console/infoCommand.ts
@@ -1,0 +1,22 @@
+import { HubError } from '~/../../../packages/utils/dist';
+import HubRpcClient from '~/rpc/client';
+
+export class InfoCommand {
+  constructor(private readonly rpcClient: HubRpcClient) {}
+
+  info = async () => {
+    const result = await this.rpcClient.getInfo();
+    return result.match(
+      (info) => {
+        return JSON.stringify(
+          { version: info.version(), synced: info.synced(), nickname: info.nickname(), root_hash: info.rootHash() },
+          null,
+          2
+        );
+      },
+      (err: HubError) => {
+        return `${err}`;
+      }
+    );
+  };
+}

--- a/apps/hub/src/console/syncTrieCommand.ts
+++ b/apps/hub/src/console/syncTrieCommand.ts
@@ -1,0 +1,54 @@
+import { HubError } from '~/../../../packages/utils/dist';
+import HubRpcClient from '~/rpc/client';
+
+export class SyncTrieCommand {
+  constructor(private readonly rpcClient: HubRpcClient) {}
+
+  rootHash = async () => {
+    const result = await this.rpcClient.getSyncTrieNodeSnapshotByPrefix('');
+    return result.match(
+      (snapshot) => {
+        return snapshot.rootHash;
+      },
+      (err: HubError) => {
+        return `${err}`;
+      }
+    );
+  };
+
+  snapshot = async (prefix?: string) => {
+    const result = await this.rpcClient.getSyncTrieNodeSnapshotByPrefix(prefix ?? '');
+    return result.match(
+      (snapshot) => {
+        return JSON.stringify(snapshot.snapshot, null, 2);
+      },
+      (err: HubError) => {
+        return `${err}`;
+      }
+    );
+  };
+
+  metadata = async (prefix?: string) => {
+    const result = await this.rpcClient.getSyncMetadataByPrefix(prefix ?? '');
+    return result.match(
+      (metadata) => {
+        return JSON.stringify(metadata, null, 2);
+      },
+      (err: HubError) => {
+        return `${err}`;
+      }
+    );
+  };
+
+  syncIds = async (prefix?: string) => {
+    const result = await this.rpcClient.getSyncIdsByPrefix(prefix ?? '');
+    return result.match(
+      (syncIds) => {
+        return JSON.stringify(syncIds, null, 2);
+      },
+      (err: HubError) => {
+        return `${err}`;
+      }
+    );
+  };
+}

--- a/apps/hub/src/rpc/server/serviceImplementations/syncImplementation.ts
+++ b/apps/hub/src/rpc/server/serviceImplementations/syncImplementation.ts
@@ -73,7 +73,7 @@ export const syncImplementation = (engine: Engine, syncEngine: SyncEngine) => {
       if (result) {
         callback(null, toTrieNodeMetadataResponse(result));
       } else {
-        const err = new HubError('bad_request', 'Failed to get trie node metadata');
+        const err = new HubError('bad_request', `Failed to get trie node metadata at ${prefix}`);
         callback(toServiceError(err));
       }
     },


### PR DESCRIPTION
## Motivation

Add a debugging REPL to the hubs

## Change Summary

- A new command `yarn console` will connect to the local Hub with the nodejs REPL.
- Several commands are available to inspect the Hub's internal state (".help" to see a list of commands)

eg: `hub> await syncTrie.rootHash()` will fetch the Hub's root hash. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)


## Additional Context

This connects to a running Hub over RPC, so you need to run it in a separate terminal window. 
