### PR TITLE
fix: Init sync engine with hub start

### DIFF
--- a/apps/hub/src/hub.ts
+++ b/apps/hub/src/hub.ts
@@ -191,6 +191,9 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
     // Start the ETH registry provider first
     await this.ethRegistryProvider.start();
 
+    // Start the sync engine
+    await this.syncEngine.initialize();
+
     await this.gossipNode.start(this.options.bootstrapAddrs ?? [], {
       peerId: this.options.peerId,
       ipMultiAddr: this.options.ipMultiAddr,


### PR DESCRIPTION
## Motivation

Initialize the sync engine at startup so the existing syncTrie loads correctly

## Change Summary

- Call `syncEngine.initialize` on hub startup

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
