### PR TITLE
fix: Switch to Unary MessageResponse instead of streaming

### DIFF
--- a/apps/protohub/src/network/sync/trieNode.test.ts
+++ b/apps/protohub/src/network/sync/trieNode.test.ts
@@ -178,7 +178,9 @@ describe('TrieNode', () => {
       root.delete(ids[0] as string);
 
       // Expect the other two ids to be present
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(root.exists(ids[1] as string)).toBeTruthy();
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(root.exists(ids[2] as string)).toBeTruthy();
       expect(root.items).toEqual(2);
     });

--- a/packages/protobufs/src/generated/message.ts
+++ b/packages/protobufs/src/generated/message.ts
@@ -314,10 +314,6 @@ export function userDataTypeToJSON(object: UserDataType): string {
   }
 }
 
-export interface UserId {
-  fid: number;
-}
-
 export interface CastId {
   fid: number;
   hash: Uint8Array;
@@ -385,57 +381,6 @@ export interface Message {
   signatureScheme: SignatureScheme;
   signer: Uint8Array;
 }
-
-function createBaseUserId(): UserId {
-  return { fid: 0 };
-}
-
-export const UserId = {
-  encode(message: UserId, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.fid !== 0) {
-      writer.uint32(8).uint64(message.fid);
-    }
-    return writer;
-  },
-
-  decode(input: _m0.Reader | Uint8Array, length?: number): UserId {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseUserId();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1:
-          message.fid = longToNumber(reader.uint64() as Long);
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
-      }
-    }
-    return message;
-  },
-
-  fromJSON(object: any): UserId {
-    return { fid: isSet(object.fid) ? Number(object.fid) : 0 };
-  },
-
-  toJSON(message: UserId): unknown {
-    const obj: any = {};
-    message.fid !== undefined && (obj.fid = Math.round(message.fid));
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<UserId>, I>>(base?: I): UserId {
-    return UserId.fromPartial(base ?? {});
-  },
-
-  fromPartial<I extends Exact<DeepPartial<UserId>, I>>(object: I): UserId {
-    const message = createBaseUserId();
-    message.fid = object.fid ?? 0;
-    return message;
-  },
-};
 
 function createBaseCastId(): CastId {
   return { fid: 0, hash: new Uint8Array() };

--- a/packages/protobufs/src/schemas/message.proto
+++ b/packages/protobufs/src/schemas/message.proto
@@ -49,10 +49,6 @@ enum UserDataType {
   USER_DATA_TYPE_FNAME = 6;
 }
 
-message UserId {
-  uint64 fid = 1;
-}
-
 message CastId {
   uint64 fid = 1;
   bytes hash = 2;

--- a/packages/protobufs/src/schemas/rpc.proto
+++ b/packages/protobufs/src/schemas/rpc.proto
@@ -44,6 +44,10 @@ message FidsResponse {
     repeated uint64 fids = 1;
 }
 
+message MessagesResponse {
+    repeated Message messages = 1;
+}
+
 message ReactionRequest {
     uint64 fid = 1;
     ReactionType reaction_type = 2;
@@ -62,7 +66,7 @@ message ReactionsByCastRequest {
 
 message AmpRequest {
     uint64 fid = 1;
-    UserId user_id = 2;
+    uint64 target_fid = 2;
 }
 
 message UserDataRequest {
@@ -92,47 +96,47 @@ service HubService {
 
     // Casts
     rpc GetCast(CastId) returns (Message);
-    rpc GetCastsByFid(FidRequest) returns (stream Message);
-    rpc GetCastsByParent(CastId) returns (stream Message);
-    rpc GetCastsByMention(FidRequest) returns (stream Message);
+    rpc GetCastsByFid(FidRequest) returns (MessagesResponse);
+    rpc GetCastsByParent(CastId) returns (MessagesResponse);
+    rpc GetCastsByMention(FidRequest) returns (MessagesResponse);
 
     // Reactions
     rpc GetReaction(ReactionRequest) returns (Message);
-    rpc GetReactionsByFid(ReactionsByFidRequest) returns (stream Message);
-    rpc GetReactionsByCast(ReactionsByCastRequest) returns (stream Message);
+    rpc GetReactionsByFid(ReactionsByFidRequest) returns (MessagesResponse);
+    rpc GetReactionsByCast(ReactionsByCastRequest) returns (MessagesResponse);
 
     // Amps
     rpc GetAmp(AmpRequest) returns (Message);
-    rpc GetAmpsByFid(FidRequest) returns (stream Message);
-    rpc GetAmpsByUser(UserId) returns (stream Message);
+    rpc GetAmpsByFid(FidRequest) returns (MessagesResponse);
+    rpc GetAmpsByUser(FidRequest) returns (MessagesResponse);
 
     // User Data
     rpc GetUserData(UserDataRequest) returns (Message);
-    rpc GetUserDataByFid(FidRequest) returns (stream Message);
+    rpc GetUserDataByFid(FidRequest) returns (MessagesResponse);
     rpc GetNameRegistryEvent(NameRegistryEventRequest) returns (NameRegistryEvent);
 
     // Verifications
     rpc GetVerification(VerificationRequest) returns (Message);
-    rpc GetVerificationsByFid(FidRequest) returns (stream Message);
+    rpc GetVerificationsByFid(FidRequest) returns (MessagesResponse);
 
     // Signer
     rpc GetSigner(SignerRequest) returns (Message);
-    rpc GetSignersByFid(FidRequest) returns (stream Message);
+    rpc GetSignersByFid(FidRequest) returns (MessagesResponse);
     rpc GetCustodyEvent(FidRequest) returns (IdRegistryEvent);
     rpc GetFids(Empty) returns (FidsResponse);
 
     // Bulk Methods
-    rpc GetAllCastMessagesByFid(FidRequest) returns (stream Message);
-    rpc GetAllReactionMessagesByFid(FidRequest) returns (stream Message);
-    rpc GetAllAmpMessagesByFid(FidRequest) returns (stream Message);
-    rpc GetAllVerificationMessagesByFid(FidRequest) returns (stream Message);
-    rpc GetAllSignerMessagesByFid(FidRequest) returns (stream Message);
-    rpc GetAllUserDataMessagesByFid(FidRequest) returns (stream Message);
+    rpc GetAllCastMessagesByFid(FidRequest) returns (MessagesResponse);
+    rpc GetAllReactionMessagesByFid(FidRequest) returns (MessagesResponse);
+    rpc GetAllAmpMessagesByFid(FidRequest) returns (MessagesResponse);
+    rpc GetAllVerificationMessagesByFid(FidRequest) returns (MessagesResponse);
+    rpc GetAllSignerMessagesByFid(FidRequest) returns (MessagesResponse);
+    rpc GetAllUserDataMessagesByFid(FidRequest) returns (MessagesResponse);
     
     // Sync Methods
     rpc GetInfo (Empty) returns (HubInfoResponse);
     rpc GetAllSyncIdsByPrefix (TrieNodePrefix) returns (SyncIds);
-    rpc GetAllMessagesBySyncIds (SyncIds) returns (stream Message);
+    rpc GetAllMessagesBySyncIds (SyncIds) returns (MessagesResponse);
     rpc GetSyncMetadataByPrefix (TrieNodePrefix) returns (TrieNodeMetadataResponse);
     rpc GetSyncSnapshotByPrefix (TrieNodePrefix) returns (TrieNodeSnapshotResponse);
 }


### PR DESCRIPTION
## Motivation

Swtich to returning unary `MessagesResponse` instead of `stream Message` from RPC methods

## Change Summary

- Switch to unary `MessagesResponse` for RPC methods
- Fix some warnings
- SyncEngine changes to use the MessagesResponse

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
