### PR TITLE
fix: Switch to 160-bit hash

### DIFF
--- a/apps/hub/src/network/sync/merkleTrie.test.ts
+++ b/apps/hub/src/network/sync/merkleTrie.test.ts
@@ -224,7 +224,7 @@ describe('MerkleTrie', () => {
       // We expect the excluded hash to be the hash of the 3 and 4 child nodes, and excludes the 5 child node
       const expectedHash = Buffer.from(
         blake3
-          .create({ dkLen: 16 })
+          .create({ dkLen: 20 })
           .update(node?.children?.get('3')?.hash || '')
           .update(node?.children?.get('4')?.hash || '')
           .digest()
@@ -244,11 +244,11 @@ describe('MerkleTrie', () => {
 
       snapshot = trie.getSnapshot('1665182343');
       node = trie.getTrieNodeMetadata('166518234');
-      const expectedLastHash = Buffer.from(blake3(node?.children?.get('5')?.hash || '', { dkLen: 16 })).toString('hex');
+      const expectedLastHash = Buffer.from(blake3(node?.children?.get('5')?.hash || '', { dkLen: 20 })).toString('hex');
       node = trie.getTrieNodeMetadata('16651823');
       const expectedPenultimateHash = Buffer.from(
         blake3
-          .create({ dkLen: 16 })
+          .create({ dkLen: 20 })
           .update(node?.children?.get('3')?.hash || '')
           .update(node?.children?.get('5')?.hash || '')
           .digest()

--- a/apps/hub/src/network/sync/syncId.ts
+++ b/apps/hub/src/network/sync/syncId.ts
@@ -1,7 +1,7 @@
 import MessageModel from '~/flatbuffers/models/messageModel';
 
 const TIMESTAMP_LENGTH = 10; // 10 bytes for timestamp in decimal
-const HASH_LENGTH = 128; // We're using 64 byte blake2b hashes
+const HASH_LENGTH = 160; // We're using 20 byte blake2b hashes
 
 /**
  * SyncId allows for a stable, time ordered lexicographic sorting of messages across hubs

--- a/apps/hub/src/network/sync/trieNode.ts
+++ b/apps/hub/src/network/sync/trieNode.ts
@@ -2,7 +2,7 @@ import { HubError } from '@farcaster/utils';
 import { blake3 } from '@noble/hashes/blake3';
 import { TIMESTAMP_LENGTH } from '~/network/sync/syncId';
 
-export const EMPTY_HASH = Buffer.from(blake3('', { dkLen: 16 })).toString('hex');
+export const EMPTY_HASH = Buffer.from(blake3('', { dkLen: 20 })).toString('hex');
 
 /**
  * A snapshot of the trie at a particular timestamp which can be used to determine if two
@@ -218,7 +218,7 @@ class TrieNode {
 
   private _excludedHash(char: string): { items: number; hash: string } {
     // TODO: Cache this for performance
-    const hash = blake3.create({ dkLen: 16 });
+    const hash = blake3.create({ dkLen: 20 });
     let excludedItems = 0;
     this._children.forEach((child, key) => {
       if (key !== char) {
@@ -255,11 +255,10 @@ class TrieNode {
   }
 
   private _updateHash() {
-    // TODO: Optimize by using a faster hash algorithm. Potentially murmurhash v3
     if (this.isLeaf) {
-      this._hash = Buffer.from(blake3(this.value || '', { dkLen: 16 })).toString('hex');
+      this._hash = Buffer.from(blake3(this.value || '', { dkLen: 20 })).toString('hex');
     } else {
-      const hash = blake3.create({ dkLen: 16 });
+      const hash = blake3.create({ dkLen: 20 });
       this._children.forEach((child) => {
         hash.update(child.hash);
       });

--- a/packages/js/src/builders.ts
+++ b/packages/js/src/builders.ts
@@ -142,7 +142,7 @@ const makeMessage = async (messageData: flatbuffers.MessageData, signer: Signer)
     return err(new HubError('bad_request.invalid_param', 'data is missing'));
   }
 
-  const hash = await blake3(dataBytes, { dkLen: 16 });
+  const hash = blake3(dataBytes, { dkLen: 20 });
 
   const signature = await signer.signMessageHash(hash);
   if (signature.isErr()) {
@@ -169,8 +169,8 @@ const makeMessage = async (messageData: flatbuffers.MessageData, signer: Signer)
 /** Generic Methods */
 
 export const makeMessageHash = async (messageData: types.MessageData): HubAsyncResult<string> => {
-  const hashBytes = await blake3(messageData.flatbuffer.bb?.bytes() ?? new Uint8Array(), { dkLen: 16 });
-  return bytesToHexString(hashBytes, { size: 32 });
+  const hashBytes = blake3(messageData.flatbuffer.bb?.bytes() ?? new Uint8Array(), { dkLen: 20 });
+  return bytesToHexString(hashBytes, { size: 40 });
 };
 
 export const makeMessageWithSignature = async (
@@ -183,7 +183,7 @@ export const makeMessageWithSignature = async (
     return err(new HubError('bad_request.invalid_param', 'data is missing'));
   }
 
-  const hash = await blake3(dataBytes, { dkLen: 16 });
+  const hash = blake3(dataBytes, { dkLen: 20 });
 
   const signatureBytes = hexStringToBytes(signature);
   if (signatureBytes.isErr()) {

--- a/packages/js/src/utils.ts
+++ b/packages/js/src/utils.ts
@@ -588,7 +588,7 @@ export const deserializeEd25519Signature = (bytes: Uint8Array): HubResult<string
  * Deserialize a message hash from a byte array to hex string.
  */
 export const deserializeMessageHash = (bytes: Uint8Array): HubResult<string> => {
-  return bytesToHexString(bytes, { size: 32 });
+  return bytesToHexString(bytes, { size: 40 });
 };
 
 export const deserializeFid = (fid: Uint8Array): HubResult<number> => {
@@ -632,7 +632,7 @@ export const serializeEd25519PublicKey = (publicKey: string): HubResult<Uint8Arr
 };
 
 export const deserializeTsHash = (tsHash: Uint8Array): HubResult<string> => {
-  return validations.validateTsHash(tsHash).andThen((tsHash) => bytesToHexString(tsHash, { size: 40 }));
+  return validations.validateTsHash(tsHash).andThen((tsHash) => bytesToHexString(tsHash, { size: 48 }));
 };
 
 export const serializeTsHash = (tsHash: string): HubResult<Uint8Array> => {

--- a/packages/utils/src/crypto/ed25519.test.ts
+++ b/packages/utils/src/crypto/ed25519.test.ts
@@ -24,7 +24,7 @@ describe('signMessageHash', () => {
   test('succeeds', async () => {
     const messageData = await Factories.SignerAddData.create();
     const bytes = messageData.bb?.bytes() ?? new Uint8Array();
-    const hash = blake3(bytes, { dkLen: 16 });
+    const hash = blake3(bytes, { dkLen: 20 });
     const signature = await ed25519.signMessageHash(hash, privateKey);
     const isValid = await ed.verify(signature._unsafeUnwrap(), hash, publicKey);
     expect(isValid).toBe(true);
@@ -35,7 +35,7 @@ describe('verifyMessageHashSignature', () => {
   test('succeeds with valid signature', async () => {
     const messageData = await Factories.SignerAddData.create();
     const bytes = messageData.bb?.bytes() ?? new Uint8Array();
-    const hash = blake3(bytes, { dkLen: 16 });
+    const hash = blake3(bytes, { dkLen: 20 });
     const signature = await ed25519.signMessageHash(hash, privateKey);
     const isValid = await ed25519.verifyMessageHashSignature(signature._unsafeUnwrap(), hash, publicKey);
     expect(isValid._unsafeUnwrap()).toBe(true);
@@ -44,7 +44,7 @@ describe('verifyMessageHashSignature', () => {
   test('fails with invalid signature', async () => {
     const messageData = await Factories.SignerAddData.create();
     const bytes = messageData.bb?.bytes() ?? new Uint8Array();
-    const hash = blake3(bytes, { dkLen: 16 });
+    const hash = blake3(bytes, { dkLen: 20 });
     const isValid = await ed25519.verifyMessageHashSignature(randomBytes(32), hash, privateKey);
     expect(isValid._unsafeUnwrapErr()).toBeInstanceOf(HubError);
   });

--- a/packages/utils/src/crypto/eip712.test.ts
+++ b/packages/utils/src/crypto/eip712.test.ts
@@ -51,7 +51,7 @@ describe('signMessageHash', () => {
   test('succeeds', async () => {
     const messageData = await Factories.SignerAddData.create();
     const bytes = messageData.bb?.bytes() ?? new Uint8Array();
-    const hash = blake3(bytes, { dkLen: 16 });
+    const hash = blake3(bytes, { dkLen: 20 });
     const signature = await eip712.signMessageHash(hash, wallet);
     const recoveredAddress = eip712.verifyMessageHashSignature(hash, signature._unsafeUnwrap());
     expect(recoveredAddress._unsafeUnwrap()).toEqual(hexStringToBytes(wallet.address)._unsafeUnwrap());

--- a/packages/utils/src/factories.test.ts
+++ b/packages/utils/src/factories.test.ts
@@ -27,9 +27,9 @@ describe('FidFactory', () => {
 });
 
 describe('TsHashFactory', () => {
-  test('generates 20 byte value', () => {
+  test('generates 24 byte value', () => {
     const tsHash = Factories.TsHash.build();
-    expect(tsHash.byteLength).toEqual(20);
+    expect(tsHash.byteLength).toEqual(24);
   });
 
   test('accepts timestamp', () => {
@@ -37,7 +37,7 @@ describe('TsHashFactory', () => {
       {},
       { transient: { timestamp: toFarcasterTime(Date.now())._unsafeUnwrap() } }
     );
-    expect(tsHash.byteLength).toEqual(20);
+    expect(tsHash.byteLength).toEqual(24);
   });
 });
 
@@ -62,7 +62,7 @@ describe('MessageFactory', () => {
   });
 
   test('generates hash', async () => {
-    expect(message.hashArray()).toEqual(blake3(data.bb?.bytes() || new Uint8Array(), { dkLen: 16 }));
+    expect(message.hashArray()).toEqual(blake3(data.bb?.bytes() || new Uint8Array(), { dkLen: 20 }));
   });
 
   test('generates signature', async () => {

--- a/packages/utils/src/factories.ts
+++ b/packages/utils/src/factories.ts
@@ -55,7 +55,7 @@ const FnameFactory = Factory.define<Uint8Array>(() => {
 
 const TsHashFactory = Factory.define<Uint8Array, { timestamp?: number; hash?: Uint8Array }>(({ transientParams }) => {
   const timestamp = transientParams.timestamp ?? toFarcasterTime(faker.date.recent().getTime())._unsafeUnwrap();
-  const hash = transientParams.hash ?? blake3(faker.random.alphaNumeric(256), { dkLen: 16 });
+  const hash = transientParams.hash ?? blake3(faker.random.alphaNumeric(256), { dkLen: 20 });
   return toTsHash(timestamp, hash)._unsafeUnwrap();
 });
 
@@ -401,7 +401,7 @@ const MessageFactory = Factory.define<
   onCreate(async (params) => {
     // Generate hash
     if (params.hash.length === 0) {
-      params.hash = Array.from(blake3(new Uint8Array(params.data), { dkLen: 16 }));
+      params.hash = Array.from(blake3(new Uint8Array(params.data), { dkLen: 20 }));
     }
 
     // Generate signature
@@ -544,7 +544,7 @@ const Ed25519PublicKeyHexFactory = Factory.define<string>(() => {
 });
 
 const TsHashHexFactory = Factory.define<string>(() => {
-  return faker.datatype.hexadecimal({ length: 40, case: 'lower' });
+  return faker.datatype.hexadecimal({ length: 48, case: 'lower' });
 });
 
 const EventTypeFactory = Factory.define<flatbuffers.EventType>(() => {

--- a/packages/utils/src/signers/ed25519Signer.test.ts
+++ b/packages/utils/src/signers/ed25519Signer.test.ts
@@ -24,7 +24,7 @@ describe('Ed25519Signer', () => {
     describe('signMessageHash', () => {
       test('generates valid signature', async () => {
         const bytes = randomBytes(32);
-        const hash = blake3(bytes, { dkLen: 16 });
+        const hash = blake3(bytes, { dkLen: 20 });
         const signature = await signer.signMessageHash(hash);
         const isValid = await ed25519.verifyMessageHashSignature(signature._unsafeUnwrap(), hash, signer.signerKey);
         expect(isValid._unsafeUnwrap()).toBe(true);

--- a/packages/utils/src/signers/eip712Signer.test.ts
+++ b/packages/utils/src/signers/eip712Signer.test.ts
@@ -31,7 +31,7 @@ describe('Eip712Signer', () => {
     describe('signMessageHash', () => {
       test('generates valid signature', async () => {
         const bytes = randomBytes(32);
-        const hash = blake3(bytes, { dkLen: 16 });
+        const hash = blake3(bytes, { dkLen: 20 });
         const signature = await signer.signMessageHash(hash);
         const recoveredAddress = await eip712.verifyMessageHashSignature(hash, signature._unsafeUnwrap());
         expect(recoveredAddress._unsafeUnwrap()).toEqual(signer.signerKey);

--- a/packages/utils/src/validations.test.ts
+++ b/packages/utils/src/validations.test.ts
@@ -95,17 +95,17 @@ describe('validateTsHash', () => {
     );
   });
 
-  test('fails when greater than 20 bytes', () => {
-    const tsHash = Factories.Bytes.build({}, { transient: { length: 21 } });
+  test('fails when greater than 24 bytes', () => {
+    const tsHash = Factories.Bytes.build({}, { transient: { length: 25 } });
     expect(validations.validateTsHash(tsHash)._unsafeUnwrapErr()).toEqual(
-      new HubError('bad_request.validation_failure', 'tsHash must be 20 bytes')
+      new HubError('bad_request.validation_failure', `tsHash must be 24 bytes, was ${tsHash.byteLength} bytes`)
     );
   });
 
-  test('fails when less than 20 bytes', () => {
-    const tsHash = Factories.Bytes.build({}, { transient: { length: 19 } });
+  test('fails when less than 24 bytes', () => {
+    const tsHash = Factories.Bytes.build({}, { transient: { length: 20 } });
     expect(validations.validateTsHash(tsHash)._unsafeUnwrapErr()).toEqual(
-      new HubError('bad_request.validation_failure', 'tsHash must be 20 bytes')
+      new HubError('bad_request.validation_failure', `tsHash must be 24 bytes, was ${tsHash.byteLength} bytes`)
     );
   });
 
@@ -740,5 +740,5 @@ describe('validateEd25519PublicKeyHex', () => {
 });
 
 describe('validateTsHashHex', () => {
-  testHexValidation(validations.validateTsHashHex, Factories.TsHashHex.build(), 40, 'ts-hash');
+  testHexValidation(validations.validateTsHashHex, Factories.TsHashHex.build(), 48, 'tsHash');
 });

--- a/packages/utils/src/validations.ts
+++ b/packages/utils/src/validations.ts
@@ -65,8 +65,10 @@ export const validateTsHash = (tsHash?: Uint8Array | null): HubResult<Uint8Array
     return err(new HubError('bad_request.validation_failure', 'tsHash is missing'));
   }
 
-  if (tsHash.byteLength !== 20) {
-    return err(new HubError('bad_request.validation_failure', 'tsHash must be 20 bytes'));
+  if (tsHash.byteLength !== 24) {
+    return err(
+      new HubError('bad_request.validation_failure', `tsHash must be 24 bytes, was ${tsHash.byteLength} bytes`)
+    );
   }
 
   return ok(tsHash);
@@ -139,7 +141,7 @@ export const validateMessage = async (message: flatbuffers.Message): HubAsyncRes
   }
 
   if (message.hashScheme() === flatbuffers.HashScheme.Blake3) {
-    const computedHash = blake3(dataBytes, { dkLen: 16 });
+    const computedHash = blake3(dataBytes, { dkLen: 20 });
     // we have to use bytesCompare, because TypedArrays cannot be compared directly
     if (bytesCompare(hash, computedHash) !== 0) {
       return err(new HubError('bad_request.validation_failure', 'invalid hash'));
@@ -523,4 +525,4 @@ export const validateEd25519ignatureHex = buildValidateHex(128, 'Ed25519 signatu
 export const validateMessageHashHex = buildValidateHex(32, 'message hash');
 export const validateEthAddressHex = buildValidateHex(40, 'eth address');
 export const validateEd25519PublicKeyHex = buildValidateHex(64, 'Ed25519 public key');
-export const validateTsHashHex = buildValidateHex(40, 'ts-hash');
+export const validateTsHashHex = buildValidateHex(48, 'tsHash');


### PR DESCRIPTION
## Motivation

Switch the Sync trie hash to be 20 bytes (160-bit)

## Change Summary

- switch to blake3 160-bit hash for sync trie.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
