### PR TITLE
fix: Add require shim to esbuild

### DIFF
--- a/packages/protobufs/package.json
+++ b/packages/protobufs/package.json
@@ -16,9 +16,9 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "build": "tsup --config tsup.config.ts",
     "clean": "rimraf ./dist",
-    "protoc": "protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./src/generated/ --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false --proto_path=./src/schemas ./src/schemas/*",
+    "protoc": "protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./src/generated/ --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputServices=grpc-js --proto_path=./src/schemas ./src/schemas/*",
     "lint": "eslint  src/ --color --ext .ts",
     "lint:fix": "yarn run lint -- --fix"
   },

--- a/packages/protobufs/src/generated/rpc.ts
+++ b/packages/protobufs/src/generated/rpc.ts
@@ -1,8 +1,20 @@
 /* eslint-disable */
+import {
+  CallOptions,
+  ChannelCredentials,
+  Client,
+  ClientOptions,
+  ClientReadableStream,
+  ClientUnaryCall,
+  handleServerStreamingCall,
+  handleUnaryCall,
+  makeGenericClientConstructor,
+  Metadata,
+  ServiceError,
+  UntypedServiceImplementation,
+} from "@grpc/grpc-js";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
-import { Observable } from "rxjs";
-import { map } from "rxjs/operators";
 import { Message } from "./message";
 
 export interface Empty {
@@ -443,63 +455,135 @@ export const SyncIds = {
   },
 };
 
-export interface SyncService {
-  GetInfo(request: Empty): Promise<HubInfoResponse>;
-  GetAllSyncIdsByPrefix(request: TrieNodePrefix): Promise<SyncIds>;
-  GetAllMessagesBySyncIds(request: SyncIds): Observable<Message>;
-  GetSyncMetadataByPrefix(request: TrieNodePrefix): Promise<TrieNodeMetadataResponse>;
-  GetSyncSnapshotByPrefix(request: TrieNodePrefix): Promise<TrieNodeSnapshotResponse>;
+export type SyncServiceService = typeof SyncServiceService;
+export const SyncServiceService = {
+  getInfo: {
+    path: "/SyncService/GetInfo",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: Empty) => Buffer.from(Empty.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => Empty.decode(value),
+    responseSerialize: (value: HubInfoResponse) => Buffer.from(HubInfoResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => HubInfoResponse.decode(value),
+  },
+  getAllSyncIdsByPrefix: {
+    path: "/SyncService/GetAllSyncIdsByPrefix",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: TrieNodePrefix) => Buffer.from(TrieNodePrefix.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => TrieNodePrefix.decode(value),
+    responseSerialize: (value: SyncIds) => Buffer.from(SyncIds.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => SyncIds.decode(value),
+  },
+  getAllMessagesBySyncIds: {
+    path: "/SyncService/GetAllMessagesBySyncIds",
+    requestStream: false,
+    responseStream: true,
+    requestSerialize: (value: SyncIds) => Buffer.from(SyncIds.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => SyncIds.decode(value),
+    responseSerialize: (value: Message) => Buffer.from(Message.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => Message.decode(value),
+  },
+  getSyncMetadataByPrefix: {
+    path: "/SyncService/GetSyncMetadataByPrefix",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: TrieNodePrefix) => Buffer.from(TrieNodePrefix.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => TrieNodePrefix.decode(value),
+    responseSerialize: (value: TrieNodeMetadataResponse) =>
+      Buffer.from(TrieNodeMetadataResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => TrieNodeMetadataResponse.decode(value),
+  },
+  getSyncSnapshotByPrefix: {
+    path: "/SyncService/GetSyncSnapshotByPrefix",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: TrieNodePrefix) => Buffer.from(TrieNodePrefix.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => TrieNodePrefix.decode(value),
+    responseSerialize: (value: TrieNodeSnapshotResponse) =>
+      Buffer.from(TrieNodeSnapshotResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => TrieNodeSnapshotResponse.decode(value),
+  },
+} as const;
+
+export interface SyncServiceServer extends UntypedServiceImplementation {
+  getInfo: handleUnaryCall<Empty, HubInfoResponse>;
+  getAllSyncIdsByPrefix: handleUnaryCall<TrieNodePrefix, SyncIds>;
+  getAllMessagesBySyncIds: handleServerStreamingCall<SyncIds, Message>;
+  getSyncMetadataByPrefix: handleUnaryCall<TrieNodePrefix, TrieNodeMetadataResponse>;
+  getSyncSnapshotByPrefix: handleUnaryCall<TrieNodePrefix, TrieNodeSnapshotResponse>;
 }
 
-export class SyncServiceClientImpl implements SyncService {
-  private readonly rpc: Rpc;
-  private readonly service: string;
-  constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "SyncService";
-    this.rpc = rpc;
-    this.GetInfo = this.GetInfo.bind(this);
-    this.GetAllSyncIdsByPrefix = this.GetAllSyncIdsByPrefix.bind(this);
-    this.GetAllMessagesBySyncIds = this.GetAllMessagesBySyncIds.bind(this);
-    this.GetSyncMetadataByPrefix = this.GetSyncMetadataByPrefix.bind(this);
-    this.GetSyncSnapshotByPrefix = this.GetSyncSnapshotByPrefix.bind(this);
-  }
-  GetInfo(request: Empty): Promise<HubInfoResponse> {
-    const data = Empty.encode(request).finish();
-    const promise = this.rpc.request(this.service, "GetInfo", data);
-    return promise.then((data) => HubInfoResponse.decode(new _m0.Reader(data)));
-  }
-
-  GetAllSyncIdsByPrefix(request: TrieNodePrefix): Promise<SyncIds> {
-    const data = TrieNodePrefix.encode(request).finish();
-    const promise = this.rpc.request(this.service, "GetAllSyncIdsByPrefix", data);
-    return promise.then((data) => SyncIds.decode(new _m0.Reader(data)));
-  }
-
-  GetAllMessagesBySyncIds(request: SyncIds): Observable<Message> {
-    const data = SyncIds.encode(request).finish();
-    const result = this.rpc.serverStreamingRequest(this.service, "GetAllMessagesBySyncIds", data);
-    return result.pipe(map((data) => Message.decode(new _m0.Reader(data))));
-  }
-
-  GetSyncMetadataByPrefix(request: TrieNodePrefix): Promise<TrieNodeMetadataResponse> {
-    const data = TrieNodePrefix.encode(request).finish();
-    const promise = this.rpc.request(this.service, "GetSyncMetadataByPrefix", data);
-    return promise.then((data) => TrieNodeMetadataResponse.decode(new _m0.Reader(data)));
-  }
-
-  GetSyncSnapshotByPrefix(request: TrieNodePrefix): Promise<TrieNodeSnapshotResponse> {
-    const data = TrieNodePrefix.encode(request).finish();
-    const promise = this.rpc.request(this.service, "GetSyncSnapshotByPrefix", data);
-    return promise.then((data) => TrieNodeSnapshotResponse.decode(new _m0.Reader(data)));
-  }
+export interface SyncServiceClient extends Client {
+  getInfo(request: Empty, callback: (error: ServiceError | null, response: HubInfoResponse) => void): ClientUnaryCall;
+  getInfo(
+    request: Empty,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: HubInfoResponse) => void,
+  ): ClientUnaryCall;
+  getInfo(
+    request: Empty,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: HubInfoResponse) => void,
+  ): ClientUnaryCall;
+  getAllSyncIdsByPrefix(
+    request: TrieNodePrefix,
+    callback: (error: ServiceError | null, response: SyncIds) => void,
+  ): ClientUnaryCall;
+  getAllSyncIdsByPrefix(
+    request: TrieNodePrefix,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: SyncIds) => void,
+  ): ClientUnaryCall;
+  getAllSyncIdsByPrefix(
+    request: TrieNodePrefix,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: SyncIds) => void,
+  ): ClientUnaryCall;
+  getAllMessagesBySyncIds(request: SyncIds, options?: Partial<CallOptions>): ClientReadableStream<Message>;
+  getAllMessagesBySyncIds(
+    request: SyncIds,
+    metadata?: Metadata,
+    options?: Partial<CallOptions>,
+  ): ClientReadableStream<Message>;
+  getSyncMetadataByPrefix(
+    request: TrieNodePrefix,
+    callback: (error: ServiceError | null, response: TrieNodeMetadataResponse) => void,
+  ): ClientUnaryCall;
+  getSyncMetadataByPrefix(
+    request: TrieNodePrefix,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: TrieNodeMetadataResponse) => void,
+  ): ClientUnaryCall;
+  getSyncMetadataByPrefix(
+    request: TrieNodePrefix,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: TrieNodeMetadataResponse) => void,
+  ): ClientUnaryCall;
+  getSyncSnapshotByPrefix(
+    request: TrieNodePrefix,
+    callback: (error: ServiceError | null, response: TrieNodeSnapshotResponse) => void,
+  ): ClientUnaryCall;
+  getSyncSnapshotByPrefix(
+    request: TrieNodePrefix,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: TrieNodeSnapshotResponse) => void,
+  ): ClientUnaryCall;
+  getSyncSnapshotByPrefix(
+    request: TrieNodePrefix,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: TrieNodeSnapshotResponse) => void,
+  ): ClientUnaryCall;
 }
 
-interface Rpc {
-  request(service: string, method: string, data: Uint8Array): Promise<Uint8Array>;
-  clientStreamingRequest(service: string, method: string, data: Observable<Uint8Array>): Promise<Uint8Array>;
-  serverStreamingRequest(service: string, method: string, data: Uint8Array): Observable<Uint8Array>;
-  bidirectionalStreamingRequest(service: string, method: string, data: Observable<Uint8Array>): Observable<Uint8Array>;
-}
+export const SyncServiceClient = makeGenericClientConstructor(SyncServiceService, "SyncService") as unknown as {
+  new (address: string, credentials: ChannelCredentials, options?: Partial<ClientOptions>): SyncServiceClient;
+  service: typeof SyncServiceService;
+};
 
 declare var self: any | undefined;
 declare var window: any | undefined;

--- a/packages/protobufs/tsup.config.ts
+++ b/packages/protobufs/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entryPoints: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  banner: { js: 'import { createRequire } from "module";const require = createRequire(import.meta.url);' },
+});

--- a/packages/protoutils/src/factories.test.ts
+++ b/packages/protoutils/src/factories.test.ts
@@ -109,6 +109,6 @@ describe('IdRegistryEventFactory', () => {
     const event = Factories.IdRegistryEvent.build();
     const encoded = protobufs.IdRegistryEvent.encode(event).finish();
     const decoded = protobufs.IdRegistryEvent.decode(encoded);
-    expect(decoded).toEqual(event);
+    expect(protobufs.IdRegistryEvent.toJSON(decoded)).toEqual(protobufs.IdRegistryEvent.toJSON(event));
   });
 });


### PR DESCRIPTION
## Motivation

Fix an issue where esbuild would not work with the dynamic requires coming from grpc-js

## Change Summary

- Add a tsup.config that injects the `require` shim needed 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)


## Additional Context

More information about the problem here: https://github.com/sveltejs/kit/issues/2400
ES build PR that this is copied from: https://github.com/evanw/esbuild/pull/2067

Adding this as a separate PR so I can revert it easily later if needed. 
