### PR TITLE
chore: clean up unused syncThreshold test in syncEngine

### DIFF
--- a/apps/hub/src/network/sync/syncEngine.test.ts
+++ b/apps/hub/src/network/sync/syncEngine.test.ts
@@ -231,17 +231,6 @@ describe('SyncEngine', () => {
     expect(syncEngine.shouldSync(oldSnapshot.excludedHashes)).toBeTruthy();
   });
 
-  // xtest('should not sync if messages were added within the sync threshold', async () => {
-  //   const user = await mockFid(engine, faker.datatype.number());
-  //   const snapshotTimestamp = syncEngine.snapshotTimestamp;
-  //   await addMessagesWithTimestamps(user, [snapshotTimestamp - 3, snapshotTimestamp - 2, snapshotTimestamp - 1]);
-
-  //   const snapshot = syncEngine.snapshot;
-  //   // Add a message after the snapshot, within the sync threshold
-  //   await addMessagesWithTimestamps(user, [snapshotTimestamp + 1]);
-  //   expect(syncEngine.shouldSync(snapshot.excludedHashes)).toBeFalsy();
-  // });
-
   test('initialize populates the trie with all existing messages', async () => {
     await engine.mergeIdRegistryEvent(custodyEvent);
     await engine.mergeMessage(signerAdd);


### PR DESCRIPTION
## Motivation

[see this convo](https://github.com/farcasterxyz/hub/pull/279#issuecomment-1385718251)
## Change Summary

- removes unused test code

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)