### PR TITLE
fix: Fix bug where trie was being incorrectly compacted

### DIFF
--- a/apps/protohub/src/network/sync/trieNode.test.ts
+++ b/apps/protohub/src/network/sync/trieNode.test.ts
@@ -160,6 +160,28 @@ describe('TrieNode', () => {
       expect(newLeafNode).toEqual(leafNode);
       expect(root.hash).toEqual(previousRootHash);
     });
+
+    test('deleting item only compacts the branch of the trie with the deleted item', async () => {
+      const ids = [
+        '0'.padStart(TIMESTAMP_LENGTH, '0') + '01068',
+        '0'.padStart(TIMESTAMP_LENGTH, '0') + '010a1',
+        '0'.padStart(TIMESTAMP_LENGTH, '0') + '05d22',
+      ];
+
+      const root = new TrieNode();
+
+      for (let i = 0; i < ids.length; i++) {
+        root.insert(ids[i] as string);
+      }
+
+      // Remove the first id
+      root.delete(ids[0] as string);
+
+      // Expect the other two ids to be present
+      expect(root.exists(ids[1] as string)).toBeTruthy();
+      expect(root.exists(ids[2] as string)).toBeTruthy();
+      expect(root.items).toEqual(2);
+    });
   });
 
   describe('get', () => {

--- a/apps/protohub/src/network/sync/trieNode.ts
+++ b/apps/protohub/src/network/sync/trieNode.ts
@@ -113,11 +113,13 @@ class TrieNode {
         this._children.delete(char);
       }
 
-      if (this._children.size === 1 && current_index >= TIMESTAMP_LENGTH) {
+      if (this._items === 1 && this._children.size === 1 && current_index >= TIMESTAMP_LENGTH) {
         // Compact the node if it has only one child
         const [char, child] = this._children.entries().next().value;
-        this._setKeyValue(child._key);
-        this._children.delete(char);
+        if (child._key) {
+          this._setKeyValue(child._key);
+          this._children.delete(char);
+        }
       }
 
       this._updateHash();


### PR DESCRIPTION
## Motivation

Fix an issue where the Sync Trie was being incorrectly compacted

## Change Summary

- Fix delete() to make sure the subtree can actually be compacted. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
